### PR TITLE
Fix: Unnecessary Re-rendering

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -250,7 +250,7 @@ function ResultBlock({ pod, id }) {
 const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const pod = useStore(store, (state) => state.pods[id]);
+  // const pod = useStore(store, (state) => state.pods[id]);
   const setPodContent = useStore(store, (state) => state.setPodContent);
   const updatePod = useStore(store, (state) => state.updatePod);
   const clearResults = useStore(store, (s) => s.clearResults);
@@ -266,11 +266,29 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
   const { setNodes } = useReactFlow();
   // const selected = useStore(store, (state) => state.selected);
   const setSelected = useStore(store, (state) => state.setSelected);
+  const getPod = useStore(store, (state) => state.getPod);
+  const pod = getPod(id);
+  const showResult = useStore(
+    store,
+    (state) =>
+      state.pods[id].running ||
+      state.pods[id].result ||
+      state.pods[id].error ||
+      state.pods[id].stdout ||
+      state.pods[id].stderr
+  );
+
+  //FIXME: keep it for degguging, see if the codenode is re-rendering, remove later
+  console.log("code node render", getPod(id));
+
+  // useEffect(() => {
+  //   console.log("podref changes", podRef.current);
+  // }, [podRef]);
 
   React.useEffect(() => {
     setTarget(ref.current);
   }, []);
-  if (!pod) return <Box>ERROR</Box>;
+  // if (!pod) return <Box>ERROR</Box>;
   return (
     <Box
       sx={{
@@ -369,22 +387,17 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
         }}
       >
         <MyMonaco
-          value={pod.content || ""}
-          id={pod.id}
+          id={id}
           onChange={(value) => {
-            setPodContent({ id: pod.id, content: value });
+            setPodContent({ id: id, content: value });
           }}
-          lang={pod.lang || "javascript"}
+          lang={"python" || "javascript"}
           onRun={() => {
-            clearResults(pod.id);
-            wsRun(pod.id);
+            clearResults(id);
+            wsRun(id);
           }}
         />
-        {(pod.running ||
-          pod.stdout ||
-          pod.stderr ||
-          pod.result ||
-          pod.error) && (
+        {showResult && (
           <Box
             className="nowheel"
             sx={{
@@ -400,7 +413,7 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
               zIndex: 100,
             }}
           >
-            <ResultBlock pod={pod} id={id} />
+            <ResultBlock pod={getPod(id)} id={id} />
           </Box>
         )}
       </Box>

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -68,9 +68,7 @@ const ScopeNode = memo<Props>(({ data, id, isConnectable }) => {
   const [frame] = React.useState({
     translate: [0, 0],
   });
-  const setSelected = useStore(store, (state) => state.setSelected);
   const selected = useStore(store, (state) => state.selected);
-  const { setNodes } = useReactFlow();
 
   const onResize = useCallback(({ width, height, offx, offy }) => {
     const node = nodesMap.get(id);
@@ -266,25 +264,8 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
   // right, bottom
   const [layout, setLayout] = useState("right");
   const { setNodes } = useReactFlow();
-  const selected = useStore(store, (state) => state.selected);
+  // const selected = useStore(store, (state) => state.selected);
   const setSelected = useStore(store, (state) => state.setSelected);
-
-  const onResize = useCallback(({ width, height, offx, offy }) => {
-    const node = nodesMap.get(id);
-    if (node) {
-      node.style = { ...node.style, width, height };
-      node.position.x += offx;
-      node.position.y += offy;
-      nodesMap.set(id, node);
-    }
-  }, []);
-  const onLayout = useCallback(({ height }) => {
-    const node = nodesMap.get(id);
-    if (node) {
-      node.style = { ...node.style, height };
-      nodesMap.set(id, node);
-    }
-  }, []);
 
   React.useEffect(() => {
     setTarget(ref.current);
@@ -398,7 +379,6 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
             clearResults(pod.id);
             wsRun(pod.id);
           }}
-          onLayout={onLayout}
         />
         {(pod.running ||
           pod.stdout ||
@@ -424,43 +404,6 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
           </Box>
         )}
       </Box>
-      {false && (
-        <Moveable
-          target={target}
-          resizable={true}
-          keepRatio={false}
-          throttleResize={1}
-          renderDirections={["e", "s", "se"]}
-          edge={false}
-          zoom={1}
-          origin={true}
-          padding={{ left: 0, top: 0, right: 0, bottom: 0 }}
-          onResizeStart={(e) => {
-            e.setOrigin(["%", "%"]);
-            e.dragStart && e.dragStart.set(frame.translate);
-          }}
-          onResize={(e) => {
-            const beforeTranslate = e.drag.beforeTranslate;
-            frame.translate = beforeTranslate;
-            e.target.style.width = `${e.width}px`;
-            e.target.style.height = `${e.height}px`;
-            e.target.style.transform = `translate(${beforeTranslate[0]}px, ${beforeTranslate[1]}px)`;
-            onResize({
-              width: e.width,
-              height: e.height,
-              offx: beforeTranslate[0],
-              offy: beforeTranslate[1],
-            });
-            updatePod({
-              id,
-              data: {
-                width: e.width,
-                height: e.height,
-              },
-            });
-          }}
-        />
-      )}
     </Box>
   );
 });
@@ -512,7 +455,8 @@ export function Canvas() {
                 ? undefined
                 : level2color[level] || level2color["default"],
             width: 700,
-            height: pods[id].height,
+            // for code node, don't set height, let it be auto
+            height: pods[id].height || undefined,
           },
         });
       }
@@ -593,7 +537,8 @@ export function Canvas() {
       } else {
         style = {
           width: 700,
-          height: 300,
+          // we must not set the height here, otherwise the auto layout will not work
+          height: undefined,
         };
       }
 

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -346,7 +346,7 @@ export function MyMonaco({
       // width: 800
       // editor.layout({ width: 800, height: contentHeight });
       editor.layout();
-      onLayout(`${contentHeight}px`);
+      // onLayout(`${contentHeight}px`);
     };
     editor.onDidContentSizeChange(updateHeight);
     // FIXME clean up?

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -1,5 +1,5 @@
 import { Position } from "monaco-editor";
-import { useState, useContext } from "react";
+import { useState, useContext, memo } from "react";
 import MonacoEditor, { MonacoDiffEditor } from "react-monaco-editor";
 import { monaco } from "react-monaco-editor";
 import { useStore } from "zustand";
@@ -298,21 +298,31 @@ async function updateGitGutter(editor) {
 // not, and the instance will only be mounted once. All variables, even a object
 // like the pod object will be fixed at original state: changing pod.staged
 // won't be visible in the editorDidMount callback.
-export function MyMonaco({
-  lang = "javascript",
+
+interface MyMonacoProps {
+  id: string;
+  gitvalue: string;
+}
+
+export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   id = "0",
   gitvalue = null,
-  onChange = (value) => {},
-  onRun = () => {},
-  // onLayout = (height) => {},
 }) {
-  // console.log("rendering monaco ..");
   // there's no racket language support
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const getPod = useStore(store, (state) => state.getPod);
+  const setPodContent = useStore(store, (state) => state.setPodContent);
+  const clearResults = useStore(store, (s) => s.clearResults);
+  const wsRun = useStore(store, (state) => state.wsRun);
   const value = getPod(id).content || "";
+  let lang = getPod(id).lang || "javascript";
+  const onChange = (value) => setPodContent({ id, content: value });
+  const onRun = () => {
+    clearResults(id);
+    wsRun(id);
+  };
 
   if (lang === "racket") {
     lang = "scheme";
@@ -421,4 +431,4 @@ export function MyMonaco({
       editorDidMount={onEditorDidMount}
     />
   );
-}
+});

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -300,18 +300,19 @@ async function updateGitGutter(editor) {
 // won't be visible in the editorDidMount callback.
 export function MyMonaco({
   lang = "javascript",
-  value = "",
   id = "0",
   gitvalue = null,
   onChange = (value) => {},
   onRun = () => {},
-  onLayout = (height) => {},
+  // onLayout = (height) => {},
 }) {
   // console.log("rendering monaco ..");
   // there's no racket language support
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
+  const getPod = useStore(store, (state) => state.getPod);
+  const value = getPod(id).content || "";
 
   if (lang === "racket") {
     lang = "scheme";

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -29,12 +29,19 @@ export function useNodesStateSynced(nodeList) {
       if (!isNodeAddChange(change) && !isNodeResetChange(change)) {
         if (isNodeRemoveChange(change)) {
           nodesMap.delete(change.id);
+          return;
         }
         const node = nextNodes.find((n) => n.id === change.id);
         if (!node) return;
 
-        if (change.type === "select") {
+        if (change.type === "select" && change.selected) {
+          // FIXME: consider the case where only unselect is called
           setSelected(node.id);
+          return;
+        }
+
+        if (change.type === "dimensions" && node.type === "code") {
+          // the re-size event of codeNode don't need to be sync, just skip.
           return;
         }
 

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -186,6 +186,8 @@ export interface RepoSlice {
   flipShowLineNumbers: () => void;
   disconnect: () => void;
   getPod: (string) => any;
+  getPods: () => any;
+  getId2children: (string) => string[];
 }
 
 type BearState = RepoSlice & RuntimeSlice;
@@ -754,7 +756,8 @@ const createRepoSlice: StateCreator<
       })
     ),
   getPod: (id: string) => get().pods[id],
-  // getPods: () => get().pods,
+  getPods: () => get().pods,
+  getId2children: (id: string) => get().id2children[id],
 });
 
 export const createRepoStore = () =>

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -185,6 +185,7 @@ export interface RepoSlice {
   deleteClient: (clientId: any) => void;
   flipShowLineNumbers: () => void;
   disconnect: () => void;
+  getPod: (string) => any;
 }
 
 type BearState = RepoSlice & RuntimeSlice;
@@ -752,6 +753,8 @@ const createRepoSlice: StateCreator<
         state.ydoc.destroy();
       })
     ),
+  getPod: (id: string) => get().pods[id],
+  // getPods: () => get().pods,
 });
 
 export const createRepoStore = () =>


### PR DESCRIPTION
Change
1. Use lazy eval function instead of accessing pods directly. So the components using pod/pods will not re-render when any value changes in pods.
2. Memorize `MyMonaco` component with only `id` and `gitvalue` property. Prevent force rendering from parent components.
3. Clean up auto layout function for `codeNode`.

The following work later if available:
1. `ResultBlock` will be re-rendered when its parent `codeNode` was dragged. I think we can also memo it and set the execution number like out[num] in (https://github.com/codepod-io/codepod/issues/55) as a prop to force re-rendering it only when the result changes. I just remained it as origin, please consider combining this issue when implementing the execution number.

close https://github.com/codepod-io/codepod/issues/51