### PR TITLE
feat: header and sidebar improvement

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -63,17 +63,8 @@ const router = createBrowserRouter([
   {
     path: "repo/:id",
     element: (
-      <Box height="100vh">
-        <Header />
-        <Box
-          height="100%"
-          boxSizing={"border-box"}
-          sx={{
-            pt: "50px",
-          }}
-        >
-          <Repo />
-        </Box>
+      <Box height="100vh" width="100%" boxSizing={"border-box"}>
+        <Repo />
       </Box>
     ),
   },

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -33,15 +33,23 @@ const theme = createTheme({
   },
 });
 
-function NormalLayout({ children }: any) {
+type NormalLayoutProps = {
+  currentPage?: string | null;
+  children: React.ReactNode;
+};
+
+const NormalLayout: React.FC<NormalLayoutProps> = ({
+  currentPage,
+  children,
+}) => {
   return (
     <Box>
-      <Header />
+      <Header currentPage={currentPage} />
       <Box pt="50px">{children}</Box>
       {/* <Footer /> */}
     </Box>
   );
-}
+};
 
 const router = createBrowserRouter([
   {
@@ -87,7 +95,7 @@ const router = createBrowserRouter([
   {
     path: "profile",
     element: (
-      <NormalLayout>
+      <NormalLayout currentPage="Profile">
         <Profile />
       </NormalLayout>
     ),

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -63,7 +63,7 @@ const router = createBrowserRouter([
   {
     path: "repos",
     element: (
-      <NormalLayout>
+      <NormalLayout currentPage="Dashboard">
         <Repos />
       </NormalLayout>
     ),

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Link as ReactLink } from "react-router-dom";
+import { Link as ReactLink, useLocation } from "react-router-dom";
 
 import { useState } from "react";
 
@@ -9,6 +9,7 @@ import MenuIcon from "@mui/icons-material/Menu";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import Avatar from "@mui/material/Avatar";
+import Breadcrumbs from "@mui/material/Breadcrumbs";
 import Link from "@mui/material/Link";
 import Button from "@mui/material/Button";
 
@@ -24,14 +25,48 @@ import { useAuth } from "../lib/auth";
 
 import useMe from "../lib/me";
 
+type HeaderTitleProps = {
+  currentPage: string | null;
+};
+
+const HeaderTitle: React.FC<HeaderTitleProps> = ({ currentPage = null }) => {
+  if (!currentPage) {
+    return (
+      <Typography variant="h6">
+        <Link component={ReactLink} underline="none" to="/">
+          CodePod
+        </Link>
+      </Typography>
+    );
+  }
+
+  return (
+    <Breadcrumbs
+      aria-label="breadcrumb"
+      sx={{
+        alignItems: "baseline",
+        display: "flex",
+        flexGrow: 1,
+      }}
+    >
+      <Link component={ReactLink} underline="hover" to="/">
+        <Typography noWrap>CodePod</Typography>
+      </Link>
+      <Typography color="text.primary">{currentPage}</Typography>
+    </Breadcrumbs>
+  );
+};
+
 type HeaderProps = {
   open?: boolean;
   drawerWidth?: number;
+  currentPage?: string | null;
 };
 
 export const Header: React.FC<HeaderProps> = ({
   open = false,
   drawerWidth = 0,
+  currentPage = null,
 }) => {
   const [anchorElNav, setAnchorElNav] = useState(null);
   const [anchorElUser, setAnchorElUser] = useState(null);
@@ -72,17 +107,6 @@ export const Header: React.FC<HeaderProps> = ({
             maxHeight: "10px",
           }}
         >
-          <Typography
-            variant="h6"
-            noWrap
-            component="div"
-            sx={{ mr: 2, display: { xs: "none", md: "flex" } }}
-          >
-            <Link component={ReactLink} underline="none" to="/">
-              CodePod
-            </Link>
-          </Typography>
-
           <Box sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}>
             <IconButton
               size="large"
@@ -108,9 +132,6 @@ export const Header: React.FC<HeaderProps> = ({
               }}
               open={Boolean(anchorElNav)}
               onClose={handleCloseNavMenu}
-              sx={{
-                display: { xs: "block", md: "none" },
-              }}
             >
               {/* The toggle menu */}
               <MenuItem onClick={handleCloseNavMenu}>
@@ -135,22 +156,11 @@ export const Header: React.FC<HeaderProps> = ({
               </MenuItem>
             </Menu>
           </Box>
-          <Typography
-            variant="h6"
-            noWrap
-            component="div"
-            color="primary"
-            sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}
-          >
-            <Link component={ReactLink} underline="none" to="/">
-              CodePod
-            </Link>
-          </Typography>
+          <HeaderTitle currentPage={currentPage} />
 
           {/* The navigation on desktop */}
           <Box
             sx={{
-              flexGrow: 1,
               display: { xs: "none", md: "flex" },
               alignItems: "center",
             }}

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -32,7 +32,7 @@ type HeaderTitleProps = {
 const HeaderTitle: React.FC<HeaderTitleProps> = ({ currentPage = null }) => {
   if (!currentPage) {
     return (
-      <Typography variant="h6">
+      <Typography variant="h6" sx={{ display: "flex", flexGrow: 1 }}>
         <Link component={ReactLink} underline="none" to="/">
           CodePod
         </Link>

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -24,7 +24,15 @@ import { useAuth } from "../lib/auth";
 
 import useMe from "../lib/me";
 
-export function Header() {
+type HeaderProps = {
+  open?: boolean;
+  drawerWidth?: number;
+};
+
+export const Header: React.FC<HeaderProps> = ({
+  open = false,
+  drawerWidth = 0,
+}) => {
   const [anchorElNav, setAnchorElNav] = useState(null);
   const [anchorElUser, setAnchorElUser] = useState(null);
 
@@ -48,7 +56,14 @@ export function Header() {
   const { me } = useMe();
 
   return (
-    <AppBar position="fixed" color="inherit">
+    <AppBar
+      position="fixed"
+      color="inherit"
+      sx={{
+        width: `calc(100% - ${open ? drawerWidth : 0}px)`,
+        transition: "width 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms",
+      }}
+    >
       <Container maxWidth="xl">
         <Toolbar
           disableGutters
@@ -186,7 +201,7 @@ export function Header() {
       </Container>
     </AppBar>
   );
-}
+};
 
 const MyMenuItem = ({ children, to = "/" }) => {
   return (

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -1,22 +1,20 @@
-import { useEffect, useState, useContext } from "react";
-
+import { useEffect, useContext } from "react";
 import { useParams } from "react-router-dom";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
 import IconButton from "@mui/material/IconButton";
-
-import { grey } from "@mui/material/colors";
-
-import { useSnackbar, VariantType } from "notistack";
-
-import { gql, useQuery, useMutation, useApolloClient } from "@apollo/client";
-
 import StopIcon from "@mui/icons-material/Stop";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import Drawer from "@mui/material/Drawer";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import Grid from "@mui/material/Grid";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import { useSnackbar, VariantType } from "notistack";
 
+import { gql, useQuery, useMutation, useApolloClient } from "@apollo/client";
 import { useStore } from "zustand";
 
 import { usePrompt } from "../lib/prompt";
@@ -24,7 +22,6 @@ import { usePrompt } from "../lib/prompt";
 import { RepoContext, selectNumDirty, RoleType } from "../lib/store";
 
 import useMe from "../lib/me";
-import { Grid } from "@mui/material";
 
 function Flex(props) {
   return (
@@ -270,40 +267,105 @@ function ToastError() {
   return <Box></Box>;
 }
 
-export function Sidebar() {
+type SidebarProps = {
+  width: number;
+  open: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+};
+
+export const Sidebar: React.FC<SidebarProps> = ({
+  width,
+  open,
+  onOpen,
+  onClose,
+}) => {
   // never render saving status / runtime module for a guest
   // FIXME: improve the implementation logic
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const role = useStore(store, (state) => state.role);
   return (
-    <Grid container spacing={2}>
-      {role === RoleType.GUEST ? (
-        <>
-          <Grid item xs={12}>
-            <Box> Read-only Mode: You are a guest. </Box>
+    <>
+      <Box
+        sx={{
+          position: "absolute",
+          display: open ? "none" : "block",
+          top: `54px`,
+          left: 1,
+        }}
+      >
+        <IconButton
+          onClick={onOpen}
+          sx={{
+            zIndex: 1,
+          }}
+        >
+          <ChevronRightIcon />
+        </IconButton>
+      </Box>
+
+      <Drawer
+        sx={{
+          width: width,
+          flexShrink: 0,
+          "& .MuiDrawer-paper": {
+            width: width,
+            boxSizing: "border-box",
+          },
+        }}
+        variant="persistent"
+        anchor="left"
+        open={open}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            paddingLeft: "8px",
+            height: 48,
+          }}
+        >
+          <IconButton onClick={onClose}>
+            <ChevronLeftIcon />
+          </IconButton>
+        </Box>
+        <Divider />
+        <Box
+          sx={{
+            padding: "8px 16px",
+          }}
+        >
+          <Grid container spacing={2}>
+            {role === RoleType.GUEST ? (
+              <>
+                <Grid item xs={12}>
+                  <Box> Read-only Mode: You are a guest. </Box>
+                </Grid>
+                <Grid item xs={12}>
+                  {" "}
+                  <SidebarSession />
+                </Grid>
+              </>
+            ) : (
+              <>
+                <Grid item xs={12}>
+                  <SyncStatus />
+                </Grid>
+                <Grid item xs={12}>
+                  {" "}
+                  <SidebarSession />
+                </Grid>
+                <Grid item xs={12}>
+                  <SidebarRuntime />
+                  <SidebarKernel />
+                </Grid>
+                <ToastError />
+              </>
+            )}
           </Grid>
-          <Grid item xs={12}>
-            {" "}
-            <SidebarSession />
-          </Grid>
-        </>
-      ) : (
-        <>
-          <Grid item xs={12}>
-            <SyncStatus />
-          </Grid>
-          <Grid item xs={12}>
-            {" "}
-            <SidebarSession />
-          </Grid>
-          <Grid item xs={12}>
-            <SidebarRuntime />
-            <SidebarKernel />
-          </Grid>
-          <ToastError />
-        </>
-      )}
-    </Grid>
+        </Box>
+      </Drawer>
+    </>
   );
-}
+};

--- a/ui/src/hooks/useLocalStorage.ts
+++ b/ui/src/hooks/useLocalStorage.ts
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+// ref: https://usehooks.com/useLocalStorage
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue] as const;
+}

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -16,11 +16,14 @@ import useMe from "../lib/me";
 import { Canvas } from "../components/Canvas";
 import { Header } from "../components/Header";
 import { Sidebar } from "../components/Sidebar";
+import { useLocalStorage } from "../hooks/useLocalStorage";
+
+const DrawerWidth = 240;
+const SIDEBAR_KEY = "sidebar";
 
 function RepoWrapper({ children }) {
   // this component is used to provide a foldable layout
-  const [open, setOpen] = useState(true);
-  const DrawerWidth = 240;
+  const [open, setOpen] = useLocalStorage(SIDEBAR_KEY, true);
 
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -2,9 +2,9 @@ import { useParams, useNavigate } from "react-router-dom";
 import { Link as ReactLink } from "react-router-dom";
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
-import Button from "@mui/material/Button";
 import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
+import { useApolloClient } from "@apollo/client";
 
 import { useEffect, useState, useRef, useContext } from "react";
 
@@ -14,71 +14,51 @@ import { createRepoStore, RepoContext } from "../lib/store";
 
 import useMe from "../lib/me";
 import { Canvas } from "../components/Canvas";
+import { Header } from "../components/Header";
 import { Sidebar } from "../components/Sidebar";
-import { useApolloClient } from "@apollo/client";
 
 function RepoWrapper({ children }) {
-  // this component is used to provide foldable sidebar
-  const [show, setShow] = useState(true);
-  let sidebar_width = 0.12;
+  // this component is used to provide a foldable layout
+  const [open, setOpen] = useState(true);
+  const DrawerWidth = 240;
+
   return (
-    <Box m="auto" height="100%">
-      <Box
-        sx={{
-          display: "inline-block",
-          verticalAlign: "top",
-          height: "100%",
-          width: show ? sidebar_width : 0,
-          overflow: "auto",
-        }}
-      >
-        <Box sx={{ display: "flex" }}>
-          {/* <Spacer /> */}
-          <Button
-            onClick={() => {
-              setShow(!show);
-            }}
-            size="small"
-            // variant="ghost"
-          >
-            {show ? "Hide" : "Show"}
-          </Button>
-        </Box>
-        <Box sx={{ mx: 2, my: 1 }}>
-          <Sidebar />
-        </Box>
-      </Box>
+    <Box
+      sx={{
+        width: "100%",
+        height: "100%",
+        overflow: "hidden",
+      }}
+    >
+      <Sidebar
+        width={DrawerWidth}
+        open={open}
+        onOpen={() => setOpen(true)}
+        onClose={() => setOpen(false)}
+      />
 
       <Box
         sx={{
-          display: "inline-block",
+          display: "flex",
+          flexGrow: 1,
           verticalAlign: "top",
           height: "100%",
-          width: show ? 1 - sidebar_width : 1,
-          overflow: "scroll",
+          transition: "margin 195ms cubic-bezier(0.4, 0, 0.6, 1) 0ms",
+          ml: open ? `${DrawerWidth}px` : 0,
         }}
       >
+        <Header open={open} drawerWidth={DrawerWidth} />
         <Box
-          style={{
-            position: "absolute",
-            margin: "5px",
-            top: "50px",
-            left: "5px",
+          sx={{
+            boxSizing: "border-box",
+            width: "100%",
+            height: "100%",
+            pt: `52px`,
+            mx: "auto",
           }}
-          zIndex={100}
-          visibility={show ? "hidden" : "inherit"}
         >
-          <Button
-            onClick={() => {
-              setShow(!show);
-            }}
-            size="small"
-            // variant="ghost"
-          >
-            {show ? "Hide" : "Show"}
-          </Button>
+          {children}
         </Box>
-        {children}
       </Box>
     </Box>
   );

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -22,6 +22,10 @@ function RepoWrapper({ children }) {
   const [open, setOpen] = useState(true);
   const DrawerWidth = 240;
 
+  const store = useContext(RepoContext);
+  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const repoName = useStore(store, (state) => state.repoName);
+
   return (
     <Box
       sx={{
@@ -47,7 +51,7 @@ function RepoWrapper({ children }) {
           ml: open ? `${DrawerWidth}px` : 0,
         }}
       >
-        <Header open={open} drawerWidth={DrawerWidth} />
+        <Header open={open} drawerWidth={DrawerWidth} currentPage={repoName} />
         <Box
           sx={{
             boxSizing: "border-box",


### PR DESCRIPTION
closes #75 

### Changes
- Add Breadcrumb for repo page, dashboard page and profile page
- Foldable sidebar
- I have pushed `Docs` to the right side! (let me know if you don't like it)

### Things we can discuss
- the position of Expand `>` button is weird
- Have a standalone HomePage
  - Automatically redirect logged-in user from `/` to `/repos`
  - Only `/repos` shows the "Dashboard" breadcrumb

## Before
![image](https://user-images.githubusercontent.com/9910706/205436133-d9d60f12-3cfa-4dc5-8c70-0df7d2e7f670.png)

## After
### Expanded by default
![image](https://user-images.githubusercontent.com/9910706/205436079-49fb24e1-6e89-483c-89aa-5a2f5b9d24b9.png)
### Collapsed
![image](https://user-images.githubusercontent.com/9910706/205436148-078f58ac-6421-4e8a-8ed5-42f77ae6f867.png)
### Profile Page
***Note:***
In the original issue, the request is `Codepod/{USERNAME}'s Profile`
But I think it's duplicate information. So let's use `CodePod / Profile` 😄 
![image](https://user-images.githubusercontent.com/9910706/205436184-dd459935-cce5-400b-98d8-baf5c3df3b61.png)

### Other pages who don't have a specific breadcrumb
![image](https://user-images.githubusercontent.com/9910706/205436417-5046d508-5cfc-4917-85e6-a3ea716141bc.png)

### Inrelevant Suggestions
- Prettier IDE integration?
- Windows developer might need some fix for file-watching
```js
// ui/config-overrides.js
config.watchOptions = {
    ignored: /node_modules/,
    poll: true,
};
```