### PR TITLE
Fix: remove output indices and horizontal scroll bar in result blocks

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -73,8 +73,6 @@ const ScopeNode = memo<Props>(({ data, id, isConnectable }) => {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const flow = useReactFlow();
-  const getPod = useStore(store, (state) => state.getPod);
-  const pod = getPod(id);
   const setPodName = useStore(store, (state) => state.setPodName);
   const updatePod = useStore(store, (state) => state.updatePod);
   const [target, setTarget] = React.useState<any>();
@@ -321,8 +319,8 @@ function ResultBlock({ pod, id }) {
       {showOutput ? (
         <Box
           sx={{ paddingBottom: "2px" }}
-          overflow="scroll"
-          maxHeight="145px"
+          overflow="auto"
+          maxHeight="140px"
           border="1px"
         >
           {/* <Box bgcolor="lightgray">Error</Box> */}
@@ -424,6 +422,10 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
   const role = useStore(store, (state) => state.role);
   const width = useStore(store, (state) => state.pods[id]?.width);
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
+  const index = useStore(
+    store,
+    (state) => state.pods[id]?.result?.count || " "
+  );
   const inputRef = useRef<HTMLInputElement>(null);
 
   const showResult = useStore(
@@ -550,7 +552,7 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
             }}
           ></InputBase>
         </Box>
-        <Box sx={styles["pod-index"]}>[{pod.index}]</Box>
+        <Box sx={styles["pod-index"]}>[{index}]</Box>
         <Box
           sx={{
             display: "flex",
@@ -634,7 +636,7 @@ const CodeNode = memo<Props>(({ data, id, isConnectable }) => {
               position: "absolute",
               top: isRightLayout ? 0 : "100%",
               left: isRightLayout ? "100%" : 0,
-              maxHeight: "158px",
+              maxHeight: "160px",
               maxWidth: isRightLayout ? "300px" : "100%",
               minWidth: isRightLayout ? "150px" : "100%",
               boxSizing: "border-box",
@@ -845,7 +847,6 @@ export function Canvas() {
       addPod(apolloClient, {
         id,
         parent: "ROOT",
-        index: nodesMap.size + 1,
         type: type === "code" ? "CODE" : "DECK",
         lang: "python",
         x: position.x,

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -238,6 +238,7 @@ export async function doRemoteAddPod(client, { repoId, parent, pod }) {
     variables: {
       repoId,
       parent,
+      index: 0,
       input: serializePodInput(pod),
     },
     // FIXME the query is not refetched.

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -95,7 +95,6 @@ export function normalize(pods) {
       y: 0,
       width: 0,
       height: 0,
-      index: 0,
     },
   };
 
@@ -129,7 +128,7 @@ export function normalize(pods) {
     // pod.children = pod.children.map(({ id }) => id);
     //
     // sort according to index
-    pod.children.sort((a, b) => res[a.id].index - res[b.id].index);
+    // pod.children.sort((a, b) => res[a.id].index - res[b.id].index);
     // if (pod.type === "WYSIWYG" || pod.type === "CODE") {
     //   pod.content = JSON.parse(pod.content);
     // }
@@ -180,7 +179,6 @@ function serializePodInput(pod) {
     column,
     lang,
     parent,
-    // index,
     children,
     result,
     stdout,
@@ -223,7 +221,7 @@ function serializePodInput(pod) {
   }))(pod);
 }
 
-export async function doRemoteAddPod(client, { repoId, parent, index, pod }) {
+export async function doRemoteAddPod(client, { repoId, parent, pod }) {
   const mutation = gql`
     mutation addPod(
       $repoId: String
@@ -240,7 +238,6 @@ export async function doRemoteAddPod(client, { repoId, parent, index, pod }) {
     variables: {
       repoId,
       parent,
-      index,
       input: serializePodInput(pod),
     },
     // FIXME the query is not refetched.


### PR DESCRIPTION
1. Replace the creation-order number with execution-order number (`pod[id].result.count`) in the top-left corner of a `codeNode`
2. Fix the useless scroll issue in result blocks (at least works on my Chrome on Win10)

![image](https://user-images.githubusercontent.com/10118462/206841527-865ab42a-6d24-4432-9583-e1c68d413fba.png)
