### PR TITLE
use the React Component apollo client in fetch.ts

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -37,6 +37,7 @@ import { useStore } from "zustand";
 import { RepoContext } from "../lib/store";
 
 import { MyMonaco } from "./MyMonaco";
+import { useApolloClient } from "@apollo/client";
 
 const nanoid = customAlphabet(nolookalikes, 10);
 
@@ -437,6 +438,7 @@ export function Canvas() {
   const reactFlowWrapper = useRef<any>(null);
 
   const addPod = useStore(store, (state) => state.addPod);
+  const apolloClient = useApolloClient();
   const setPodPosition = useStore(store, (state) => state.setPodPosition);
   const setPodParent = useStore(store, (state) => state.setPodParent);
   const deletePod = useStore(store, (state) => state.deletePod);
@@ -481,7 +483,7 @@ export function Canvas() {
       setNodes((nds) => nds.concat(newNode));
 
       // add to pods
-      addPod({
+      addPod(apolloClient, {
         id,
         parent: "ROOT",
         index: 0,
@@ -654,7 +656,7 @@ export function Canvas() {
     (nodes) => {
       // remove from pods
       for (const node of nodes) {
-        deletePod({ id: node.id, toDelete: [] });
+        deletePod(apolloClient, { id: node.id, toDelete: [] });
       }
     },
     [deletePod]

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -160,6 +160,7 @@ function ApplyAll() {
   const numDirty = useStore(store, selectNumDirty());
   const clearAllResults = useStore(store, (s) => s.clearAllResults);
   const remoteUpdateAllPods = useStore(store, (s) => s.remoteUpdateAllPods);
+  const client = useApolloClient();
   usePrompt(
     `You have unsaved ${numDirty} changes. Are you sure you want to leave?`,
     numDirty > 0
@@ -173,7 +174,7 @@ function ApplyAll() {
     let id = setInterval(() => {
       // websocket resets after 60s of idle by most firewalls
       console.log("periodically saving ..");
-      remoteUpdateAllPods();
+      remoteUpdateAllPods(client);
     }, 1000);
     return () => {
       console.log("removing interval");
@@ -188,7 +189,7 @@ function ApplyAll() {
         size="small"
         disabled={numDirty === 0}
         onClick={() => {
-          remoteUpdateAllPods();
+          remoteUpdateAllPods(client);
         }}
       >
         <CloudUploadIcon />

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -12,6 +12,7 @@ import { createRepoStore, RepoContext } from "../lib/store";
 import useMe from "../lib/me";
 import { Canvas } from "../components/Canvas";
 import { Sidebar } from "../components/Sidebar";
+import { useApolloClient } from "@apollo/client";
 
 function RepoWrapper({ children }) {
   // this component is used to provide foldable sidebar
@@ -83,6 +84,7 @@ function RepoImpl() {
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const resetState = useStore(store, (state) => state.resetState);
   const setRepo = useStore(store, (state) => state.setRepo);
+  const client = useApolloClient();
   const loadRepo = useStore(store, (state) => state.loadRepo);
   const setSessionId = useStore(store, (state) => state.setSessionId);
   const repoLoaded = useStore(store, (state) => state.repoLoaded);
@@ -97,8 +99,8 @@ function RepoImpl() {
     resetState();
     setRepo(id!);
     // load the repo. It is actually not a queue, just an async thunk
-    loadRepo(id!);
-  }, [id, loadRepo, resetState, setRepo]);
+    loadRepo(client, id!);
+  }, [client, id, loadRepo, resetState, setRepo]);
 
   // FIXME Removing queueL. This will cause Repo to be re-rendered a lot of
   // times, particularly the delete pod action would cause syncstatus and repo


### PR DESCRIPTION
Previously the frontend used two methods to access backend GraphQL APIs:
1. through apollo client as a React context
2. through manually calling fetch() with server URL

Now we removed the second kind of API calls, and consistently use the apollo client everywhere.