### PR TITLE
move analyzeCode logic into wsRun

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -325,8 +325,6 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
   // const pod = useStore(store, (state) => state.pods[id]);
   const wsRun = useStore(store, (state) => state.wsRun);
   const clearResults = useStore(store, (s) => s.clearResults);
-  const setSymbolTable = useStore(store, (s) => s.setSymbolTable);
-  const setPodVisibility = useStore(store, (s) => s.setPodVisibility);
   const ref = useRef(null);
   const [target, setTarget] = React.useState<any>(null);
   const [frame] = React.useState({
@@ -381,18 +379,8 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
         deleteNodeById(id);
         break;
       case ToolTypes.play:
-        {
-          // analyze code and set symbol table
-          // TODO maybe put this logic elsewhere?
-          let { ispublic, names } = analyzeCode(pod.content);
-          setPodVisibility(id, ispublic);
-          console.log("names", names);
-          if (names) {
-            setSymbolTable(data.id, names);
-          }
-          clearResults(data.id);
-          wsRun(data.id);
-        }
+        clearResults(data.id);
+        wsRun(data.id);
         break;
       case ToolTypes.layout:
         setLayout(layout === "bottom" ? "right" : "bottom");

--- a/ui/src/lib/runtime.tsx
+++ b/ui/src/lib/runtime.tsx
@@ -4,7 +4,7 @@ import { createStore, StateCreator, StoreApi } from "zustand";
 
 // FIXME cyclic import
 import { RepoSlice } from "./store";
-import { rewriteCode } from "./parser";
+import { analyzeCode, rewriteCode } from "./parser";
 
 function getChildExports({ id, pods }) {
   // get all the exports and reexports. The return would be:
@@ -711,6 +711,13 @@ export const createRuntimeSlice: StateCreator<
       });
       return;
     }
+    // Analyze code and set symbol table
+    let { ispublic, names } = analyzeCode(get().pods[id].content);
+    get().setPodVisibility(id, ispublic);
+    if (names) {
+      get().setSymbolTable(id, names);
+    }
+    // Run the code in remote kernel.
     doRun({
       id,
       socket: {


### PR DESCRIPTION
There are two ways to run code: click the toolbar button and shift-enter keyboard shortcut. This PR put `analyzeCode` into wsRun action so that both ways behave consistently.