### PR TITLE
Fix: sync store.pods[id].parent/position immediately on updates from anywhere

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -64,211 +64,220 @@ interface Props {
   id: string;
   isConnectable: boolean;
   selected: boolean;
+  xPos: number;
+  yPos: number;
 }
 
-const ScopeNode = memo<Props>(({ data, id, isConnectable, selected }) => {
-  // add resize to the node
-  const ref = useRef(null);
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const flow = useReactFlow();
-  const setPodName = useStore(store, (state) => state.setPodName);
-  const updatePod = useStore(store, (state) => state.updatePod);
-  const [target, setTarget] = React.useState<any>();
-  const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
-  const [frame] = React.useState({
-    translate: [0, 0],
-  });
-  // const selected = useStore(store, (state) => state.pods[id]?.selected);
-  const role = useStore(store, (state) => state.role);
-  const inputRef = useRef<HTMLInputElement>(null);
+const ScopeNode = memo<Props>(
+  ({ data, id, isConnectable, selected, xPos, yPos }) => {
+    // add resize to the node
+    const ref = useRef(null);
+    const store = useContext(RepoContext);
+    if (!store) throw new Error("Missing BearContext.Provider in the tree");
+    const flow = useReactFlow();
+    const setPodName = useStore(store, (state) => state.setPodName);
+    const updatePod = useStore(store, (state) => state.updatePod);
+    const [target, setTarget] = React.useState<any>();
+    const nodesMap = useStore(store, (state) =>
+      state.ydoc.getMap<Node>("pods")
+    );
+    const [frame] = React.useState({
+      translate: [0, 0],
+    });
+    // const selected = useStore(store, (state) => state.pods[id]?.selected);
+    const role = useStore(store, (state) => state.role);
+    const inputRef = useRef<HTMLInputElement>(null);
 
-  const deleteNodeById = useCallback(
-    (id: string) => {
-      flow.deleteElements({
-        nodes: [
-          {
-            id,
-          },
-        ],
-      });
-    },
-    [flow]
-  );
-
-  const onResize = useCallback(({ width, height, offx, offy }) => {
-    const node = nodesMap.get(id);
-    if (node) {
-      node.style = { ...node.style, width, height };
-      node.position.x += offx;
-      node.position.y += offy;
-      nodesMap.set(id, node);
-    }
-  }, []);
-
-  useEffect(() => {
-    setTarget(ref.current);
-  }, []);
-
-  useEffect(() => {
-    if (!data.name) return;
-    setPodName({ id, name: data.name || "" });
-    if (inputRef?.current) {
-      inputRef.current.value = data.name;
-    }
-  }, [data.name, id, setPodName]);
-
-  return (
-    <Box
-      ref={ref}
-      sx={{
-        width: "100%",
-        height: "100%",
-        border: "solid 1px #d6dee6",
-        borderRadius: "4px",
-      }}
-      className="custom-drag-handle"
-    >
-      <Box
-        sx={{
-          display: "flex",
-          marginLeft: "10px",
-          borderRadius: "4px",
-          position: "absolute",
-          border: "solid 1px #d6dee6",
-          right: "25px",
-          top: "-15px",
-          background: "white",
-          zIndex: 250,
-          justifyContent: "center",
-        }}
-      >
-        {role !== RoleType.GUEST && (
-          <Tooltip title="Delete">
-            <IconButton
-              size="small"
-              onClick={(e: any) => {
-                e.stopPropagation();
-                e.preventDefault();
-                deleteNodeById(id);
-              }}
-            >
-              <DeleteIcon fontSize="inherit" />
-            </IconButton>
-          </Tooltip>
-        )}
-      </Box>
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="top"
-        isConnectable={isConnectable}
-      />
-      {/* The header of scope nodes. */}
-      <Box
-        className="custom-drag-handle"
-        bgcolor={"rgb(225,225,225)"}
-        sx={{ display: "flex" }}
-      >
-        <Grid container spacing={2} sx={{ alignItems: "center" }}>
-          <Grid item xs={4}>
-            <IconButton size="small">
-              <CircleIcon sx={{ color: "red" }} fontSize="inherit" />
-            </IconButton>
-          </Grid>
-          <Grid item xs={4}>
-            <Box
-              sx={{
-                display: "flex",
-                flexGrow: 1,
-                justifyContent: "center",
-              }}
-            >
-              <InputBase
-                className="nodrag"
-                defaultValue={data.name || "Scope"}
-                onBlur={(e) => {
-                  const name = e.target.value;
-                  if (name === data.name) return;
-                  const node = nodesMap.get(id);
-                  if (node) {
-                    nodesMap.set(id, { ...node, data: { ...node.data, name } });
-                  }
-                  // setPodName({ id, name });
-                }}
-                inputRef={inputRef}
-                disabled={role === RoleType.GUEST}
-                inputProps={{
-                  style: {
-                    padding: "0px",
-                    textAlign: "center",
-                    textOverflow: "ellipsis",
-                  },
-                }}
-              ></InputBase>
-            </Box>
-          </Grid>
-          <Grid item xs={4}></Grid>
-        </Grid>
-      </Box>
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottom"
-        isConnectable={isConnectable}
-      />
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="left"
-        isConnectable={isConnectable}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="right"
-        isConnectable={isConnectable}
-      />
-      {selected && role !== RoleType.GUEST && (
-        <Moveable
-          target={target}
-          resizable={true}
-          keepRatio={false}
-          throttleResize={1}
-          renderDirections={["e", "s", "se"]}
-          edge={false}
-          zoom={1}
-          origin={false}
-          padding={{ left: 0, top: 0, right: 0, bottom: 0 }}
-          onResizeStart={(e) => {
-            e.setOrigin(["%", "%"]);
-            e.dragStart && e.dragStart.set(frame.translate);
-          }}
-          onResize={(e) => {
-            const beforeTranslate = e.drag.beforeTranslate;
-            frame.translate = beforeTranslate;
-            e.target.style.width = `${e.width}px`;
-            e.target.style.height = `${e.height}px`;
-            e.target.style.transform = `translate(${beforeTranslate[0]}px, ${beforeTranslate[1]}px)`;
-            onResize({
-              width: e.width,
-              height: e.height,
-              offx: beforeTranslate[0],
-              offy: beforeTranslate[1],
-            });
-            updatePod({
+    const deleteNodeById = useCallback(
+      (id: string) => {
+        flow.deleteElements({
+          nodes: [
+            {
               id,
-              data: {
+            },
+          ],
+        });
+      },
+      [flow]
+    );
+
+    const onResize = useCallback(({ width, height, offx, offy }) => {
+      const node = nodesMap.get(id);
+      if (node) {
+        node.style = { ...node.style, width, height };
+        node.position.x += offx;
+        node.position.y += offy;
+        nodesMap.set(id, node);
+      }
+    }, []);
+
+    useEffect(() => {
+      setTarget(ref.current);
+    }, []);
+
+    useEffect(() => {
+      if (!data.name) return;
+      setPodName({ id, name: data.name || "" });
+      if (inputRef?.current) {
+        inputRef.current.value = data.name;
+      }
+    }, [data.name, id, setPodName]);
+
+    return (
+      <Box
+        ref={ref}
+        sx={{
+          width: "100%",
+          height: "100%",
+          border: "solid 1px #d6dee6",
+          borderRadius: "4px",
+        }}
+        className="custom-drag-handle"
+      >
+        <Box
+          sx={{
+            display: "flex",
+            marginLeft: "10px",
+            borderRadius: "4px",
+            position: "absolute",
+            border: "solid 1px #d6dee6",
+            right: "25px",
+            top: "-15px",
+            background: "white",
+            zIndex: 250,
+            justifyContent: "center",
+          }}
+        >
+          {role !== RoleType.GUEST && (
+            <Tooltip title="Delete" className="nodrag">
+              <IconButton
+                size="small"
+                onClick={(e: any) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  deleteNodeById(id);
+                }}
+              >
+                <DeleteIcon fontSize="inherit" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Box>
+        <Handle
+          type="source"
+          position={Position.Top}
+          id="top"
+          isConnectable={isConnectable}
+        />
+        {/* The header of scope nodes. */}
+        <Box
+          className="custom-drag-handle"
+          bgcolor={"rgb(225,225,225)"}
+          sx={{ display: "flex" }}
+        >
+          <Grid container spacing={2} sx={{ alignItems: "center" }}>
+            <Grid item xs={4}>
+              <IconButton size="small">
+                <CircleIcon sx={{ color: "red" }} fontSize="inherit" />
+              </IconButton>
+            </Grid>
+            <Grid item xs={4}>
+              <Box
+                sx={{
+                  display: "flex",
+                  flexGrow: 1,
+                  justifyContent: "center",
+                }}
+              >
+                <InputBase
+                  className="nodrag"
+                  defaultValue={data.name || "Scope"}
+                  onBlur={(e) => {
+                    const name = e.target.value;
+                    if (name === data.name) return;
+                    const node = nodesMap.get(id);
+                    if (node) {
+                      nodesMap.set(id, {
+                        ...node,
+                        data: { ...node.data, name },
+                      });
+                    }
+                    // setPodName({ id, name });
+                  }}
+                  inputRef={inputRef}
+                  disabled={role === RoleType.GUEST}
+                  inputProps={{
+                    style: {
+                      padding: "0px",
+                      textAlign: "center",
+                      textOverflow: "ellipsis",
+                    },
+                  }}
+                ></InputBase>
+              </Box>
+            </Grid>
+            <Grid item xs={4}></Grid>
+          </Grid>
+        </Box>
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          id="bottom"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Left}
+          id="left"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="right"
+          isConnectable={isConnectable}
+        />
+        {selected && role !== RoleType.GUEST && (
+          <Moveable
+            target={target}
+            resizable={true}
+            keepRatio={false}
+            throttleResize={1}
+            renderDirections={["e", "s", "se"]}
+            edge={false}
+            zoom={1}
+            origin={false}
+            padding={{ left: 0, top: 0, right: 0, bottom: 0 }}
+            onResizeStart={(e) => {
+              e.setOrigin(["%", "%"]);
+              e.dragStart && e.dragStart.set(frame.translate);
+            }}
+            onResize={(e) => {
+              const beforeTranslate = e.drag.beforeTranslate;
+              frame.translate = beforeTranslate;
+              e.target.style.width = `${e.width}px`;
+              e.target.style.height = `${e.height}px`;
+              e.target.style.transform = `translate(${beforeTranslate[0]}px, ${beforeTranslate[1]}px)`;
+              onResize({
                 width: e.width,
                 height: e.height,
-              },
-            });
-          }}
-        />
-      )}
-    </Box>
-  );
-});
+                offx: beforeTranslate[0],
+                offy: beforeTranslate[1],
+              });
+              updatePod({
+                id,
+                data: {
+                  width: e.width,
+                  height: e.height,
+                },
+              });
+            }}
+          />
+        )}
+      </Box>
+    );
+  }
+);
 
 // FIXME: the resultblock is rendered every time the parent codeNode changes (e.g., dragging), we may set the result number as a state of a pod to memoize the resultblock.
 
@@ -398,245 +407,255 @@ function ResultBlock({ pod, id }) {
   );
 }
 
-const CodeNode = memo<Props>(({ data, id, isConnectable, selected }) => {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  // const pod = useStore(store, (state) => state.pods[id]);
-  const wsRun = useStore(store, (state) => state.wsRun);
-  const clearResults = useStore(store, (s) => s.clearResults);
-  const ref = useRef(null);
-  const [target, setTarget] = React.useState<any>(null);
-  const [frame] = React.useState({
-    translate: [0, 0],
-  });
-  // right, bottom
-  const [layout, setLayout] = useState("bottom");
-  const isRightLayout = layout === "right";
-  const { setNodes } = useReactFlow();
-  // const selected = useStore(store, (state) => state.selected);
-  const setPodName = useStore(store, (state) => state.setPodName);
-  const setCurrentEditor = useStore(store, (state) => state.setCurrentEditor);
-  const getPod = useStore(store, (state) => state.getPod);
-  const pod = getPod(id);
-  const role = useStore(store, (state) => state.role);
-  const width = useStore(store, (state) => state.pods[id]?.width);
-  const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
-  const index = useStore(
-    store,
-    (state) => state.pods[id]?.result?.count || " "
-  );
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const showResult = useStore(
-    store,
-    (state) =>
-      state.pods[id]?.running ||
-      state.pods[id]?.result ||
-      state.pods[id]?.error ||
-      state.pods[id]?.stdout ||
-      state.pods[id]?.stderr
-  );
-  const onResize = useCallback((e, data) => {
-    const { size } = data;
-    const node = nodesMap.get(id);
-    if (node) {
-      node.style = { ...node.style, width: size.width };
-      nodesMap.set(id, node);
-    }
-  }, []);
-  const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
-  const apolloClient = useApolloClient();
-  const deletePod = useStore(store, (state) => state.deletePod);
-  const deleteNodeById = (id) => {
-    deletePod(apolloClient, { id: id, toDelete: [] });
-    nodesMap.delete(id);
-  };
-
-  useEffect(() => {
-    setTarget(ref.current);
-  }, []);
-
-  useEffect(() => {
-    if (!data.name) return;
-    setPodName({ id, name: data.name });
-    if (inputRef?.current) {
-      inputRef.current.value = data.name || "";
-    }
-  }, [data.name, setPodName, id]);
-
-  if (!pod) return null;
-
-  // onsize is banned for a guest, FIXME: ugly code
-  const Wrap = (child) =>
-    role === RoleType.GUEST ? (
-      <>{child}</>
-    ) : (
-      <ResizableBox
-        onResizeStop={onResize}
-        height={pod.height || 100}
-        width={width}
-        axis={"x"}
-        minConstraints={[200, 200]}
-      >
-        {child}
-      </ResizableBox>
+const CodeNode = memo<Props>(
+  ({ data, id, isConnectable, selected, xPos, yPos }) => {
+    const store = useContext(RepoContext);
+    if (!store) throw new Error("Missing BearContext.Provider in the tree");
+    // const pod = useStore(store, (state) => state.pods[id]);
+    const wsRun = useStore(store, (state) => state.wsRun);
+    const clearResults = useStore(store, (s) => s.clearResults);
+    const ref = useRef(null);
+    const [target, setTarget] = React.useState<any>(null);
+    const [frame] = React.useState({
+      translate: [0, 0],
+    });
+    // right, bottom
+    const [layout, setLayout] = useState("bottom");
+    const isRightLayout = layout === "right";
+    const { setNodes } = useReactFlow();
+    // const selected = useStore(store, (state) => state.selected);
+    const setPodName = useStore(store, (state) => state.setPodName);
+    const setCurrentEditor = useStore(store, (state) => state.setCurrentEditor);
+    const getPod = useStore(store, (state) => state.getPod);
+    const pod = getPod(id);
+    const role = useStore(store, (state) => state.role);
+    const width = useStore(store, (state) => state.pods[id]?.width);
+    const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
+    const index = useStore(
+      store,
+      (state) => state.pods[id]?.result?.count || " "
     );
+    const inputRef = useRef<HTMLInputElement>(null);
 
-  return Wrap(
-    <Box
-      sx={{
-        border: "solid 1px #d6dee6",
-        borderWidth: pod.ispublic ? "4px" : "2px",
-        borderRadius: "4px",
-        width: "100%",
-        height: "100%",
-        backgroundColor: "rgb(244, 246, 248)",
-        borderColor: pod.ispublic
-          ? "green"
-          : selected
-          ? "#003c8f"
-          : !isPodFocused
-          ? "#d6dee6"
-          : "#5e92f3",
-      }}
-    >
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="top"
-        isConnectable={isConnectable}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottom"
-        isConnectable={isConnectable}
-      />
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="left"
-        isConnectable={isConnectable}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="right"
-        isConnectable={isConnectable}
-      />
-      {/* The header of code pods. */}
-      <Box className="custom-drag-handle">
-        <Box
-          sx={{
-            position: "absolute",
-            top: "-24px",
-            width: "50%",
-          }}
+    const showResult = useStore(
+      store,
+      (state) =>
+        state.pods[id]?.running ||
+        state.pods[id]?.result ||
+        state.pods[id]?.error ||
+        state.pods[id]?.stdout ||
+        state.pods[id]?.stderr
+    );
+    const onResize = useCallback((e, data) => {
+      const { size } = data;
+      const node = nodesMap.get(id);
+      if (node) {
+        node.style = { ...node.style, width: size.width };
+        nodesMap.set(id, node);
+      }
+    }, []);
+    const nodesMap = useStore(store, (state) =>
+      state.ydoc.getMap<Node>("pods")
+    );
+    const apolloClient = useApolloClient();
+    const deletePod = useStore(store, (state) => state.deletePod);
+    const deleteNodeById = (id) => {
+      deletePod(apolloClient, { id: id, toDelete: [] });
+      nodesMap.delete(id);
+    };
+
+    useEffect(() => {
+      setTarget(ref.current);
+    }, []);
+
+    useEffect(() => {
+      if (!data.name) return;
+      setPodName({ id, name: data.name });
+      if (inputRef?.current) {
+        inputRef.current.value = data.name || "";
+      }
+    }, [data.name, setPodName, id]);
+
+    useEffect(() => {
+      console.log("position", xPos, yPos);
+      console.log(nodesMap.get(id));
+    }, [xPos, yPos]);
+
+    if (!pod) return null;
+
+    // onsize is banned for a guest, FIXME: ugly code
+    const Wrap = (child) =>
+      role === RoleType.GUEST ? (
+        <>{child}</>
+      ) : (
+        <ResizableBox
+          onResizeStop={onResize}
+          height={pod.height || 100}
+          width={width}
+          axis={"x"}
+          minConstraints={[200, 200]}
         >
-          <InputBase
-            inputRef={inputRef}
-            className="nodrag"
-            defaultValue={data.name || ""}
-            disabled={role === RoleType.GUEST}
-            onBlur={(e) => {
-              const name = e.target.value;
-              if (name === data.name) return;
-              const node = nodesMap.get(id);
-              if (node) {
-                nodesMap.set(id, { ...node, data: { ...node.data, name } });
-              }
-            }}
-            inputProps={{
-              style: {
-                padding: "0px",
-                textOverflow: "ellipsis",
-              },
-            }}
-          ></InputBase>
-        </Box>
-        <Box sx={styles["pod-index"]}>[{index}]</Box>
-        <Box
-          sx={{
-            display: "flex",
-            marginLeft: "10px",
-            borderRadius: "4px",
-            position: "absolute",
-            border: "solid 1px #d6dee6",
-            right: "25px",
-            top: "-15px",
-            background: "white",
-            zIndex: 250,
-            justifyContent: "center",
-          }}
-        >
-          {role !== RoleType.GUEST && (
-            <Tooltip title="Run (shift-enter)">
-              <IconButton
-                size="small"
-                onClick={() => {
-                  clearResults(id);
-                  wsRun(id);
-                }}
-              >
-                <PlayCircleOutlineIcon fontSize="inherit" />
-              </IconButton>
-            </Tooltip>
-          )}
-          {role !== RoleType.GUEST && (
-            <Tooltip title="Delete">
-              <IconButton
-                size="small"
-                onClick={() => {
-                  deleteNodeById(id);
-                }}
-              >
-                <DeleteIcon fontSize="inherit" />
-              </IconButton>
-            </Tooltip>
-          )}
-          <Tooltip title="Change layout">
-            <IconButton
-              size="small"
-              onClick={() => {
-                setLayout(layout === "bottom" ? "right" : "bottom");
-              }}
-            >
-              <ViewComfyIcon fontSize="inherit" />
-            </IconButton>
-          </Tooltip>
-        </Box>
-      </Box>
+          {child}
+        </ResizableBox>
+      );
+
+    return Wrap(
       <Box
         sx={{
-          height: "90%",
+          border: "solid 1px #d6dee6",
+          borderWidth: pod.ispublic ? "4px" : "2px",
+          borderRadius: "4px",
+          width: "100%",
+          height: "100%",
+          backgroundColor: "rgb(244, 246, 248)",
+          borderColor: pod.ispublic
+            ? "green"
+            : selected
+            ? "#003c8f"
+            : !isPodFocused
+            ? "#d6dee6"
+            : "#5e92f3",
         }}
       >
-        <MyMonaco id={id} gitvalue="" />
-        {showResult && (
+        <Handle
+          type="source"
+          position={Position.Top}
+          id="top"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          id="bottom"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Left}
+          id="left"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="right"
+          isConnectable={isConnectable}
+        />
+        {/* The header of code pods. */}
+        <Box className="custom-drag-handle">
           <Box
-            className="nowheel"
             sx={{
-              border: "solid 1px #d6dee6",
-              borderRadius: "4px",
               position: "absolute",
-              top: isRightLayout ? 0 : "100%",
-              left: isRightLayout ? "100%" : 0,
-              maxHeight: "160px",
-              maxWidth: isRightLayout ? "300px" : "100%",
-              minWidth: isRightLayout ? "150px" : "100%",
-              boxSizing: "border-box",
-              backgroundColor: "white",
-              zIndex: 100,
-              padding: "0 10px",
+              top: "-24px",
+              width: "50%",
             }}
           >
-            <ResultBlock pod={pod} id={id} />
+            <InputBase
+              inputRef={inputRef}
+              className="nodrag"
+              defaultValue={data.name || ""}
+              disabled={role === RoleType.GUEST}
+              onBlur={(e) => {
+                const name = e.target.value;
+                if (name === data.name) return;
+                const node = nodesMap.get(id);
+                if (node) {
+                  nodesMap.set(id, { ...node, data: { ...node.data, name } });
+                }
+              }}
+              inputProps={{
+                style: {
+                  padding: "0px",
+                  textOverflow: "ellipsis",
+                },
+              }}
+            ></InputBase>
           </Box>
-        )}
+          <Box sx={styles["pod-index"]}>[{index}]</Box>
+          <Box
+            sx={{
+              display: "flex",
+              marginLeft: "10px",
+              borderRadius: "4px",
+              position: "absolute",
+              border: "solid 1px #d6dee6",
+              right: "25px",
+              top: "-15px",
+              background: "white",
+              zIndex: 250,
+              justifyContent: "center",
+            }}
+            className="nodrag"
+          >
+            {role !== RoleType.GUEST && (
+              <Tooltip title="Run (shift-enter)">
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    clearResults(id);
+                    wsRun(id);
+                  }}
+                >
+                  <PlayCircleOutlineIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+            )}
+            {role !== RoleType.GUEST && (
+              <Tooltip title="Delete">
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    deleteNodeById(id);
+                  }}
+                >
+                  <DeleteIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+            )}
+            <Tooltip title="Change layout">
+              <IconButton
+                size="small"
+                onClick={() => {
+                  setLayout(layout === "bottom" ? "right" : "bottom");
+                }}
+              >
+                <ViewComfyIcon fontSize="inherit" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+        <Box
+          sx={{
+            height: "90%",
+          }}
+        >
+          <MyMonaco id={id} gitvalue="" />
+          {showResult && (
+            <Box
+              className="nowheel"
+              sx={{
+                border: "solid 1px #d6dee6",
+                borderRadius: "4px",
+                position: "absolute",
+                top: isRightLayout ? 0 : "100%",
+                left: isRightLayout ? "100%" : 0,
+                maxHeight: "160px",
+                maxWidth: isRightLayout ? "300px" : "100%",
+                minWidth: isRightLayout ? "150px" : "100%",
+                boxSizing: "border-box",
+                backgroundColor: "white",
+                zIndex: 100,
+                padding: "0 10px",
+              }}
+            >
+              <ResultBlock pod={pod} id={id} />
+            </Box>
+          )}
+        </Box>
       </Box>
-    </Box>
-  );
-});
+    );
+  }
+);
 
 const nodeTypes = { scope: ScopeNode, code: CodeNode };
 

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -69,238 +69,241 @@ interface Props {
   yPos: number;
 }
 
-const ScopeNode = memo<Props>(
-  ({ data, id, isConnectable, selected, xPos, yPos }) => {
-    // add resize to the node
-    const ref = useRef(null);
-    const store = useContext(RepoContext);
-    if (!store) throw new Error("Missing BearContext.Provider in the tree");
-    const flow = useReactFlow();
-    const setPodName = useStore(store, (state) => state.setPodName);
-    const updatePod = useStore(store, (state) => state.updatePod);
-    const setPodPosition = useStore(store, (state) => state.setPodPosition);
-    const setPodParent = useStore(store, (state) => state.setPodParent);
-    const [target, setTarget] = React.useState<any>();
-    const nodesMap = useStore(store, (state) =>
-      state.ydoc.getMap<Node>("pods")
-    );
-    const [frame] = React.useState({
-      translate: [0, 0],
-    });
-    // const selected = useStore(store, (state) => state.pods[id]?.selected);
-    const role = useStore(store, (state) => state.role);
-    const inputRef = useRef<HTMLInputElement>(null);
+const ScopeNode = memo<Props>(function ScopeNode({
+  data,
+  id,
+  isConnectable,
+  selected,
+  xPos,
+  yPos,
+}) {
+  // add resize to the node
+  const ref = useRef(null);
+  const store = useContext(RepoContext);
+  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const flow = useReactFlow();
+  const setPodName = useStore(store, (state) => state.setPodName);
+  const updatePod = useStore(store, (state) => state.updatePod);
+  const setPodPosition = useStore(store, (state) => state.setPodPosition);
+  const setPodParent = useStore(store, (state) => state.setPodParent);
+  const [target, setTarget] = React.useState<any>();
+  const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
+  const [frame] = React.useState({
+    translate: [0, 0],
+  });
+  // const selected = useStore(store, (state) => state.pods[id]?.selected);
+  const role = useStore(store, (state) => state.role);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-    const deleteNodeById = useCallback(
-      (id: string) => {
-        flow.deleteElements({
-          nodes: [
-            {
-              id,
-            },
-          ],
-        });
-      },
-      [flow]
-    );
+  const deleteNodeById = useCallback(
+    (id: string) => {
+      flow.deleteElements({
+        nodes: [
+          {
+            id,
+          },
+        ],
+      });
+    },
+    [flow]
+  );
 
-    const onResize = useCallback(({ width, height, offx, offy }) => {
-      const node = nodesMap.get(id);
-      if (node) {
-        node.style = { ...node.style, width, height };
-        node.position.x += offx;
-        node.position.y += offy;
-        nodesMap.set(id, node);
-      }
-    }, []);
+  const onResize = useCallback(({ width, height, offx, offy }) => {
+    const node = nodesMap.get(id);
+    if (node) {
+      node.style = { ...node.style, width, height };
+      node.position.x += offx;
+      node.position.y += offy;
+      nodesMap.set(id, node);
+    }
+  }, []);
 
-    useEffect(() => {
-      setTarget(ref.current);
-    }, []);
+  useEffect(() => {
+    setTarget(ref.current);
+  }, []);
 
-    useEffect(() => {
-      if (!data.name) return;
-      setPodName({ id, name: data.name || "" });
-      if (inputRef?.current) {
-        inputRef.current.value = data.name;
-      }
-    }, [data.name, id, setPodName]);
+  useEffect(() => {
+    if (!data.name) return;
+    setPodName({ id, name: data.name || "" });
+    if (inputRef?.current) {
+      inputRef.current.value = data.name;
+    }
+  }, [data.name, id, setPodName]);
 
-    useEffect(() => {
-      // get relative position
-      const node = nodesMap.get(id);
-      if (node?.position) {
-        // update pods[id].position but don't trigger DB update (dirty: false)
-        setPodPosition({
-          id,
-          x: node.position.x,
-          y: node.position.y,
-          dirty: false,
-        });
-      }
-    }, [xPos, yPos, setPodPosition, id]);
+  useEffect(() => {
+    // get relative position
+    const node = nodesMap.get(id);
+    if (node?.position) {
+      // update pods[id].position but don't trigger DB update (dirty: false)
+      setPodPosition({
+        id,
+        x: node.position.x,
+        y: node.position.y,
+        dirty: false,
+      });
+    }
+  }, [xPos, yPos, setPodPosition, id]);
 
-    useEffect(() => {
-      if (data.parent && data.parent !== "ROOT") {
-        setPodParent({ id, parent: data.parent, dirty: false });
-      }
-    }, [data.parent, setPodParent, id]);
+  useEffect(() => {
+    if (data.parent && data.parent !== "ROOT") {
+      setPodParent({ id, parent: data.parent, dirty: false });
+    }
+  }, [data.parent, setPodParent, id]);
 
-    return (
+  return (
+    <Box
+      ref={ref}
+      sx={{
+        width: "100%",
+        height: "100%",
+        border: "solid 1px #d6dee6",
+        borderRadius: "4px",
+      }}
+      className="custom-drag-handle"
+    >
       <Box
-        ref={ref}
         sx={{
-          width: "100%",
-          height: "100%",
-          border: "solid 1px #d6dee6",
+          display: "flex",
+          marginLeft: "10px",
           borderRadius: "4px",
+          position: "absolute",
+          border: "solid 1px #d6dee6",
+          right: "25px",
+          top: "-15px",
+          background: "white",
+          zIndex: 250,
+          justifyContent: "center",
         }}
-        className="custom-drag-handle"
       >
-        <Box
-          sx={{
-            display: "flex",
-            marginLeft: "10px",
-            borderRadius: "4px",
-            position: "absolute",
-            border: "solid 1px #d6dee6",
-            right: "25px",
-            top: "-15px",
-            background: "white",
-            zIndex: 250,
-            justifyContent: "center",
-          }}
-        >
-          {role !== RoleType.GUEST && (
-            <Tooltip title="Delete" className="nodrag">
-              <IconButton
-                size="small"
-                onClick={(e: any) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  deleteNodeById(id);
-                }}
-              >
-                <DeleteIcon fontSize="inherit" />
-              </IconButton>
-            </Tooltip>
-          )}
-        </Box>
-        <Handle
-          type="source"
-          position={Position.Top}
-          id="top"
-          isConnectable={isConnectable}
-        />
-        {/* The header of scope nodes. */}
-        <Box
-          className="custom-drag-handle"
-          bgcolor={"rgb(225,225,225)"}
-          sx={{ display: "flex" }}
-        >
-          <Grid container spacing={2} sx={{ alignItems: "center" }}>
-            <Grid item xs={4}>
-              <IconButton size="small">
-                <CircleIcon sx={{ color: "red" }} fontSize="inherit" />
-              </IconButton>
-            </Grid>
-            <Grid item xs={4}>
-              <Box
-                sx={{
-                  display: "flex",
-                  flexGrow: 1,
-                  justifyContent: "center",
-                }}
-              >
-                <InputBase
-                  className="nodrag"
-                  defaultValue={data.name || "Scope"}
-                  onBlur={(e) => {
-                    const name = e.target.value;
-                    if (name === data.name) return;
-                    const node = nodesMap.get(id);
-                    if (node) {
-                      nodesMap.set(id, {
-                        ...node,
-                        data: { ...node.data, name },
-                      });
-                    }
-                    // setPodName({ id, name });
-                  }}
-                  inputRef={inputRef}
-                  disabled={role === RoleType.GUEST}
-                  inputProps={{
-                    style: {
-                      padding: "0px",
-                      textAlign: "center",
-                      textOverflow: "ellipsis",
-                    },
-                  }}
-                ></InputBase>
-              </Box>
-            </Grid>
-            <Grid item xs={4}></Grid>
-          </Grid>
-        </Box>
-        <Handle
-          type="source"
-          position={Position.Bottom}
-          id="bottom"
-          isConnectable={isConnectable}
-        />
-        <Handle
-          type="source"
-          position={Position.Left}
-          id="left"
-          isConnectable={isConnectable}
-        />
-        <Handle
-          type="source"
-          position={Position.Right}
-          id="right"
-          isConnectable={isConnectable}
-        />
-        {selected && role !== RoleType.GUEST && (
-          <Moveable
-            target={target}
-            resizable={true}
-            keepRatio={false}
-            throttleResize={1}
-            renderDirections={["e", "s", "se"]}
-            edge={false}
-            zoom={1}
-            origin={false}
-            padding={{ left: 0, top: 0, right: 0, bottom: 0 }}
-            onResizeStart={(e) => {
-              e.setOrigin(["%", "%"]);
-              e.dragStart && e.dragStart.set(frame.translate);
-            }}
-            onResize={(e) => {
-              const beforeTranslate = e.drag.beforeTranslate;
-              frame.translate = beforeTranslate;
-              e.target.style.width = `${e.width}px`;
-              e.target.style.height = `${e.height}px`;
-              e.target.style.transform = `translate(${beforeTranslate[0]}px, ${beforeTranslate[1]}px)`;
-              onResize({
-                width: e.width,
-                height: e.height,
-                offx: beforeTranslate[0],
-                offy: beforeTranslate[1],
-              });
-              updatePod({
-                id,
-                data: {
-                  width: e.width,
-                  height: e.height,
-                },
-              });
-            }}
-          />
+        {role !== RoleType.GUEST && (
+          <Tooltip title="Delete" className="nodrag">
+            <IconButton
+              size="small"
+              onClick={(e: any) => {
+                e.stopPropagation();
+                e.preventDefault();
+                deleteNodeById(id);
+              }}
+            >
+              <DeleteIcon fontSize="inherit" />
+            </IconButton>
+          </Tooltip>
         )}
       </Box>
-    );
-  }
-);
+      <Handle
+        type="source"
+        position={Position.Top}
+        id="top"
+        isConnectable={isConnectable}
+      />
+      {/* The header of scope nodes. */}
+      <Box
+        className="custom-drag-handle"
+        bgcolor={"rgb(225,225,225)"}
+        sx={{ display: "flex" }}
+      >
+        <Grid container spacing={2} sx={{ alignItems: "center" }}>
+          <Grid item xs={4}>
+            <IconButton size="small">
+              <CircleIcon sx={{ color: "red" }} fontSize="inherit" />
+            </IconButton>
+          </Grid>
+          <Grid item xs={4}>
+            <Box
+              sx={{
+                display: "flex",
+                flexGrow: 1,
+                justifyContent: "center",
+              }}
+            >
+              <InputBase
+                className="nodrag"
+                defaultValue={data.name || "Scope"}
+                onBlur={(e) => {
+                  const name = e.target.value;
+                  if (name === data.name) return;
+                  const node = nodesMap.get(id);
+                  if (node) {
+                    nodesMap.set(id, {
+                      ...node,
+                      data: { ...node.data, name },
+                    });
+                  }
+                  // setPodName({ id, name });
+                }}
+                inputRef={inputRef}
+                disabled={role === RoleType.GUEST}
+                inputProps={{
+                  style: {
+                    padding: "0px",
+                    textAlign: "center",
+                    textOverflow: "ellipsis",
+                  },
+                }}
+              ></InputBase>
+            </Box>
+          </Grid>
+          <Grid item xs={4}></Grid>
+        </Grid>
+      </Box>
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="bottom"
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        position={Position.Left}
+        id="left"
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="right"
+        isConnectable={isConnectable}
+      />
+      {selected && role !== RoleType.GUEST && (
+        <Moveable
+          target={target}
+          resizable={true}
+          keepRatio={false}
+          throttleResize={1}
+          renderDirections={["e", "s", "se"]}
+          edge={false}
+          zoom={1}
+          origin={false}
+          padding={{ left: 0, top: 0, right: 0, bottom: 0 }}
+          onResizeStart={(e) => {
+            e.setOrigin(["%", "%"]);
+            e.dragStart && e.dragStart.set(frame.translate);
+          }}
+          onResize={(e) => {
+            const beforeTranslate = e.drag.beforeTranslate;
+            frame.translate = beforeTranslate;
+            e.target.style.width = `${e.width}px`;
+            e.target.style.height = `${e.height}px`;
+            e.target.style.transform = `translate(${beforeTranslate[0]}px, ${beforeTranslate[1]}px)`;
+            onResize({
+              width: e.width,
+              height: e.height,
+              offx: beforeTranslate[0],
+              offy: beforeTranslate[1],
+            });
+            updatePod({
+              id,
+              data: {
+                width: e.width,
+                height: e.height,
+              },
+            });
+          }}
+        />
+      )}
+    </Box>
+  );
+});
 
 // FIXME: the resultblock is rendered every time the parent codeNode changes (e.g., dragging), we may set the result number as a state of a pod to memoize the resultblock.
 
@@ -430,270 +433,273 @@ function ResultBlock({ pod, id }) {
   );
 }
 
-const CodeNode = memo<Props>(
-  ({ data, id, isConnectable, selected, xPos, yPos }) => {
-    const store = useContext(RepoContext);
-    if (!store) throw new Error("Missing BearContext.Provider in the tree");
-    // const pod = useStore(store, (state) => state.pods[id]);
-    const wsRun = useStore(store, (state) => state.wsRun);
-    const clearResults = useStore(store, (s) => s.clearResults);
-    const ref = useRef(null);
-    const [target, setTarget] = React.useState<any>(null);
-    const [frame] = React.useState({
-      translate: [0, 0],
-    });
-    // right, bottom
-    const [layout, setLayout] = useState("bottom");
-    const isRightLayout = layout === "right";
-    const setPodName = useStore(store, (state) => state.setPodName);
-    const setPodPosition = useStore(store, (state) => state.setPodPosition);
-    const setCurrentEditor = useStore(store, (state) => state.setCurrentEditor);
-    const setPodParent = useStore(store, (state) => state.setPodParent);
-    const getPod = useStore(store, (state) => state.getPod);
-    const pod = getPod(id);
-    const role = useStore(store, (state) => state.role);
-    const width = useStore(store, (state) => state.pods[id]?.width);
-    const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
-    const index = useStore(
-      store,
-      (state) => state.pods[id]?.result?.count || " "
-    );
-    const inputRef = useRef<HTMLInputElement>(null);
+const CodeNode = memo<Props>(function ({
+  data,
+  id,
+  isConnectable,
+  selected,
+  xPos,
+  yPos,
+}) {
+  const store = useContext(RepoContext);
+  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  // const pod = useStore(store, (state) => state.pods[id]);
+  const wsRun = useStore(store, (state) => state.wsRun);
+  const clearResults = useStore(store, (s) => s.clearResults);
+  const ref = useRef(null);
+  const [target, setTarget] = React.useState<any>(null);
+  const [frame] = React.useState({
+    translate: [0, 0],
+  });
+  // right, bottom
+  const [layout, setLayout] = useState("bottom");
+  const isRightLayout = layout === "right";
+  const setPodName = useStore(store, (state) => state.setPodName);
+  const setPodPosition = useStore(store, (state) => state.setPodPosition);
+  const setCurrentEditor = useStore(store, (state) => state.setCurrentEditor);
+  const setPodParent = useStore(store, (state) => state.setPodParent);
+  const getPod = useStore(store, (state) => state.getPod);
+  const pod = getPod(id);
+  const role = useStore(store, (state) => state.role);
+  const width = useStore(store, (state) => state.pods[id]?.width);
+  const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
+  const index = useStore(
+    store,
+    (state) => state.pods[id]?.result?.count || " "
+  );
+  const inputRef = useRef<HTMLInputElement>(null);
 
-    const showResult = useStore(
-      store,
-      (state) =>
-        state.pods[id]?.running ||
-        state.pods[id]?.result ||
-        state.pods[id]?.error ||
-        state.pods[id]?.stdout ||
-        state.pods[id]?.stderr
-    );
-    const onResize = useCallback((e, data) => {
-      const { size } = data;
-      const node = nodesMap.get(id);
-      if (node) {
-        node.style = { ...node.style, width: size.width };
-        nodesMap.set(id, node);
-      }
-    }, []);
-    const nodesMap = useStore(store, (state) =>
-      state.ydoc.getMap<Node>("pods")
-    );
-    const apolloClient = useApolloClient();
-    const deletePod = useStore(store, (state) => state.deletePod);
-    const deleteNodeById = (id) => {
-      deletePod(apolloClient, { id: id, toDelete: [] });
-      nodesMap.delete(id);
-    };
+  const showResult = useStore(
+    store,
+    (state) =>
+      state.pods[id]?.running ||
+      state.pods[id]?.result ||
+      state.pods[id]?.error ||
+      state.pods[id]?.stdout ||
+      state.pods[id]?.stderr
+  );
+  const onResize = useCallback((e, data) => {
+    const { size } = data;
+    const node = nodesMap.get(id);
+    if (node) {
+      node.style = { ...node.style, width: size.width };
+      nodesMap.set(id, node);
+    }
+  }, []);
+  const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
+  const apolloClient = useApolloClient();
+  const deletePod = useStore(store, (state) => state.deletePod);
+  const deleteNodeById = (id) => {
+    deletePod(apolloClient, { id: id, toDelete: [] });
+    nodesMap.delete(id);
+  };
 
-    useEffect(() => {
-      setTarget(ref.current);
-    }, []);
+  useEffect(() => {
+    setTarget(ref.current);
+  }, []);
 
-    useEffect(() => {
-      if (!data.name) return;
-      setPodName({ id, name: data.name });
-      if (inputRef?.current) {
-        inputRef.current.value = data.name || "";
-      }
-    }, [data.name, setPodName, id]);
+  useEffect(() => {
+    if (!data.name) return;
+    setPodName({ id, name: data.name });
+    if (inputRef?.current) {
+      inputRef.current.value = data.name || "";
+    }
+  }, [data.name, setPodName, id]);
 
-    useEffect(() => {
-      // get relative position
-      const node = nodesMap.get(id);
-      if (node?.position) {
-        // update pods[id].position but don't trigger DB update (dirty: false)
-        setPodPosition({
-          id,
-          x: node.position.x,
-          y: node.position.y,
-          dirty: false,
-        });
-      }
-    }, [xPos, yPos, setPodPosition, id]);
+  useEffect(() => {
+    // get relative position
+    const node = nodesMap.get(id);
+    if (node?.position) {
+      // update pods[id].position but don't trigger DB update (dirty: false)
+      setPodPosition({
+        id,
+        x: node.position.x,
+        y: node.position.y,
+        dirty: false,
+      });
+    }
+  }, [xPos, yPos, setPodPosition, id]);
 
-    useEffect(() => {
-      if (data.parent !== undefined) {
-        setPodParent({ id, parent: data.parent, dirty: false });
-      }
-    }, [data.parent, setPodParent, id]);
+  useEffect(() => {
+    if (data.parent !== undefined) {
+      setPodParent({ id, parent: data.parent, dirty: false });
+    }
+  }, [data.parent, setPodParent, id]);
 
-    if (!pod) return null;
+  if (!pod) return null;
 
-    // onsize is banned for a guest, FIXME: ugly code
-    const Wrap = (child) =>
-      role === RoleType.GUEST ? (
-        <>{child}</>
-      ) : (
-        <ResizableBox
-          onResizeStop={onResize}
-          height={pod.height || 100}
-          width={width}
-          axis={"x"}
-          minConstraints={[200, 200]}
-        >
-          {child}
-        </ResizableBox>
-      );
-
-    return Wrap(
-      <Box
-        sx={{
-          border: "solid 1px #d6dee6",
-          borderWidth: pod.ispublic ? "4px" : "2px",
-          borderRadius: "4px",
-          width: "100%",
-          height: "100%",
-          backgroundColor: "rgb(244, 246, 248)",
-          borderColor: pod.ispublic
-            ? "green"
-            : selected
-            ? "#003c8f"
-            : !isPodFocused
-            ? "#d6dee6"
-            : "#5e92f3",
-        }}
+  // onsize is banned for a guest, FIXME: ugly code
+  const Wrap = (child) =>
+    role === RoleType.GUEST ? (
+      <>{child}</>
+    ) : (
+      <ResizableBox
+        onResizeStop={onResize}
+        height={pod.height || 100}
+        width={width}
+        axis={"x"}
+        minConstraints={[200, 200]}
       >
-        <Handle
-          type="source"
-          position={Position.Top}
-          id="top"
-          isConnectable={isConnectable}
-        />
-        <Handle
-          type="source"
-          position={Position.Bottom}
-          id="bottom"
-          isConnectable={isConnectable}
-        />
-        <Handle
-          type="source"
-          position={Position.Left}
-          id="left"
-          isConnectable={isConnectable}
-        />
-        <Handle
-          type="source"
-          position={Position.Right}
-          id="right"
-          isConnectable={isConnectable}
-        />
-        {/* The header of code pods. */}
-        <Box className="custom-drag-handle">
-          <Box
-            sx={{
-              position: "absolute",
-              top: "-24px",
-              width: "50%",
-            }}
-          >
-            <InputBase
-              inputRef={inputRef}
-              className="nodrag"
-              defaultValue={data.name || ""}
-              disabled={role === RoleType.GUEST}
-              onBlur={(e) => {
-                const name = e.target.value;
-                if (name === data.name) return;
-                const node = nodesMap.get(id);
-                if (node) {
-                  nodesMap.set(id, { ...node, data: { ...node.data, name } });
-                }
-              }}
-              inputProps={{
-                style: {
-                  padding: "0px",
-                  textOverflow: "ellipsis",
-                },
-              }}
-            ></InputBase>
-          </Box>
-          <Box sx={styles["pod-index"]}>[{index}]</Box>
-          <Box
-            sx={{
-              display: "flex",
-              marginLeft: "10px",
-              borderRadius: "4px",
-              position: "absolute",
-              border: "solid 1px #d6dee6",
-              right: "25px",
-              top: "-15px",
-              background: "white",
-              zIndex: 250,
-              justifyContent: "center",
-            }}
+        {child}
+      </ResizableBox>
+    );
+
+  return Wrap(
+    <Box
+      sx={{
+        border: "solid 1px #d6dee6",
+        borderWidth: pod.ispublic ? "4px" : "2px",
+        borderRadius: "4px",
+        width: "100%",
+        height: "100%",
+        backgroundColor: "rgb(244, 246, 248)",
+        borderColor: pod.ispublic
+          ? "green"
+          : selected
+          ? "#003c8f"
+          : !isPodFocused
+          ? "#d6dee6"
+          : "#5e92f3",
+      }}
+    >
+      <Handle
+        type="source"
+        position={Position.Top}
+        id="top"
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="bottom"
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        position={Position.Left}
+        id="left"
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="right"
+        isConnectable={isConnectable}
+      />
+      {/* The header of code pods. */}
+      <Box className="custom-drag-handle">
+        <Box
+          sx={{
+            position: "absolute",
+            top: "-24px",
+            width: "50%",
+          }}
+        >
+          <InputBase
+            inputRef={inputRef}
             className="nodrag"
-          >
-            {role !== RoleType.GUEST && (
-              <Tooltip title="Run (shift-enter)">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    clearResults(id);
-                    wsRun(id);
-                  }}
-                >
-                  <PlayCircleOutlineIcon fontSize="inherit" />
-                </IconButton>
-              </Tooltip>
-            )}
-            {role !== RoleType.GUEST && (
-              <Tooltip title="Delete">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    deleteNodeById(id);
-                  }}
-                >
-                  <DeleteIcon fontSize="inherit" />
-                </IconButton>
-              </Tooltip>
-            )}
-            <Tooltip title="Change layout">
+            defaultValue={data.name || ""}
+            disabled={role === RoleType.GUEST}
+            onBlur={(e) => {
+              const name = e.target.value;
+              if (name === data.name) return;
+              const node = nodesMap.get(id);
+              if (node) {
+                nodesMap.set(id, { ...node, data: { ...node.data, name } });
+              }
+            }}
+            inputProps={{
+              style: {
+                padding: "0px",
+                textOverflow: "ellipsis",
+              },
+            }}
+          ></InputBase>
+        </Box>
+        <Box sx={styles["pod-index"]}>[{index}]</Box>
+        <Box
+          sx={{
+            display: "flex",
+            marginLeft: "10px",
+            borderRadius: "4px",
+            position: "absolute",
+            border: "solid 1px #d6dee6",
+            right: "25px",
+            top: "-15px",
+            background: "white",
+            zIndex: 250,
+            justifyContent: "center",
+          }}
+          className="nodrag"
+        >
+          {role !== RoleType.GUEST && (
+            <Tooltip title="Run (shift-enter)">
               <IconButton
                 size="small"
                 onClick={() => {
-                  setLayout(layout === "bottom" ? "right" : "bottom");
+                  clearResults(id);
+                  wsRun(id);
                 }}
               >
-                <ViewComfyIcon fontSize="inherit" />
+                <PlayCircleOutlineIcon fontSize="inherit" />
               </IconButton>
             </Tooltip>
-          </Box>
-        </Box>
-        <Box
-          sx={{
-            height: "90%",
-          }}
-        >
-          <MyMonaco id={id} gitvalue="" />
-          {showResult && (
-            <Box
-              className="nowheel"
-              sx={{
-                border: "solid 1px #d6dee6",
-                borderRadius: "4px",
-                position: "absolute",
-                top: isRightLayout ? 0 : "100%",
-                left: isRightLayout ? "100%" : 0,
-                maxHeight: "160px",
-                maxWidth: isRightLayout ? "300px" : "100%",
-                minWidth: isRightLayout ? "150px" : "100%",
-                boxSizing: "border-box",
-                backgroundColor: "white",
-                zIndex: 100,
-                padding: "0 10px",
+          )}
+          {role !== RoleType.GUEST && (
+            <Tooltip title="Delete">
+              <IconButton
+                size="small"
+                onClick={() => {
+                  deleteNodeById(id);
+                }}
+              >
+                <DeleteIcon fontSize="inherit" />
+              </IconButton>
+            </Tooltip>
+          )}
+          <Tooltip title="Change layout">
+            <IconButton
+              size="small"
+              onClick={() => {
+                setLayout(layout === "bottom" ? "right" : "bottom");
               }}
             >
-              <ResultBlock pod={pod} id={id} />
-            </Box>
-          )}
+              <ViewComfyIcon fontSize="inherit" />
+            </IconButton>
+          </Tooltip>
         </Box>
       </Box>
-    );
-  }
-);
+      <Box
+        sx={{
+          height: "90%",
+        }}
+      >
+        <MyMonaco id={id} gitvalue="" />
+        {showResult && (
+          <Box
+            className="nowheel"
+            sx={{
+              border: "solid 1px #d6dee6",
+              borderRadius: "4px",
+              position: "absolute",
+              top: isRightLayout ? 0 : "100%",
+              left: isRightLayout ? "100%" : 0,
+              maxHeight: "160px",
+              maxWidth: isRightLayout ? "300px" : "100%",
+              minWidth: isRightLayout ? "150px" : "100%",
+              boxSizing: "border-box",
+              backgroundColor: "white",
+              zIndex: 100,
+              padding: "0 10px",
+            }}
+          >
+            <ResultBlock pod={pod} id={id} />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+});
 
 const nodeTypes = { scope: ScopeNode, code: CodeNode };
 

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -177,7 +177,17 @@ export interface RepoSlice {
     content: { data: { html: string; text: string; image: string } };
     count: number;
   }) => void;
-  setPodPosition: ({ id, x, y }: any) => void;
+  setPodPosition: ({
+    id,
+    x,
+    y,
+    dirty,
+  }: {
+    id: string;
+    x: number;
+    y: number;
+    dirty: boolean;
+  }) => void;
   setPodParent: ({ id, parent }: any) => void;
   currentEditor: string | null;
   setCurrentEditor: (id: string | null) => void;
@@ -492,13 +502,14 @@ const createRepoSlice: StateCreator<
         state.pods[id].render = value;
       })
     ),
-  setPodPosition: ({ id, x, y }) =>
+  setPodPosition: ({ id, x, y, dirty = true }) =>
     set(
       produce((state) => {
+        console.log("setPodPosition", id, x, y, dirty);
         let pod = state.pods[id];
         pod.x = x;
         pod.y = y;
-        pod.dirty = true;
+        pod.dirty = dirty;
       }),
       false,
       // @ts-ignore

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -188,7 +188,15 @@ export interface RepoSlice {
     y: number;
     dirty: boolean;
   }) => void;
-  setPodParent: ({ id, parent }: any) => void;
+  setPodParent: ({
+    id,
+    parent,
+    dirty,
+  }: {
+    id: string;
+    parent: string;
+    dirty: boolean;
+  }) => void;
   currentEditor: string | null;
   setCurrentEditor: (id: string | null) => void;
   setUser: (user: any) => void;
@@ -505,11 +513,10 @@ const createRepoSlice: StateCreator<
   setPodPosition: ({ id, x, y, dirty = true }) =>
     set(
       produce((state) => {
-        console.log("setPodPosition", id, x, y, dirty);
         let pod = state.pods[id];
         pod.x = x;
         pod.y = y;
-        pod.dirty = dirty;
+        pod.dirty ||= dirty;
       }),
       false,
       // @ts-ignore
@@ -664,7 +671,7 @@ const createRepoSlice: StateCreator<
         }
       })
     ),
-  setPodParent: ({ id, parent }) =>
+  setPodParent: ({ id, parent, dirty = true }) =>
     set(
       produce((state) => {
         // FIXME I need to modify many pods here.
@@ -672,7 +679,7 @@ const createRepoSlice: StateCreator<
         const oldparent = state.pods[state.pods[id].parent];
         state.pods[id].parent = parent;
         // FXME I'm marking all the pods as dirty here.
-        state.pods[id].dirty = true;
+        state.pods[id].dirty ||= dirty;
         state.pods[parent].children.push(state.pods[id]);
         let idx = oldparent.children.findIndex(({ id: _id }) => _id === id);
         oldparent.children.splice(idx, 1);


### PR DESCRIPTION
I don't know what triggered such a horrible code reformation in `canvas`, actually this is just a very tiny modification. Eventually, I adopted another simpler optimization strategy other than [what I proposed here](https://github.com/codepod-io/codepod/pull/136#discussion_r1045877268).  Please test it carefully before merging, it works on my side, but I'm not sure if any issue exists.

A brief summary:

1. Make all tooltips not draggable.
2. Rewrite `store.setPodPosition` and `store.setPodParent`, add a parameter `dirty: bool`, set `pod.dirty = pod.dirty | dirty`, that is, only triggers remote update request when the argument `dirty=true`. Note that we use `|` (or) operation instead of `=` (assign) to avoid a dirty pod cleaned by another local `setPodPosition` or `setPodParent` with  `dirty=false` before the update is synced to the DB.
3. For `codeNode` and `scopeNode`, `useEffect` listens on the change of node position or change, call `setPodPosition` or `setPodParent` with `dirty=false` whenever the corresponding position or parent node changes. We don't need to write the change to DB for now, but we must sync `store.pods` with the nodes in canvas.
4.  `dirty=true` is only used when stopping dragging nodes (in `onNodeDragStop`, that is, we only writes the update to DB when it is caused by operations by our current user. We don't need to write update pulled from the remote yjs server to the DB.

Possible issue:

- During dragging, the position of a node changes all the time, so we keep rendering the node and calling `setPodPosition` continually, even though it doesn't change `store.pods[id].dirty` and no data is written to the DB. One solution to mitigate the update to `store`: take a look at `dragging` as well, only update `store.pods[id]` after the dragging stops, like:

```ts
function codeNode({..., xPos, yPos, dragging}) {
// ....
useEffect( () => {
 if(!dragging) {
 let [x, y] = relativePostion(xPos, yPos); // transform XY coordinate
 setPodPosition({id, x, y, dirty: false})
}
}, [...,xPos, yPos, dragging])
// ....
}
```

But I think the performance of dragging is acceptable now, if you feel uncomfortable with the performance in the future, the solution is just for reference.

close https://github.com/codepod-io/codepod/issues/138