### PR TITLE
Fix: multi-selection with the same-parent rule & drop multiple pods into a scope at once

### DIFF
--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -5,6 +5,8 @@ import { monaco } from "react-monaco-editor";
 import { useStore } from "zustand";
 import { RepoContext, RoleType } from "../lib/store";
 import { MonacoBinding } from "y-monaco";
+import { resetSelection } from "../lib/nodes";
+import { useReactFlow } from "reactflow";
 
 const theme: monaco.editor.IStandaloneThemeData = {
   base: "vs",
@@ -329,6 +331,8 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const wsRun = useStore(store, (state) => state.wsRun);
   const setPodFocus = useStore(store, (state) => state.setPodFocus);
   const setPodBlur = useStore(store, (state) => state.setPodBlur);
+  const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
+  const { setNodes } = useReactFlow();
 
   const value = getPod(id).content || "";
   let lang = getPod(id).lang || "javascript";
@@ -382,6 +386,9 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
     });
     editor.onDidFocusEditorText(() => {
       setPodFocus(id);
+
+      // FIXME: this is ugly, but useReactFlow.setNodes doesn't work to reset the selection
+      if (resetSelection()) nodesMap.set(id, nodesMap.get(id) as Node);
       setCurrentEditor(id);
     });
     editor.onDidContentSizeChange(updateHeight);

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -7,6 +7,16 @@ const isNodeAddChange = (change) => change.type === "add";
 const isNodeRemoveChange = (change) => change.type === "remove";
 const isNodeResetChange = (change) => change.type === "reset";
 
+const selectedPods = new Set();
+var parent: string | undefined = undefined;
+
+export function resetSelection() {
+  if (selectedPods.size === 0) return false;
+  selectedPods.clear();
+  parent = undefined;
+  return true;
+}
+
 export function useNodesStateSynced(nodeList) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
@@ -14,7 +24,6 @@ export function useNodesStateSynced(nodeList) {
   const getPod = useStore(store, (state) => state.getPod);
   const deletePod = useStore(store, (state) => state.deletePod);
   const updatePod = useStore(store, (state) => state.updatePod);
-  const setPodSelected = useStore(store, (state) => state.setPodSelected);
   const role = useStore(store, (state) => state.role);
   const ydoc = useStore(store, (state) => state.ydoc);
   const nodesMap = ydoc.getMap<Node>("pods");
@@ -22,6 +31,24 @@ export function useNodesStateSynced(nodeList) {
   const [nodes, setNodes] = useState(nodeList);
   // const setNodeId = useStore((state) => state.setSelectNode);
   // const selected = useStore((state) => state.selectNode);
+
+  function selectPod(id, selected) {
+    if (selected) {
+      const p = getPod(id)?.parent;
+
+      // if you select a node that has a different parent, clear all previous selections
+      if (parent !== undefined && parent !== p) {
+        selectedPods.clear();
+        setNodes((nds) => nds.map((n) => ({ ...n, selected: false })));
+      }
+      parent = p;
+      selectedPods.add(id);
+    } else {
+      if (!selectedPods.delete(id)) return;
+      if (selectedPods.size === 0) parent = undefined;
+    }
+    setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, selected } : n)));
+  }
 
   const onNodesChanges = useCallback((changes) => {
     const nodes = Array.from(nodesMap.values());
@@ -45,7 +72,8 @@ export function useNodesStateSynced(nodeList) {
         if (!node) return;
 
         if (isNodeResetChange(change) || change.type === "select") {
-          setPodSelected(node.id, change.selected as boolean);
+          console.log(change.type, change);
+          selectPod(node.id, change.selected);
           return;
         }
 
@@ -100,7 +128,7 @@ export function useNodesStateSynced(nodeList) {
       setNodes(
         Array.from(nodesMap.values())
           .sort((a: Node & { level }, b: Node & { level }) => a.level - b.level)
-          .map((node) => ({ ...node, selected: getPod(node.id)?.selected }))
+          .map((node) => ({ ...node, selected: selectedPods.has(node.id) }))
       );
 
       // setNodes(Array.from(nodesMap.values()));
@@ -111,6 +139,7 @@ export function useNodesStateSynced(nodeList) {
 
     return () => {
       nodesMap.unobserve(observer);
+      resetSelection();
     };
   }, []);
 

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -8,8 +8,11 @@ const isNodeRemoveChange = (change) => change.type === "remove";
 const isNodeResetChange = (change) => change.type === "reset";
 
 const selectedPods = new Set();
-var parent: string | undefined = undefined;
 
+// apply the same-parent rule, make sure all selected nodes have the same parent
+export var parent: string | undefined = undefined;
+
+// clear all selections
 export function resetSelection() {
   if (selectedPods.size === 0) return false;
   selectedPods.clear();
@@ -72,7 +75,6 @@ export function useNodesStateSynced(nodeList) {
         if (!node) return;
 
         if (isNodeResetChange(change) || change.type === "select") {
-          console.log(change.type, change);
           selectPod(node.id, change.selected);
           return;
         }

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -121,7 +121,6 @@ export type Pod = {
   ns?: string;
   running?: boolean;
   focus?: boolean;
-  selected?: boolean;
 };
 
 export interface RepoSlice {
@@ -193,7 +192,6 @@ export interface RepoSlice {
   setPodVisibility: (id: any, visible: any) => void;
   setPodFocus: (id: string) => void;
   setPodBlur: (id: string) => void;
-  setPodSelected: (id: string, target: boolean) => void;
 }
 
 type BearState = RepoSlice & RuntimeSlice;
@@ -278,7 +276,6 @@ const createRepoSlice: StateCreator<
       // the backend instead.
       children: [],
       io: {},
-      selected: false,
       focus: false,
       // from payload
       parent,
@@ -831,16 +828,6 @@ const createRepoSlice: StateCreator<
         }
       })
     ),
-  setPodSelected: (id: string, target: boolean) => {
-    set(
-      produce((state) => {
-        if (state.pods[id]) {
-          state.pods[id].selected = target;
-        }
-      })
-    );
-  },
-  getPodSelected: (id: string) => get().pods[id]?.selected as boolean,
 });
 
 export const createRepoStore = () =>

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -458,7 +458,7 @@ const createRepoSlice: StateCreator<
     set(
       produce((state) => {
         let pod = state.pods[id];
-        if (pod) {
+        if (pod && pod.name !== name) {
           pod.name = name;
           pod.dirty = true;
         }


### PR DESCRIPTION
1. Fix the multi-selection hotkey issue for Mac users: Mac users can press `meta` key to multi-select nodes as what `ctrl` does for other users
2. Highlight the border in a darker blue than focused when selected.  Un-selection logic is also fixed
3. Apply the "same-parent rule": when a user selects more than one node in either `ctrl` or `shift` way, it checks if all selected nodes are of the same parent, otherwise, it will be difficult to drag them into the same scope or delete/cut them together. If the rule is violated when a new node is selected, we **un-select all previously selected nodes** and select only the new one.
4. Multiple pods can be dragged into a scope at once when selected: when dragging more than one node and the target is a scope, all selected nodes are dropped into the scope.
5. Auto-bind node to parent scope: when dragging stop with the mouse in a target scope, even if the selected nodes are not completely inside the scope (or completely not inside the scope), they will be moved into it completely at once.

Known issues:

1. Auto-binding only works properly when the target scope is larger than all child nodes, or it may look strange.
2. If you multi-select pods in  `ctrl` way, please only press `ctrl` when selecting, release it right after the node is selected, or the last one will be dragged with all previously selected nodes regardless of the same-parent rule. This is an intrinsic bug in reactflow, the drag behavior is not totally controlled by selection. Don't abuse `ctrl`.
3. `pod[id].parent` can't be updated correctly or in time in collaboration mode: a user may drag a node into a scope and update everything as expected on their own side, but the collaborator users can only view the change on front-end side, `store.pods` on their side doesn't update. It may cause some issues when the collaborators delete involved scopes. It's not very hard to fix, use `data.parent` field to record their parent, and update with `useEffect` when it changes. Actually, **I propose this approach to update `store.pods` for almost every important fields of a pod to guarantee all users maintain the data up-to-date**. However, I don't have enough time to refactor such a big project. Left it to do when I am available.