### PR TITLE
fix setloading recursive rendering issue

### DIFF
--- a/ui/src/pages/repos/index.tsx
+++ b/ui/src/pages/repos/index.tsx
@@ -188,17 +188,10 @@ function RepoLine({ repo, deletable, sharable }) {
   );
 }
 
-function Repos({
-  url = FETCH_REPOS,
-  type = RepoTypes.repo,
-  onLoading = (load) => {},
-}) {
+function Repos({ url = FETCH_REPOS, type = RepoTypes.repo }) {
   const { loading, error, data } = useQuery(url);
   if (loading) {
-    onLoading(loading);
-    return null;
-  } else {
-    onLoading(loading);
+    return <CircularProgress />;
   }
   if (error) {
     return null;
@@ -299,8 +292,7 @@ function NoLogginErrorAlert() {
 }
 export default function Page() {
   const { me } = useMe();
-  const [loading, setLoading] = useState(true);
-  if (!me && !loading) {
+  if (!me) {
     return <NoLogginErrorAlert />;
   }
   return (
@@ -319,21 +311,7 @@ export default function Page() {
         👋 Welcome, {me?.firstname}! Please open or create a repository to get
         started.
       </Box>
-      {loading && (
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "center",
-          }}
-        >
-          <CircularProgress />
-        </Box>
-      )}
-      <Repos
-        onLoading={(value) => {
-          setLoading(value);
-        }}
-      />
+      <Repos />
       <Repos url={FETCH_COLLAB_REPOS} type={RepoTypes.collab} />
     </Box>
   );


### PR DESCRIPTION
In the following code, we should not change the local `loading` state in a child component, as that will trigger a re-render of the parent component.

https://github.com/codepod-io/codepod/blob/c3d457f5f44d6fc53435b0a6029421fa50ee1c69/ui/src/pages/repos/index.tsx#L332-L336

As a result, there was a warning:

<img width="1730" alt="Screenshot 2022-11-29 at 12 10 03 PM" src="https://user-images.githubusercontent.com/4576201/204639647-8019772b-fbeb-4539-af77-a900388af611.png">

This PR fixes it.