### PR TITLE
Fix: Support Multi-selection in `ctrl` way

### DIFF
--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -78,7 +78,6 @@ const initialState = {
   socket: null,
   socketIntervalId: null,
   // keep different seletced info on each user themselves
-  selected: null,
   // to fixed maco editor command bug
   currentEditor: null,
   //TODO: all presence information are now saved in clients map for future usage. create a modern UI to show those information from clients (e.g., online users)
@@ -123,6 +122,7 @@ export type Pod = {
   ns?: string;
   running?: boolean;
   focus?: boolean;
+  selected?: boolean;
 };
 
 export interface RepoSlice {
@@ -180,8 +180,6 @@ export interface RepoSlice {
   }) => void;
   setPodPosition: ({ id, x, y }: any) => void;
   setPodParent: ({ id, parent }: any) => void;
-  selected: string | null;
-  setSelected: (id: string | null) => void;
   currentEditor: string | null;
   setCurrentEditor: (id: string | null) => void;
   setUser: (user: any) => void;
@@ -189,12 +187,13 @@ export interface RepoSlice {
   deleteClient: (clientId: any) => void;
   flipShowLineNumbers: () => void;
   disconnect: () => void;
-  getPod: (string) => Pod;
+  getPod: (id: string) => Pod;
   getPods: () => Record<string, Pod>;
   getId2children: (string) => string[];
-  setPodVisibility: (id, visible) => void;
-  setPodFocus: (id) => void;
-  setPodBlur: (id) => void;
+  setPodVisibility: (id: any, visible: any) => void;
+  setPodFocus: (id: string) => void;
+  setPodBlur: (id: string) => void;
+  setPodSelected: (id: string, target: boolean) => void;
 }
 
 type BearState = RepoSlice & RuntimeSlice;
@@ -244,7 +243,6 @@ const createRepoSlice: StateCreator<
   setSessionId: (id) => set({ sessionId: id }),
   addError: (error) => set({ error }),
   clearError: () => set({ error: null }),
-  setSelected: (id) => set({ selected: id }),
   setCurrentEditor: (id) => set({ currentEditor: id }),
   addPod: async (
     client,
@@ -286,6 +284,8 @@ const createRepoSlice: StateCreator<
       // the backend instead.
       children: [],
       io: {},
+      selected: false,
+      focus: false,
       // from payload
       parent,
       index,
@@ -835,6 +835,16 @@ const createRepoSlice: StateCreator<
         }
       })
     ),
+  setPodSelected: (id: string, target: boolean) => {
+    set(
+      produce((state) => {
+        if (state.pods[id]) {
+          state.pods[id].selected = target;
+        }
+      })
+    );
+  },
+  getPodSelected: (id: string) => get().pods[id]?.selected as boolean,
 });
 
 export const createRepoStore = () =>


### PR DESCRIPTION
Separate the pod `selected` states for each user, stop synchronizing all node data by remote YMap. Maintain `pod[id].selected` in local and apply their states every time after pulling updates from the remote yjs server.

Change the implementation to support multi-selection in a <kbd>Ctrl</kbd> way: keep pressing <kbd>Ctrl</kbd> and click on the drag handle of several pods, then you can drag or delete all of them at once, like what we do on a Windows desktop when selecting multiple files.

close https://github.com/codepod-io/codepod/issues/112

Known issues:

1. A guest user cannot select any pod now. It is fine so far. I will fix it when implementing the clipboard to enable copy a bunch of pods from a read-only repo and then paste them into another repo where they are allowed to write.
2. If you select two codeNodes and drag them into one scopeNode, only the one you drag on can be bound into the scope. I can fix it by overwriting `onNodeDragStop` if I have time, as it looks complicated.
3. If you choose nodes with different levels (e.g., a codeNode and its parent Scope Node), drag or delete them, anything cloud happen, including they are moving in a mess, or crash. If you have time, please discuss the rule to group nodes and I can prohibit some unexpected selection behaviors to mitigate it.