### PR TITLE
feat: add docker runtime TTL; better runtime connection & feedback

### DIFF
--- a/api/src/resolver_runtime.ts
+++ b/api/src/resolver_runtime.ts
@@ -1,8 +1,6 @@
 import { ApolloClient, InMemoryCache, gql } from "@apollo/client/core";
 import Prisma from "@prisma/client";
 
-import { loadOrCreateContainer, removeContainer } from "./spawner-docker";
-
 const { PrismaClient } = Prisma;
 
 const prisma = new PrismaClient();
@@ -29,16 +27,23 @@ export async function listAllRuntimes(_, {}, { userId }) {
     // `,
     query: gql`
       query {
-        getUrls
+        getUrls {
+          url
+          lastActive
+        }
       }
     `,
     fetchPolicy: "network-only",
   });
   let res = urls.data.getUrls
-    .map((url) => {
+    .map(({ url, lastActive }) => {
       let match_res = url.match(/\/user_(.*)_repo_(.*)/);
       if (match_res) {
-        if (`user_${match_res[1]}` === userId) return `repo_${match_res[2]}`;
+        if (`user_${match_res[1]}` === userId)
+          return {
+            sessionId: `user_${match_res[1]}_repo_${match_res[2]}`,
+            lastActive,
+          };
       }
       return false;
     })

--- a/api/src/spawner-k8s.ts
+++ b/api/src/spawner-k8s.ts
@@ -285,3 +285,16 @@ export async function killRuntime(_, { sessionId }) {
   });
   return true;
 }
+
+/**
+ * Get the runtime info.
+ * @param sessionId the session ID
+ * @returns {startedAt} the time when the runtime is started.
+ */
+export async function infoRuntime(_, { sessionId }) {
+  // TODO implement
+  throw new Error("Not implemented");
+  return {
+    startedAt: null,
+  };
+}

--- a/api/src/typedefs.ts
+++ b/api/src/typedefs.ts
@@ -76,6 +76,13 @@ export const typeDefs = gql`
     children: [ID]
   }
 
+  type RuntimeInfo {
+    startedAt: String
+    lastActive: String
+    sessionId: String
+    ttl: Int
+  }
+
   type Query {
     hello: String
     users: [User]
@@ -85,8 +92,9 @@ export const typeDefs = gql`
     pod(id: ID!): Pod
     myRepos: [Repo]
     activeSessions: [String]
-    listAllRuntimes: [String]
+    listAllRuntimes: [RuntimeInfo]
     myCollabRepos: [Repo]
+    infoRuntime(sessionId: String!): RuntimeInfo
   }
 
   type Mutation {

--- a/ui/src/lib/runtime.tsx
+++ b/ui/src/lib/runtime.tsx
@@ -183,15 +183,7 @@ async function spawnRuntime({ client, sessionId }) {
     // https://lightrun.com/answers/apollographql-apollo-client-refetchqueries-not-working-when-using-string-array-after-mutation
     //
     // refetchQueries: ["listAllRuntimes"],
-    refetchQueries: [
-      {
-        query: gql`
-          query {
-            listAllRuntimes
-          }
-        `,
-      },
-    ],
+    refetchQueries: ["ListAllRuntimes", "GetRuntimeInfo"],
   });
   console.log("spawnRuntime res", res);
   if (res.errors) {

--- a/ui/src/lib/utils.tsx
+++ b/ui/src/lib/utils.tsx
@@ -21,3 +21,29 @@ export const getAuthHeaders = () => {
     authorization: `Bearer ${authToken}`,
   };
 };
+
+// pretty print the time difference
+export function prettyPrintTime(d) {
+  let year = d.getUTCFullYear() - 1970;
+  let month = d.getUTCMonth();
+  let day = d.getUTCDate() - 1;
+  let hour = d.getUTCHours();
+  let minute = d.getUTCMinutes();
+  let second = d.getUTCSeconds();
+  return (
+    (year > 0 ? year + "y" : "") +
+    (month > 0 ? month + "m" : "") +
+    (day > 0 ? day + "d" : "") +
+    (hour > 0 ? hour + "h" : "") +
+    (minute >= 0 ? minute + "m" : "") +
+    (second > 0 ? second + "s" : "")
+  );
+}
+
+export function getUpTime(startedAt: string) {
+  let d1 = new Date(parseInt(startedAt));
+  let now = new Date();
+  let diff = new Date(now.getTime() - d1.getTime());
+  let prettyTime = prettyPrintTime(diff);
+  return prettyTime;
+}


### PR DESCRIPTION
Add two timers for runtime:
- **last active time**: this is the last time a runtime session is **connected**. The runtime **will be terminated** 12h after the last active time. Opening the repo (and connecting the runtime) will refresh the last active record.
- **up time**: the is when the runtime is **started**

On the dashboard, show the runtime's **last active time** for each repo.

<img width="500" alt="Screenshot 2022-12-10 at 10 25 05 AM" src="https://user-images.githubusercontent.com/4576201/206869992-d8622afd-1f5f-42f4-ae07-b603528234af.png">

On the repo canvas page, the sidebar shows the **up time**.

<img width="350" alt="Screenshot 2022-12-10 at 10 27 59 AM" src="https://user-images.githubusercontent.com/4576201/206869997-542c3a53-1ba6-4f47-ab1e-d35053137ba4.png">
