### PR TITLE
fix: dropping into nested scope

### DIFF
--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -77,8 +77,12 @@ export function useNodesStateSynced(nodeList) {
       });
 
       // TOFIX: a node may be shadowed behind its parent, due to the order to render reactflow node, to fix this, comment out the following sorted method, which brings in a large overhead.
-      // setNodes(Array.from(nodesMap.values()).sort((a:Node, b:Node) => (a.level - b.level)));
-      setNodes(Array.from(nodesMap.values()));
+      setNodes(
+        Array.from(nodesMap.values()).sort(
+          (a: Node & { level }, b: Node & { level }) => a.level - b.level
+        )
+      );
+      // setNodes(Array.from(nodesMap.values()));
     };
 
     // setNodes(Array.from(nodesMap.values()));

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -188,8 +188,8 @@ export interface RepoSlice {
   deleteClient: (clientId: any) => void;
   flipShowLineNumbers: () => void;
   disconnect: () => void;
-  getPod: (string) => any;
-  getPods: () => any;
+  getPod: (string) => Pod;
+  getPods: () => Record<string, Pod>;
   getId2children: (string) => string[];
 }
 


### PR DESCRIPTION
1. fix the previous bug on computing the absolute position of nested scopes
2. sort the nodes so that nodes of a higher level always appear on top (close #63)

