### PR TITLE
Fix: read/write access control for public repos

### DIFF
--- a/api/src/typedefs.ts
+++ b/api/src/typedefs.ts
@@ -18,6 +18,7 @@ export const typeDefs = gql`
     id: ID!
     name: String!
     pods: [Pod]
+    userId: ID!
     collaboratorIds: [ID!]
     public: Boolean!
   }

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -46,7 +46,7 @@ import { nolookalikes } from "nanoid-dictionary";
 
 import { useStore } from "zustand";
 
-import { RepoContext } from "../lib/store";
+import { RepoContext, RoleType } from "../lib/store";
 import { useNodesStateSynced } from "../lib/nodes";
 
 import { MyMonaco } from "./MyMonaco";
@@ -342,6 +342,7 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
   const setCurrentEditor = useStore(store, (state) => state.setCurrentEditor);
   const getPod = useStore(store, (state) => state.getPod);
   const pod = getPod(id);
+  const role = useStore(store, (state) => state.role);
 
   const showResult = useStore(
     store,
@@ -445,27 +446,31 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
               justifyContent: "center",
             }}
           >
-            <Tooltip title="Run (shift-enter)">
-              <IconButton
-                size="small"
-                onClick={() => {
-                  clearResults(id);
-                  wsRun(id);
-                }}
-              >
-                <PlayCircleOutlineIcon fontSize="inherit" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Delete">
-              <IconButton
-                size="small"
-                onClick={() => {
-                  deleteNodeById(id);
-                }}
-              >
-                <DeleteIcon fontSize="inherit" />
-              </IconButton>
-            </Tooltip>
+            {role !== RoleType.GUEST && (
+              <Tooltip title="Run (shift-enter)">
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    clearResults(id);
+                    wsRun(id);
+                  }}
+                >
+                  <PlayCircleOutlineIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+            )}
+            {role !== RoleType.GUEST && (
+              <Tooltip title="Delete">
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    deleteNodeById(id);
+                  }}
+                >
+                  <DeleteIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+            )}
             <Tooltip title="Change layout">
               <IconButton
                 size="small"
@@ -579,6 +584,7 @@ export function Canvas() {
   const [showShareDialog, setShowShareDialog] = useState(false);
   const repoId = useStore(store, (state) => state.repoId);
   const repoName = useStore(store, (state) => state.repoName);
+  const role = useStore(store, (state) => state.role);
 
   const getRealNodes = useCallback(
     (id, level) => {
@@ -597,7 +603,6 @@ export function Canvas() {
           position: { x: pod.x, y: pod.y },
           parentNode: pod.parent !== "ROOT" ? pod.parent : undefined,
           extent: "parent",
-          dragHandle: ".custom-drag-handle",
           level,
           style: {
             backgroundColor:
@@ -957,6 +962,9 @@ export function Canvas() {
           zoomOnScroll={false}
           panOnScroll={true}
           connectionMode={ConnectionMode.Loose}
+          nodesDraggable={role !== RoleType.GUEST}
+          // disable node delete on backspace when the user is a guest.
+          deleteKeyCode={role === RoleType.GUEST ? null : "Backspace"}
         >
           <Box>
             <MiniMap

--- a/ui/src/components/CanvasContextMenu.tsx
+++ b/ui/src/components/CanvasContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useStore } from "zustand";
-import { RepoContext } from "../lib/store";
+import { RepoContext, RoleType } from "../lib/store";
 import Box from "@mui/material/Box";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
@@ -40,6 +40,7 @@ export function CanvasContextMenu(props) {
     store,
     (state) => state.flipShowLineNumbers
   );
+  const role = useStore(store, (state) => state.role);
   return (
     <Box sx={paneMenuStyle(props.x, props.y)}>
       <MenuList className="paneContextMenu">
@@ -63,12 +64,14 @@ export function CanvasContextMenu(props) {
             {showLineNumbers ? "Hide " : "Show "} Line Numbers
           </ListItemText>
         </MenuItem>
-        <MenuItem onClick={props.onShareClick} sx={ItemStyle}>
-          <ListItemIcon>
-            <ShareOutlinedIcon />
-          </ListItemIcon>
-          <ListItemText> Share with Collaborators </ListItemText>
-        </MenuItem>
+        {role === RoleType.OWNER && (
+          <MenuItem onClick={props.onShareClick} sx={ItemStyle}>
+            <ListItemIcon>
+              <ShareOutlinedIcon />
+            </ListItemIcon>
+            <ListItemText> Share with Collaborators </ListItemText>
+          </MenuItem>
+        )}
       </MenuList>
     </Box>
   );

--- a/ui/src/components/CanvasContextMenu.tsx
+++ b/ui/src/components/CanvasContextMenu.tsx
@@ -44,18 +44,22 @@ export function CanvasContextMenu(props) {
   return (
     <Box sx={paneMenuStyle(props.x, props.y)}>
       <MenuList className="paneContextMenu">
-        <MenuItem onClick={props.addCode} sx={ItemStyle}>
-          <ListItemIcon>
-            <CodeIcon />
-          </ListItemIcon>
-          <ListItemText>New Code</ListItemText>
-        </MenuItem>
-        <MenuItem onClick={props.addScope} sx={ItemStyle}>
-          <ListItemIcon>
-            <PostAddIcon />
-          </ListItemIcon>
-          <ListItemText>New Scope</ListItemText>
-        </MenuItem>
+        {role !== RoleType.GUEST && (
+          <MenuItem onClick={props.addCode} sx={ItemStyle}>
+            <ListItemIcon>
+              <CodeIcon />
+            </ListItemIcon>
+            <ListItemText>New Code</ListItemText>
+          </MenuItem>
+        )}
+        {role !== RoleType.GUEST && (
+          <MenuItem onClick={props.addScope} sx={ItemStyle}>
+            <ListItemIcon>
+              <PostAddIcon />
+            </ListItemIcon>
+            <ListItemText>New Scope</ListItemText>
+          </MenuItem>
+        )}
         <MenuItem onClick={flipShowLineNumbers} sx={ItemStyle}>
           <ListItemIcon>
             <FormatListNumberedIcon />

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -3,7 +3,7 @@ import { useState, useContext, memo } from "react";
 import MonacoEditor, { MonacoDiffEditor } from "react-monaco-editor";
 import { monaco } from "react-monaco-editor";
 import { useStore } from "zustand";
-import { RepoContext } from "../lib/store";
+import { RepoContext, RoleType } from "../lib/store";
 import { MonacoBinding } from "y-monaco";
 
 const theme: monaco.editor.IStandaloneThemeData = {
@@ -324,6 +324,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   // there's no racket language support
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const readOnly = useStore(store, (state) => state.role === RoleType.GUEST);
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const getPod = useStore(store, (state) => state.getPod);
   const setPodContent = useStore(store, (state) => state.setPodContent);
@@ -408,7 +409,6 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
 
     if (!provider || !provider.wsconnected) {
       // TODO: consider offline situation later
-      console.log("editor", provider?.wsconnected, provider, editor.getModel());
       // editor.getModel().setValue(value);
       return;
     } else if (provider.synced) {
@@ -427,6 +427,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
       theme="codepod"
       options={{
         selectOnLineNumbers: true,
+        readOnly: readOnly,
         // This scrollBeyondLastLine is super important. Without this, it will
         // try to adjust height infinitely.
         scrollBeyondLastLine: false,

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -21,7 +21,7 @@ import { useStore } from "zustand";
 
 import { usePrompt } from "../lib/prompt";
 
-import { RepoContext, selectNumDirty } from "../lib/store";
+import { RepoContext, selectNumDirty, RoleType } from "../lib/store";
 
 import useMe from "../lib/me";
 import { Grid } from "@mui/material";
@@ -271,20 +271,39 @@ function ToastError() {
 }
 
 export function Sidebar() {
+  // never render saving status / runtime module for a guest
+  // FIXME: improve the implementation logic
+  const store = useContext(RepoContext);
+  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const role = useStore(store, (state) => state.role);
   return (
     <Grid container spacing={2}>
-      <Grid item xs={12}>
-        <SyncStatus />
-      </Grid>
-      <Grid item xs={12}>
-        {" "}
-        <SidebarSession />
-      </Grid>
-      <Grid item xs={12}>
-        <SidebarRuntime />
-        <SidebarKernel />
-      </Grid>
-      <ToastError />
+      {role === RoleType.GUEST ? (
+        <>
+          <Grid item xs={12}>
+            <Box> Read-only Mode: You are a guest. </Box>
+          </Grid>
+          <Grid item xs={12}>
+            {" "}
+            <SidebarSession />
+          </Grid>
+        </>
+      ) : (
+        <>
+          <Grid item xs={12}>
+            <SyncStatus />
+          </Grid>
+          <Grid item xs={12}>
+            {" "}
+            <SidebarSession />
+          </Grid>
+          <Grid item xs={12}>
+            <SidebarRuntime />
+            <SidebarKernel />
+          </Grid>
+          <ToastError />
+        </>
+      )}
     </Grid>
   );
 }

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -16,6 +16,8 @@ export async function doRemoteLoadRepo({ id, client }) {
       repo(id: $id) {
         id
         name
+        userId
+        collaboratorIds
         pods {
           id
           type
@@ -61,10 +63,16 @@ export async function doRemoteLoadRepo({ id, client }) {
     });
     // We need to do a deep copy here, because apollo client returned immutable objects.
     let pods = res.data.repo.pods.map((pod) => ({ ...pod }));
-    return { pods, name: res.data.repo.name, error: null };
+    return {
+      pods,
+      name: res.data.repo.name,
+      error: null,
+      userId: res.data.repo.userId,
+      collaboratorIds: res.data.repo.collaboratorIds,
+    };
   } catch (e) {
     console.log(e);
-    return { pods: [], name: "", error: e };
+    return { pods: [], name: "", error: e, userId: null, collaboratorIds: [] };
   }
 }
 

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -697,6 +697,7 @@ const createRepoSlice: StateCreator<
         }
         state.pods = normalize(pods);
         state.repoName = name;
+        // set the user role in this repo
         if (userId == state.user.id) {
           state.role = RoleType.OWNER;
         } else if (state.user && collaboratorIds.indexOf(state.user.id) >= 0) {
@@ -704,6 +705,17 @@ const createRepoSlice: StateCreator<
         } else {
           state.role = RoleType.GUEST;
         }
+        // only set the local awareness when the user is an owner or a collaborator
+        if (state.provider && state.role !== RoleType.GUEST) {
+          console.log("set awareness", state.user.firstname);
+          const awareness = state.provider.awareness;
+          awareness.setLocalStateField("user", {
+            name: state.user.firstname,
+            color: state.user.color,
+          });
+          console.log("awareness", awareness);
+        }
+
         // fill in the parent/children relationships
         for (const id in state.pods) {
           let pod = state.pods[id];
@@ -777,11 +789,6 @@ const createRepoSlice: StateCreator<
     set(
       produce((state: BearState) => {
         const color = "#" + Math.floor(Math.random() * 16777215).toString(16);
-        // if (!state.ydoc) state.ydoc = new Doc();
-        if (state.provider) {
-          const awareness = state.provider.awareness;
-          awareness.setLocalStateField("user", { name: user.firstname, color });
-        }
         state.user = { ...user, color };
       })
     ),

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -28,6 +28,12 @@ if (window.location.protocol === "http:") {
 }
 console.log("yjs server url: ", serverURL);
 
+export enum RoleType {
+  OWNER,
+  COLLABORATOR,
+  GUEST,
+}
+
 export const RepoContext = createContext<StoreApi<
   RepoSlice & RuntimeSlice
 > | null>(null);
@@ -92,6 +98,7 @@ const initialState = {
   clients: new Map(),
   showLineNumbers: false,
   loadError: null,
+  role: RoleType.GUEST,
 };
 
 export type Pod = {
@@ -138,6 +145,7 @@ export interface RepoSlice {
   // runtime: string;
   repoId: string | null;
   loadError: any;
+  role: RoleType;
   // sessionId?: string;
 
   resetState: () => void;
@@ -676,7 +684,8 @@ const createRepoSlice: StateCreator<
     );
   },
   loadRepo: async (client, id) => {
-    const { pods, name, error } = await doRemoteLoadRepo({ id, client });
+    const { pods, name, error, userId, collaboratorIds } =
+      await doRemoteLoadRepo({ id, client });
     set(
       produce((state) => {
         // TODO the children ordered by index
@@ -688,6 +697,13 @@ const createRepoSlice: StateCreator<
         }
         state.pods = normalize(pods);
         state.repoName = name;
+        if (userId == state.user.id) {
+          state.role = RoleType.OWNER;
+        } else if (state.user && collaboratorIds.indexOf(state.user.id) >= 0) {
+          state.role = RoleType.COLLABORATOR;
+        } else {
+          state.role = RoleType.GUEST;
+        }
         // fill in the parent/children relationships
         for (const id in state.pods) {
           let pod = state.pods[id];


### PR DESCRIPTION
For a public repo, even an anonymous user can read everything in it, but only the owner and collaborators are allowed to edit. In this PR: we further distinguish the access for different roles in a repo, enforced the access rule both on the front-end and back-end side. 

- front-end: hide operation UI for guests, including auto saving button, runtime kernel in the sidebar, new code/scope menu
- back-end: prohibit mutate query when auth fails

Besides, remove the awareness info (remote cursor/selection) of guests, only show the operation update from an owner/collaborator. A guest can never edit/run code in the pod or drag a pod.

![image](https://user-images.githubusercontent.com/10118462/205229402-d44149d9-dcb5-46d5-80be-eaad724971ca.png)

Now, a public repo can also be shared with collaborators.

TODO
- [ ] the resizing button and drag handles sometimes do not work properly when multiple users are collaborating on the repo.

