### PR TITLE
Fix: auth error auto redirect & tree-sitter load path & toast notification

### DIFF
--- a/api/src/resolver_repo.ts
+++ b/api/src/resolver_repo.ts
@@ -76,6 +76,7 @@ export async function myCollabRepos(_, __, {userId}) {
 }
 
 export async function repo(_, { id }, { userId }) {
+  // a user can only access a private repo if he is the owner or a collaborator
   const repo = await prisma.repo.findFirst({
     where: { OR: [
       { id, public: true },

--- a/api/src/resolver_repo.ts
+++ b/api/src/resolver_repo.ts
@@ -79,8 +79,8 @@ export async function repo(_, { id }, { userId }) {
   const repo = await prisma.repo.findFirst({
     where: { OR: [
       { id, public: true },
-      { id, owner: { id: userId!} },
-      { id, collaboratorIds: { has: userId!} },
+      { id, owner: { id: userId || "undefined"} },
+      { id, collaboratorIds: { has: userId || "undefined"} },
     ]
     },
     include: {
@@ -96,6 +96,7 @@ export async function repo(_, { id }, { userId }) {
       },
     },
   });
+  if(!repo) throw Error("Repo not found");
   return repo;
 }
 

--- a/ui/src/components/ShareProjDialog.tsx
+++ b/ui/src/components/ShareProjDialog.tsx
@@ -6,6 +6,7 @@ import DialogContentText from "@mui/material/DialogContentText";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import Alert from "@mui/material/Alert";
+import { AlertColor } from "@mui/material/Alert";
 import Snackbar from "@mui/material/Snackbar";
 import { useState, useEffect } from "react";
 import { useMutation, gql } from "@apollo/client";
@@ -33,7 +34,7 @@ export function ShareProjDialog({
   id,
 }: ShareProjDialogProps) {
   const [email, setEmail] = useState("");
-  const [status, setStatus] = useState("info");
+  const [status, setStatus] = useState<AlertColor>("info");
   const [message, setMessage] = useState("inviting...");
   const [infoOpen, setInfoOpen] = useState(false);
 
@@ -78,7 +79,7 @@ export function ShareProjDialog({
     onClose();
   }
 
-  function onCloseAlert(event, reason) {
+  function onCloseAlert(event: React.SyntheticEvent | Event, reason?: string) {
     if (reason === "clickaway") {
       return;
     }

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -7,7 +7,7 @@ import { Pod } from "./store";
  * Load remote repo
  * @param id repo id
  * @param client apollo client
- * @returns a list of podsa
+ * @returns a list of pods
  */
 export async function doRemoteLoadRepo({ id, client }) {
   // load from remote

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -7,7 +7,7 @@ import { Pod } from "./store";
  * Load remote repo
  * @param id repo id
  * @param client apollo client
- * @returns a list of pods
+ * @returns a list of podsa
  */
 export async function doRemoteLoadRepo({ id, client }) {
   // load from remote

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -50,17 +50,22 @@ export async function doRemoteLoadRepo({ id, client }) {
       }
     }
   `;
-  let res = await client.query({
-    query,
-    variables: {
-      id,
-    },
-    // CAUTION I must set this because refetechQueries does not work.
-    fetchPolicy: "no-cache",
-  });
-  // We need to do a deep copy here, because apollo client returned immutable objects.
-  let pods = res.data.repo.pods.map((pod) => ({ ...pod }));
-  return { pods, name: res.data.repo.name };
+  try {
+    let res = await client.query({
+      query,
+      variables: {
+        id,
+      },
+      // CAUTION I must set this because refetechQueries does not work.
+      fetchPolicy: "no-cache",
+    });
+    // We need to do a deep copy here, because apollo client returned immutable objects.
+    let pods = res.data.repo.pods.map((pod) => ({ ...pod }));
+    return { pods, name: res.data.repo.name, error: null };
+  } catch (e) {
+    console.log(e);
+    return { pods: [], name: "", error: e };
+  }
 }
 
 export function normalize(pods) {

--- a/ui/src/lib/me.tsx
+++ b/ui/src/lib/me.tsx
@@ -15,7 +15,7 @@ const PROFILE_QUERY = gql`
 
 export default function useMe() {
   /* eslint-disable no-unused-vars */
-  const { client, loading, data } = useQuery(PROFILE_QUERY, {
+  const { loading, data } = useQuery(PROFILE_QUERY, {
     // fetchPolicy: "network-only",
   });
   return { loading, me: data?.me };

--- a/ui/src/lib/parser.tsx
+++ b/ui/src/lib/parser.tsx
@@ -3,7 +3,7 @@ import Parser from "web-tree-sitter";
 let parser: Parser | null = null;
 Parser.init({
   locateFile(scriptName: string, scriptDirectory: string) {
-    return scriptName;
+    return "/" + scriptName;
   },
 }).then(async () => {
   /* the library is ready */
@@ -12,8 +12,6 @@ Parser.init({
   const Python = await Parser.Language.load("/tree-sitter-python.wasm");
   parser.setLanguage(Python);
 });
-
-console.log("parser", parser);
 
 /**
  * Return a list of names defined in this code.
@@ -30,6 +28,7 @@ export function analyzeCode(code) {
   if (!parser) {
     throw Error("warning: parser not ready");
   }
+  console.log("parser", code, parser);
   let tree = parser.parse(code);
   tree.rootNode.children.forEach((node) => {
     if (node.type === "function_definition") {

--- a/ui/src/lib/parser.tsx
+++ b/ui/src/lib/parser.tsx
@@ -13,6 +13,8 @@ Parser.init({
   parser.setLanguage(Python);
 });
 
+console.log("parser", parser);
+
 /**
  * Return a list of names defined in this code.
  * @param code the code

--- a/ui/src/lib/parser.tsx
+++ b/ui/src/lib/parser.tsx
@@ -28,7 +28,6 @@ export function analyzeCode(code) {
   if (!parser) {
     throw Error("warning: parser not ready");
   }
-  console.log("parser", code, parser);
   let tree = parser.parse(code);
   tree.rootNode.children.forEach((node) => {
     if (node.type === "function_definition") {

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -91,6 +91,7 @@ const initialState = {
   //TODO: all presence information are now saved in clients map for future usage. create a modern UI to show those information from clients (e.g., online users)
   clients: new Map(),
   showLineNumbers: false,
+  loadError: null,
 };
 
 export type Pod = {
@@ -136,6 +137,7 @@ export interface RepoSlice {
   id2children: Record<string, string[]>;
   // runtime: string;
   repoId: string | null;
+  loadError: any;
   // sessionId?: string;
 
   resetState: () => void;
@@ -682,6 +684,7 @@ const createRepoSlice: StateCreator<
         state.repoName = name;
         // fill in the parent/children relationships
         for (const id in state.pods) {
+          console.log("id", id);
           let pod = state.pods[id];
           if (pod.parent) {
             state.id2parent[pod.id] = pod.parent.id;

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -690,7 +690,6 @@ const createRepoSlice: StateCreator<
         state.repoName = name;
         // fill in the parent/children relationships
         for (const id in state.pods) {
-          console.log("id", id);
           let pod = state.pods[id];
           if (pod.parent) {
             state.id2parent[pod.id] = pod.parent.id;

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -680,12 +680,13 @@ const createRepoSlice: StateCreator<
     set(
       produce((state) => {
         // TODO the children ordered by index
+        if (error) {
+          // TOFIX: If you enter a repo by URL directly, it may throw a repo not found error because of your user info is not loaded in time.
+          console.log("ERROR", error, id);
+          state.loadError = error;
+          return;
+        }
         state.pods = normalize(pods);
-        // if (error) {
-        //   console.log("ERROR", error);
-        //   state.loadError = error;
-        //   return;
-        // }
         state.repoName = name;
         // fill in the parent/children relationships
         for (const id in state.pods) {

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -676,11 +676,16 @@ const createRepoSlice: StateCreator<
     );
   },
   loadRepo: async (client, id) => {
-    const { pods, name } = await doRemoteLoadRepo({ id, client });
+    const { pods, name, error } = await doRemoteLoadRepo({ id, client });
     set(
       produce((state) => {
         // TODO the children ordered by index
         state.pods = normalize(pods);
+        // if (error) {
+        //   console.log("ERROR", error);
+        //   state.loadError = error;
+        //   return;
+        // }
         state.repoName = name;
         // fill in the parent/children relationships
         for (const id in state.pods) {

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -2,6 +2,7 @@ import { useParams } from "react-router-dom";
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Alert from "@mui/material/Alert";
 
 import { useEffect, useState, useRef, useContext } from "react";
 
@@ -81,6 +82,16 @@ function RepoWrapper({ children }) {
   );
 }
 
+function NotFoundAlert() {
+  return (
+    <Box sx={{ maxWidth: "sm", alignItems: "center", m: "auto" }}>
+      <Alert severity="error">
+        The repo you are looking for is not found. Please check the URL.
+      </Alert>
+    </Box>
+  );
+}
+
 function RepoImpl() {
   let { id } = useParams();
   const store = useContext(RepoContext);
@@ -89,6 +100,7 @@ function RepoImpl() {
   const setRepo = useStore(store, (state) => state.setRepo);
   const client = useApolloClient();
   const loadRepo = useStore(store, (state) => state.loadRepo);
+  // const loadError = useStore(store, (state) => state.loadError);
   const setSessionId = useStore(store, (state) => state.setSessionId);
   const repoLoaded = useStore(store, (state) => state.repoLoaded);
   const setUser = useStore(store, (state) => state.setUser);
@@ -138,6 +150,7 @@ function RepoImpl() {
   // to be re-rendered in conflict, which is weird.
 
   if (loading) return <Box>Loading</Box>;
+  // if (loadError) return <Box>Error </Box>;
 
   return (
     <RepoWrapper>

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -1,8 +1,10 @@
-import { useParams } from "react-router-dom";
-
+import { useParams, useNavigate } from "react-router-dom";
+import { Link as ReactLink } from "react-router-dom";
 import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
 import Button from "@mui/material/Button";
 import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
 
 import { useEffect, useState, useRef, useContext } from "react";
 
@@ -82,11 +84,35 @@ function RepoWrapper({ children }) {
   );
 }
 
-function NotFoundAlert() {
+function NotFoundAlert({ error }) {
+  const navigate = useNavigate();
+  const [seconds, setSeconds] = useState(3);
+
+  useEffect(() => {
+    if (seconds === 0) {
+      setSeconds(null);
+      navigate("/");
+      return;
+    }
+    if (seconds === null) return;
+
+    const timer = setTimeout(() => {
+      setSeconds((prev) => prev - 1);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [seconds]);
+
   return (
     <Box sx={{ maxWidth: "sm", alignItems: "center", m: "auto" }}>
       <Alert severity="error">
-        The repo you are looking for is not found. Please check the URL.
+        <AlertTitle>Error: {error}</AlertTitle>
+        The repo you are looking for is not found. Please check the URL. Go back
+        your{" "}
+        <Link component={ReactLink} to="/">
+          dashboard
+        </Link>{" "}
+        page in {seconds} seconds.
       </Alert>
     </Box>
   );
@@ -150,7 +176,12 @@ function RepoImpl() {
   // to be re-rendered in conflict, which is weird.
 
   if (loading) return <Box>Loading</Box>;
-  if (loadError) return <Box>Error </Box>;
+
+  // TOFIX: consider more types of error and display detailed error message in the future
+  // TOFIX: if the repo is not found, sidebar should not be rendered and runtime should not be lanuched.
+  if (!repoLoaded && loadError) {
+    return <NotFoundAlert error={loadError.message} />;
+  }
 
   return (
     <RepoWrapper>

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -100,7 +100,7 @@ function RepoImpl() {
   const setRepo = useStore(store, (state) => state.setRepo);
   const client = useApolloClient();
   const loadRepo = useStore(store, (state) => state.loadRepo);
-  // const loadError = useStore(store, (state) => state.loadError);
+  const loadError = useStore(store, (state) => state.loadError);
   const setSessionId = useStore(store, (state) => state.setSessionId);
   const repoLoaded = useStore(store, (state) => state.repoLoaded);
   const setUser = useStore(store, (state) => state.setUser);
@@ -150,7 +150,7 @@ function RepoImpl() {
   // to be re-rendered in conflict, which is weird.
 
   if (loading) return <Box>Loading</Box>;
-  // if (loadError) return <Box>Error </Box>;
+  if (loadError) return <Box>Error </Box>;
 
   return (
     <RepoWrapper>

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -86,7 +86,7 @@ function RepoWrapper({ children }) {
 
 function NotFoundAlert({ error }) {
   const navigate = useNavigate();
-  const [seconds, setSeconds] = useState(3);
+  const [seconds, setSeconds] = useState<number | null>(3);
 
   useEffect(() => {
     if (seconds === 0) {
@@ -97,7 +97,7 @@ function NotFoundAlert({ error }) {
     if (seconds === null) return;
 
     const timer = setTimeout(() => {
-      setSeconds((prev) => prev - 1);
+      setSeconds((prev) => prev! - 1);
     }, 1000);
 
     return () => clearTimeout(timer);

--- a/ui/src/pages/repos/CreateRepoForm.tsx
+++ b/ui/src/pages/repos/CreateRepoForm.tsx
@@ -65,7 +65,7 @@ export default function CreateRepoForm(props: form = {}) {
             fontWeight: 500,
           }}
         >
-          New Repo
+          New {isPrivate ? " Private " : " Public "} Repo
         </DialogTitle>
         <DialogContent>
           <Formik

--- a/ui/src/pages/repos/CreateRepoForm.tsx
+++ b/ui/src/pages/repos/CreateRepoForm.tsx
@@ -89,6 +89,7 @@ export default function CreateRepoForm(props: form = {}) {
                   variables: {
                     name: values.reponame,
                     id,
+                    isPublic: !isPrivate,
                   },
                 });
                 if (res.data) {

--- a/ui/src/pages/repos/index.tsx
+++ b/ui/src/pages/repos/index.tsx
@@ -18,6 +18,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import StopCircleIcon from "@mui/icons-material/StopCircle";
 import CircularProgress from "@mui/material/CircularProgress";
 import SourceIcon from "@mui/icons-material/Source";
+import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import Tooltip from "@mui/material/Tooltip";
 import IconButton from "@mui/material/IconButton";
 import ShareIcon from "@mui/icons-material/Share";
@@ -109,7 +110,7 @@ function RepoLine({ repo, deletable, sharable }) {
               alignItems: "center",
             }}
           >
-            <SourceIcon
+            <DescriptionOutlinedIcon
               sx={{
                 marginRight: "5px",
               }}
@@ -267,12 +268,22 @@ function Repos({
 
 function NoLogginErrorAlert() {
   const nevigate = useNavigate();
+  const [seconds, setSeconds] = useState(3);
 
   useEffect(() => {
-    setTimeout(() => {
+    if (seconds === 0) {
+      setSeconds(null);
       nevigate("/login");
-    }, 3000);
-  }, []);
+      return;
+    }
+    if (seconds === null) return;
+
+    const timer = setTimeout(() => {
+      setSeconds((prev) => prev - 1);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [seconds]);
 
   return (
     <Box sx={{ maxWidth: "sm", alignItems: "center", m: "auto" }}>
@@ -281,7 +292,7 @@ function NoLogginErrorAlert() {
         <Link component={ReactLink} to="/login">
           login
         </Link>{" "}
-        page in 3 seconds.
+        page in {seconds} seconds.
       </Alert>
     </Box>
   );
@@ -289,7 +300,7 @@ function NoLogginErrorAlert() {
 export default function Page() {
   const { me } = useMe();
   const [loading, setLoading] = useState(true);
-  if (!me) {
+  if (!me && !loading) {
     return <NoLogginErrorAlert />;
   }
   return (

--- a/ui/src/pages/repos/index.tsx
+++ b/ui/src/pages/repos/index.tsx
@@ -1,8 +1,9 @@
 import { useQuery, useMutation, gql } from "@apollo/client";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import Link from "@mui/material/Link";
 import { Link as ReactLink } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import Box from "@mui/material/Box";
 import Alert from "@mui/material/Alert";
@@ -263,9 +264,34 @@ function Repos({
     </Box>
   );
 }
+
+function NoLogginErrorAlert() {
+  const nevigate = useNavigate();
+
+  useEffect(() => {
+    setTimeout(() => {
+      nevigate("/login");
+    }, 3000);
+  }, []);
+
+  return (
+    <Box sx={{ maxWidth: "sm", alignItems: "center", m: "auto" }}>
+      <Alert severity="error">
+        Please login first! Automatically jump to{" "}
+        <Link component={ReactLink} to="/login">
+          login
+        </Link>{" "}
+        page in 3 seconds.
+      </Alert>
+    </Box>
+  );
+}
 export default function Page() {
   const { me } = useMe();
   const [loading, setLoading] = useState(true);
+  if (!me) {
+    return <NoLogginErrorAlert />;
+  }
   return (
     <Box sx={{ maxWidth: "sm", alignItems: "center", m: "auto" }}>
       {/* TODO some meta information about the user */}
@@ -293,9 +319,10 @@ export default function Page() {
         </Box>
       )}
       <Repos
-        onLoading={(value)=>{
-          setLoading(value)
-        }}/>
+        onLoading={(value) => {
+          setLoading(value);
+        }}
+      />
       <Repos url={FETCH_COLLAB_REPOS} type={RepoTypes.collab} />
     </Box>
   );

--- a/ui/src/pages/repos/index.tsx
+++ b/ui/src/pages/repos/index.tsx
@@ -268,7 +268,7 @@ function Repos({
 
 function NoLogginErrorAlert() {
   const nevigate = useNavigate();
-  const [seconds, setSeconds] = useState(3);
+  const [seconds, setSeconds] = useState<number | null>(3);
 
   useEffect(() => {
     if (seconds === 0) {
@@ -279,7 +279,7 @@ function NoLogginErrorAlert() {
     if (seconds === null) return;
 
     const timer = setTimeout(() => {
-      setSeconds((prev) => prev - 1);
+      setSeconds((prev) => prev! - 1);
     }, 1000);
 
     return () => clearTimeout(timer);


### PR DESCRIPTION
1. When you haven't logged in, show the error message and auto redirect to login page:

![image](https://user-images.githubusercontent.com/10118462/204195546-b6604312-8533-4b2c-9615-56fb29f6aea8.png)

2. When you access a repo that you are not supposed to be there (e.g., a private repo where you are neither an author or collaborator, or a wrong URL), show the error message and auto redirect to your dashboard page.

![image](https://user-images.githubusercontent.com/10118462/204195993-405fce58-5ab1-4d35-8d33-2eecfbfa8370.png)

3. Fix the load path issue in parser, otherwise, a user can't enter a repo by URL directly. Thanks to @lihebi , but it doesn't promise the parser ready for analyzing code when you directly jump to a repo by URL. We may modify more code to support waiting for the loading in the future.

4. Fix the bug that a public repo can't be created. （But I think the UI can be improved, it looks a little misleading)

![image](https://user-images.githubusercontent.com/10118462/204196736-216602f4-9dc2-4aac-a7dc-74ce86df9394.png)

5. Change the notification in share project dialog into toast style, which is auto hidden is 3 seconds in the bottom-left of a page. So the success message can also be left alone for a while after auto closing the dialog.

![image](https://user-images.githubusercontent.com/10118462/204197297-849135b6-9cd5-4585-86f2-7209ed723702.png)

![image](https://user-images.githubusercontent.com/10118462/204197413-c7e092ee-0ba5-4f0a-a9c8-6f0b185b7be3.png)

close https://github.com/codepod-io/codepod/issues/77
