### PR TITLE
use relation for collaborators

### DIFF
--- a/api/prisma/migrations/20221213213322_use_relation_for_collaborators/migration.sql
+++ b/api/prisma/migrations/20221213213322_use_relation_for_collaborators/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `collaboratorIds` on the `Repo` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "Repo_name_userId_key";
+
+-- AlterTable
+ALTER TABLE "Repo" DROP COLUMN "collaboratorIds";
+
+-- CreateTable
+CREATE TABLE "_COLLABORATOR" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_COLLABORATOR_AB_unique" ON "_COLLABORATOR"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_COLLABORATOR_B_index" ON "_COLLABORATOR"("B");
+
+-- AddForeignKey
+ALTER TABLE "_COLLABORATOR" ADD CONSTRAINT "_COLLABORATOR_A_fkey" FOREIGN KEY ("A") REFERENCES "Repo"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_COLLABORATOR" ADD CONSTRAINT "_COLLABORATOR_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -44,21 +44,20 @@ model User {
     hashedPassword String?
     posts          Post[]
     profile        Profile?
-    Repo           Repo[]
+    Repo           Repo[]   @relation("OWNER")
+    sharedRepos    Repo[]   @relation("COLLABORATOR")
 }
 
 model Repo {
-    id              String   @id
-    name            String?
+    id            String   @id
+    name          String?
     // fullname String  @unique
-    owner           User     @relation(fields: [userId], references: [id])
-    userId          String
-    pods            Pod[]    @relation("BELONG")
-    podsId          String[]
-    public          Boolean  @default(false)
-    collaboratorIds String[]
-
-    @@unique([name, userId])
+    owner         User     @relation("OWNER", fields: [userId], references: [id])
+    userId        String
+    pods          Pod[]    @relation("BELONG")
+    podsId        String[]
+    public        Boolean  @default(false)
+    collaborators User[]   @relation("COLLABORATOR")
 }
 
 enum PodType {

--- a/api/src/typedefs.ts
+++ b/api/src/typedefs.ts
@@ -19,7 +19,7 @@ export const typeDefs = gql`
     name: String
     pods: [Pod]
     userId: ID!
-    collaboratorIds: [ID!]
+    collaborators: [User]
     public: Boolean
   }
 

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -17,7 +17,9 @@ export async function doRemoteLoadRepo({ id, client }) {
         id
         name
         userId
-        collaboratorIds
+        collaborators {
+          id
+        }
         pods {
           id
           type
@@ -68,11 +70,11 @@ export async function doRemoteLoadRepo({ id, client }) {
       name: res.data.repo.name,
       error: null,
       userId: res.data.repo.userId,
-      collaboratorIds: res.data.repo.collaboratorIds,
+      collaborators: res.data.repo.collaborators,
     };
   } catch (e) {
     console.log(e);
-    return { pods: [], name: "", error: e, userId: null, collaboratorIds: [] };
+    return { pods: [], name: "", error: e, userId: null, collaborators: [] };
   }
 }
 

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -723,8 +723,9 @@ const createRepoSlice: StateCreator<
     );
   },
   loadRepo: async (client, id) => {
-    const { pods, name, error, userId, collaboratorIds } =
-      await doRemoteLoadRepo({ id, client });
+    const { pods, name, error, userId, collaborators } = await doRemoteLoadRepo(
+      { id, client }
+    );
     set(
       produce((state) => {
         // TODO the children ordered by index
@@ -739,7 +740,10 @@ const createRepoSlice: StateCreator<
         // set the user role in this repo
         if (userId === state.user.id) {
           state.role = RoleType.OWNER;
-        } else if (state.user && collaboratorIds.indexOf(state.user.id) >= 0) {
+        } else if (
+          state.user &&
+          collaborators.findIndex(({ id }) => state.user.id === id) >= 0
+        ) {
           state.role = RoleType.COLLABORATOR;
         } else {
           state.role = RoleType.GUEST;


### PR DESCRIPTION
Replace previous `collaboratorIds` with a [Prisma relation](https://www.prisma.io/docs/concepts/components/prisma-schema/relations).

DB schema changed. Migration will have to drop all current `collaboratorIds` fields.