### PR TITLE
Fix: Lock interactivity & sync width resize & improve render performance

### DIFF
--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -311,15 +311,11 @@ async function updateGitGutter(editor) {
 interface MyMonacoProps {
   id: string;
   gitvalue: string;
-  onBlur?: Function;
-  onFocus?: Function;
 }
 
 export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   id = "0",
   gitvalue = null,
-  onBlur = () => {},
-  onFocus = () => {},
 }) {
   // there's no racket language support
   const store = useContext(RepoContext);
@@ -330,6 +326,8 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const setPodContent = useStore(store, (state) => state.setPodContent);
   const clearResults = useStore(store, (s) => s.clearResults);
   const wsRun = useStore(store, (state) => state.wsRun);
+  const setPodFocus = useStore(store, (state) => state.setPodFocus);
+  const setPodBlur = useStore(store, (state) => state.setPodBlur);
 
   const value = getPod(id).content || "";
   let lang = getPod(id).lang || "javascript";
@@ -377,10 +375,10 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
       // onLayout(`${contentHeight}px`);
     };
     editor.onDidBlurEditorText(() => {
-      onBlur();
+      setPodBlur(id);
     });
     editor.onDidFocusEditorText(() => {
-      onFocus();
+      setPodFocus(id);
     });
     editor.onDidContentSizeChange(updateHeight);
     // FIXME clean up?

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -22,6 +22,7 @@ import { usePrompt } from "../lib/prompt";
 import { RepoContext, selectNumDirty, RoleType } from "../lib/store";
 
 import useMe from "../lib/me";
+import { Stack } from "@mui/material";
 
 function Flex(props) {
   return (
@@ -148,13 +149,13 @@ function SidebarKernel() {
 function SyncStatus() {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const numDirty = useStore(store, selectNumDirty());
+  const dirtyIds = useStore(store, selectNumDirty());
   const clearAllResults = useStore(store, (s) => s.clearAllResults);
   const remoteUpdateAllPods = useStore(store, (s) => s.remoteUpdateAllPods);
   const client = useApolloClient();
   usePrompt(
-    `You have unsaved ${numDirty} changes. Are you sure you want to leave?`,
-    numDirty > 0
+    `You have unsaved ${dirtyIds.length} changes. Are you sure you want to leave?`,
+    dirtyIds.length > 0
   );
 
   useEffect(() => {
@@ -173,24 +174,26 @@ function SyncStatus() {
 
   return (
     <Box>
-      <Button
-        size="small"
-        disabled={numDirty === 0}
-        onClick={() => {
-          remoteUpdateAllPods(client);
+      <Stack
+        direction="row"
+        spacing={2}
+        color={dirtyIds.length === 0 ? "gray" : "blue"}
+        sx={{
+          alignItems: "center",
         }}
       >
         <CloudUploadIcon />
-        {numDirty > 0 ? (
+        {dirtyIds.length > 0 ? (
           <Box component="span" color="blue" mx={1}>
-            saving {numDirty} to cloud
+            saving {dirtyIds.length} to cloud
+            {/* <pre>{JSON.stringify(dirtyIds)}</pre> */}
           </Box>
         ) : (
           <Box component="span" color="grey" mx={1}>
             Saved to cloud.
           </Box>
         )}
-      </Button>
+      </Stack>
     </Box>
   );
 }

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 
-import { hashPod, computeNamespace } from "./utils";
+import { computeNamespace } from "./utils";
 import { Pod } from "./store";
 
 /**
@@ -154,7 +154,6 @@ export function normalize(pods) {
     if (pod.midports) {
       pod.midports = JSON.parse(pod.midports);
     }
-    pod.remoteHash = hashPod(pod);
     // DEBUG the deck's content seems to be a long string of escaped \
     if (pod.type === "DECK" && pod.content) {
       console.log(

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -11,6 +11,7 @@ export function useNodesStateSynced(nodeList) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const addPod = useStore(store, (state) => state.addPod);
+  const getPod = useStore(store, (state) => state.getPod);
   const deletePod = useStore(store, (state) => state.deletePod);
   const updatePod = useStore(store, (state) => state.updatePod);
   const setSelected = useStore(store, (state) => state.setSelected);
@@ -49,13 +50,18 @@ export function useNodesStateSynced(nodeList) {
         }
 
         if (change.type === "dimensions" && node.type === "code") {
-          // only sync width
-          updatePod({
-            id: node.id,
-            data: {
-              width: node.style?.width as number,
-            },
-          });
+          // There is a (seemingly unnecessary) dimension change at the very
+          // beginning of canvas page, which causes dirty status of all
+          // CodeNodes to be set. This is a workaround to prevent that.
+          if (getPod(node.id).width !== node.width) {
+            // only sync width
+            updatePod({
+              id: node.id,
+              data: {
+                width: node.style?.width as number,
+              },
+            });
+          }
           return;
         }
 

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -41,6 +41,7 @@ export function useNodesStateSynced(nodeList) {
         }
 
         if (change.type === "dimensions" && node.type === "code") {
+          console.log("dimensions", change);
           // the re-size event of codeNode don't need to be sync, just skip.
           return;
         }
@@ -66,8 +67,8 @@ export function useNodesStateSynced(nodeList) {
             lang: "python",
             x: node.position.x,
             y: node.position.y,
-            width: node.width,
-            height: node.height,
+            width: node.style?.width,
+            height: node.style?.height,
           });
         } else if (change.action === "delete") {
           const node = change.oldValue;
@@ -83,6 +84,8 @@ export function useNodesStateSynced(nodeList) {
         )
       );
       // setNodes(Array.from(nodesMap.values()));
+
+      console.log("nodes", Array.from(nodesMap.values()));
     };
 
     // setNodes(Array.from(nodesMap.values()));

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -687,7 +687,7 @@ const createRepoSlice: StateCreator<
         state.pods = normalize(pods);
         state.repoName = name;
         // set the user role in this repo
-        if (userId == state.user.id) {
+        if (userId === state.user.id) {
           state.role = RoleType.OWNER;
         } else if (state.user && collaboratorIds.indexOf(state.user.id) >= 0) {
           state.role = RoleType.COLLABORATOR;

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -38,28 +38,14 @@ export const RepoContext = createContext<StoreApi<
   RepoSlice & RuntimeSlice
 > | null>(null);
 
-// TODO use a selector to compute and retrieve the status
-// TODO this need to cooperate with syncing indicator
-export function selectIsDirty(id) {
-  return (state) => {
-    let pod = state.pods[id];
-    // console.log("selectIsDirty");
-    if (pod.remoteHash === hashPod(pod)) {
-      return false;
-    } else {
-      return true;
-    }
-  };
-}
-
 // FIXME performance
 export function selectNumDirty() {
   return (state) => {
-    let res = 0;
+    let res: string[] = [];
     if (state.repoLoaded) {
       for (const id in state.pods) {
         if (state.pods[id].dirty) {
-          res += 1;
+          res.push(id);
         }
       }
     }

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -136,6 +136,7 @@ export type Pod = {
   height: number;
   ns?: string;
   running?: boolean;
+  focus?: boolean;
 };
 
 export interface RepoSlice {
@@ -206,6 +207,8 @@ export interface RepoSlice {
   getPods: () => Record<string, Pod>;
   getId2children: (string) => string[];
   setPodVisibility: (id, visible) => void;
+  setPodFocus: (id) => void;
+  setPodBlur: (id) => void;
 }
 
 type BearState = RepoSlice & RuntimeSlice;
@@ -713,7 +716,6 @@ const createRepoSlice: StateCreator<
             name: state.user.firstname,
             color: state.user.color,
           });
-          console.log("awareness", awareness);
         }
 
         // fill in the parent/children relationships
@@ -801,7 +803,6 @@ const createRepoSlice: StateCreator<
         if (state.provider) {
           state.provider.destroy();
           // just for debug usage, remove it later
-          console.log("remove awareness", state.provider.awareness);
           state.provider = null;
         }
         state.ydoc.destroy();
@@ -810,6 +811,22 @@ const createRepoSlice: StateCreator<
   getPod: (id: string) => get().pods[id],
   getPods: () => get().pods,
   getId2children: (id: string) => get().id2children[id],
+  setPodFocus: (id: string) =>
+    set(
+      produce((state) => {
+        if (state.pods[id]) {
+          state.pods[id].focus = true;
+        }
+      })
+    ),
+  setPodBlur: (id: string) =>
+    set(
+      produce((state) => {
+        if (state.pods[id]) {
+          state.pods[id].focus = false;
+        }
+      })
+    ),
 });
 
 export const createRepoStore = () =>

--- a/ui/src/lib/utils.tsx
+++ b/ui/src/lib/utils.tsx
@@ -13,33 +13,6 @@ export function computeNamespace(pods, id) {
   return res.reverse().join("/");
 }
 
-export function hashPod(pod) {
-  return sha256(
-    JSON.stringify({
-      id: pod.id,
-      content: pod.content,
-      column: pod.column,
-      type: pod.type,
-      lang: pod.lang,
-      // result: pod.result,
-      // stdout: pod.stdout,
-      // error: pod.error,
-      imports: pod.imports,
-      exports: pod.exports,
-      reexports: pod.reexports,
-      midports: pod.midports,
-      fold: pod.fold,
-      thundar: pod.thundar,
-      utility: pod.utility,
-      name: pod.name,
-      x: pod.x,
-      y: pod.y,
-      width: pod.width,
-      height: pod.height,
-    })
-  ).toString();
-}
-
 // FIXME performance for reading this from localstorage
 export const getAuthHeaders = () => {
   let authToken = localStorage.getItem("token") || null;


### PR DESCRIPTION
1. **Fix several node initialization issues**: specify custom drag handle, check init state after the provider synced, specify width when adding pod to the db, etc.
2. **Enforce write access control for guests**: hide the interactivity button (lock) globally, disable the resize box, and discard any node info update to the `yjs` servers from a guest. In this early stage, a user may feel a little inconvenient to select text in a pod without the button, however, they can fix the viewpoint by pressing <kbd>Control</kbd> temporarily. We (@lihebi ) will implement some other robust method to add auth layer to the yjs servers and fix the viewpoint automatically in the future if we have time.

![image](https://user-images.githubusercontent.com/10118462/205536828-55005fcc-2be5-404a-be96-31c0495f56a0.png)

3. **Sync code pod resize in real-time**: rewrite the logic of resetting the pod width, which makes all users observe the dimension update immediately when a user conduct resizing operation on it.
4. **Improve the render speed when a `codeNode` is re-rendered**: manage the `isEditorBlur` state globally instead of locally, otherwise, `MyMonaco` will be re-render over and over again any time the `codeNode` changes. If we click on the editor and then click other places, you can see it causes the re-rendering of  `MyMonaco` twice, which takes much time:

![Before](https://user-images.githubusercontent.com/10118462/205538644-649e979b-b11d-46d9-af28-e1b896057e32.png)

But after we apply this PR,  any update propagation stops at the `MyMonaco` .

![After](https://user-images.githubusercontent.com/10118462/205538799-5b2b22e6-c314-4c8e-afad-dda3d3d650eb.png) It reduces the re-render overhead a lot, especially when you drag a codeNode.
