### PR TITLE
Feat: add a top-right share-button on the repo page

### DIFF
--- a/api/src/resolver.ts
+++ b/api/src/resolver.ts
@@ -11,8 +11,11 @@ import {
   createRepo,
   deletePod,
   deleteRepo,
+  deleteCollaborator,
   myRepos,
   myCollabRepos,
+  getVisibility,
+  updateVisibility,
   addCollaborator,
   pod,
   repo,
@@ -50,7 +53,9 @@ export const resolvers = {
     repo,
     pod,
     listAllRuntimes,
+    getVisibility,
     myCollabRepos,
+
     ...(process.env.RUNTIME_SPAWNER === "k8s"
       ? {
           infoRuntime: infoRuntime_k8s,
@@ -72,6 +77,8 @@ export const resolvers = {
     updatePod,
     deletePod,
     addCollaborator,
+    updateVisibility,
+    deleteCollaborator,
     ...(process.env.RUNTIME_SPAWNER === "k8s"
       ? {
           spawnRuntime: spawnRuntime_k8s,

--- a/api/src/typedefs.ts
+++ b/api/src/typedefs.ts
@@ -14,6 +14,11 @@ export const typeDefs = gql`
     lastname: String!
   }
 
+  type Visibility {
+    collaborators: [User]
+    isPublic: Boolean
+  }
+
   type Repo {
     id: ID!
     name: String
@@ -92,6 +97,7 @@ export const typeDefs = gql`
     pod(id: ID!): Pod
     myRepos: [Repo]
     activeSessions: [String]
+    getVisibility(repoId: String): Visibility
     listAllRuntimes: [RuntimeInfo]
     myCollabRepos: [Repo]
     infoRuntime(sessionId: String!): RuntimeInfo
@@ -118,6 +124,8 @@ export const typeDefs = gql`
     clearPod: Boolean
     spawnRuntime(sessionId: String): Boolean
     killRuntime(sessionId: String!): Boolean
+    updateVisibility(repoId: String, isPublic: Boolean): Boolean
     addCollaborator(repoId: String, email: String): Boolean
+    deleteCollaborator(repoId: String, collaboratorId: String): Boolean
   }
 `;

--- a/ui/package.json
+++ b/ui/package.json
@@ -86,6 +86,7 @@
     ]
   },
   "devDependencies": {
+    "@types/react-copy-to-clipboard": "^5.0.4",
     "@types/react-resizable": "^3.0.3",
     "babel-plugin-named-exports-order": "^0.0.2",
     "prop-types": "^15.8.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
     "net": "^1.0.2",
     "notistack": "^2.0.8",
     "react": "^18.2.0",
+    "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.6.0",
     "react-monaco-editor": "^0.50.1",

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -740,7 +740,6 @@ export function Canvas() {
   const getPod = useStore(store, (state) => state.getPod);
   const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
   const repoId = useStore(store, (state) => state.repoId);
-  const repoName = useStore(store, (state) => state.repoName);
   const role = useStore(store, (state) => state.role);
   const provider = useStore(store, (state) => state.provider);
   const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
@@ -1168,13 +1167,7 @@ export function Canvas() {
             }}
           />
         )}
-        {shareOpen && (
-          <ShareProjDialog
-            open={shareOpen}
-            title={repoName || ""}
-            id={repoId || ""}
-          />
-        )}
+        {shareOpen && <ShareProjDialog open={shareOpen} id={repoId || ""} />}
       </Box>
     </Box>
   );

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -739,12 +739,13 @@ export function Canvas() {
   // const pods = useStore(store, (state) => state.pods);
   const getPod = useStore(store, (state) => state.getPod);
   const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
-  const [showShareDialog, setShowShareDialog] = useState(false);
   const repoId = useStore(store, (state) => state.repoId);
   const repoName = useStore(store, (state) => state.repoName);
   const role = useStore(store, (state) => state.role);
   const provider = useStore(store, (state) => state.provider);
   const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+  const shareOpen = useStore(store, (state) => state.shareOpen);
+  const setShareOpen = useStore(store, (state) => state.setShareOpen);
 
   const getRealNodes = useCallback(
     (id: string, level: number) => {
@@ -1163,16 +1164,17 @@ export function Canvas() {
             addCode={() => addNode(client.x, client.y, "code")}
             addScope={() => addNode(client.x, client.y, "scope")}
             onShareClick={() => {
-              setShowShareDialog(true);
+              setShareOpen(true);
             }}
           />
         )}
-        <ShareProjDialog
-          open={showShareDialog}
-          onClose={() => setShowShareDialog(false)}
-          title={repoName || ""}
-          id={repoId || ""}
-        />
+        {shareOpen && (
+          <ShareProjDialog
+            open={shareOpen}
+            title={repoName || ""}
+            id={repoId || ""}
+          />
+        )}
       </Box>
     </Box>
   );

--- a/ui/src/components/CanvasContextMenu.tsx
+++ b/ui/src/components/CanvasContextMenu.tsx
@@ -9,7 +9,6 @@ import React, { useContext } from "react";
 import CodeIcon from "@mui/icons-material/Code";
 import PostAddIcon from "@mui/icons-material/PostAdd";
 import FormatListNumberedIcon from "@mui/icons-material/FormatListNumbered";
-import ShareOutlinedIcon from "@mui/icons-material/ShareOutlined";
 
 const paneMenuStyle = (left, top) => {
   return {
@@ -67,12 +66,6 @@ export function CanvasContextMenu(props) {
           <ListItemText>
             {showLineNumbers ? "Hide " : "Show "} Line Numbers
           </ListItemText>
-        </MenuItem>
-        <MenuItem onClick={props.onShareClick} sx={ItemStyle}>
-          <ListItemIcon>
-            <ShareOutlinedIcon />
-          </ListItemIcon>
-          <ListItemText> Share </ListItemText>
         </MenuItem>
       </MenuList>
     </Box>

--- a/ui/src/components/CanvasContextMenu.tsx
+++ b/ui/src/components/CanvasContextMenu.tsx
@@ -68,14 +68,12 @@ export function CanvasContextMenu(props) {
             {showLineNumbers ? "Hide " : "Show "} Line Numbers
           </ListItemText>
         </MenuItem>
-        {role === RoleType.OWNER && (
-          <MenuItem onClick={props.onShareClick} sx={ItemStyle}>
-            <ListItemIcon>
-              <ShareOutlinedIcon />
-            </ListItemIcon>
-            <ListItemText> Share with Collaborators </ListItemText>
-          </MenuItem>
-        )}
+        <MenuItem onClick={props.onShareClick} sx={ItemStyle}>
+          <ListItemIcon>
+            <ShareOutlinedIcon />
+          </ListItemIcon>
+          <ListItemText> Share </ListItemText>
+        </MenuItem>
       </MenuList>
     </Box>
   );

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -12,6 +12,7 @@ import Avatar from "@mui/material/Avatar";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
 import Link from "@mui/material/Link";
 import Button from "@mui/material/Button";
+import ShareIcon from "@mui/icons-material/Share";
 
 import Toolbar from "@mui/material/Toolbar";
 import IconButton from "@mui/material/IconButton";
@@ -30,6 +31,8 @@ type HeaderProps = {
   drawerWidth?: number;
   currentPage?: string | null;
   breadcrumbItem?: React.ReactNode;
+  inRepo?: boolean;
+  setShareOpen?: () => void;
 };
 
 export const Header: React.FC<HeaderProps> = ({
@@ -37,6 +40,8 @@ export const Header: React.FC<HeaderProps> = ({
   drawerWidth = 0,
   currentPage = null,
   breadcrumbItem = null,
+  inRepo = false,
+  setShareOpen = () => {},
 }) => {
   const [anchorElNav, setAnchorElNav] = useState(null);
   const [anchorElUser, setAnchorElUser] = useState(null);
@@ -93,6 +98,24 @@ export const Header: React.FC<HeaderProps> = ({
             )}
             {breadcrumbItem}
           </Breadcrumbs>
+
+          {inRepo && (
+            <Box
+              sx={{
+                display: { xs: "none", md: "flex" },
+                alignItems: "center",
+                paddingRight: "10px",
+              }}
+            >
+              <Button
+                endIcon={<ShareIcon />}
+                onClick={setShareOpen}
+                variant="contained"
+              >
+                Share
+              </Button>
+            </Box>
+          )}
 
           {/* The navigation on desktop */}
           <Box

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -12,7 +12,6 @@ import Avatar from "@mui/material/Avatar";
 import Breadcrumbs from "@mui/material/Breadcrumbs";
 import Link from "@mui/material/Link";
 import Button from "@mui/material/Button";
-import ShareIcon from "@mui/icons-material/Share";
 
 import Toolbar from "@mui/material/Toolbar";
 import IconButton from "@mui/material/IconButton";
@@ -31,8 +30,7 @@ type HeaderProps = {
   drawerWidth?: number;
   currentPage?: string | null;
   breadcrumbItem?: React.ReactNode;
-  inRepo?: boolean;
-  setShareOpen?: () => void;
+  shareButton?: React.ReactNode;
 };
 
 export const Header: React.FC<HeaderProps> = ({
@@ -40,8 +38,7 @@ export const Header: React.FC<HeaderProps> = ({
   drawerWidth = 0,
   currentPage = null,
   breadcrumbItem = null,
-  inRepo = false,
-  setShareOpen = () => {},
+  shareButton = null,
 }) => {
   const [anchorElNav, setAnchorElNav] = useState(null);
   const [anchorElUser, setAnchorElUser] = useState(null);
@@ -99,23 +96,15 @@ export const Header: React.FC<HeaderProps> = ({
             {breadcrumbItem}
           </Breadcrumbs>
 
-          {inRepo && (
-            <Box
-              sx={{
-                display: { xs: "none", md: "flex" },
-                alignItems: "center",
-                paddingRight: "10px",
-              }}
-            >
-              <Button
-                endIcon={<ShareIcon />}
-                onClick={setShareOpen}
-                variant="contained"
-              >
-                Share
-              </Button>
-            </Box>
-          )}
+          <Box
+            sx={{
+              display: { xs: "none", md: "flex" },
+              alignItems: "center",
+              paddingRight: "10px",
+            }}
+          >
+            {shareButton}
+          </Box>
 
           {/* The navigation on desktop */}
           <Box

--- a/ui/src/components/ShareProjDialog.tsx
+++ b/ui/src/components/ShareProjDialog.tsx
@@ -8,75 +8,167 @@ import Button from "@mui/material/Button";
 import Alert from "@mui/material/Alert";
 import { AlertColor } from "@mui/material/Alert";
 import Snackbar from "@mui/material/Snackbar";
-import { useState, useEffect } from "react";
-import { useMutation, gql } from "@apollo/client";
-import MuiAlert, { AlertProps } from "@mui/material/Alert";
-import React from "react";
-
-// const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
-//   props,
-//   ref,
-// ) {
-//   return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
-// });
+import { useState } from "react";
+import ListSubheader from "@mui/material/ListSubheader";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import ListItemAvatar from "@mui/material/ListItemAvatar";
+import GroupAddIcon from "@mui/icons-material/GroupAdd";
+import Avatar from "@mui/material/Avatar";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import FileCopyIcon from "@mui/icons-material/FileCopy";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import CloseIcon from "@mui/icons-material/Close";
+import React, { useContext } from "react";
+import { CopyToClipboard } from "react-copy-to-clipboard";
+import { useStore } from "zustand";
+import { RepoContext, RoleType } from "../lib/store";
+import { useApolloClient } from "@apollo/client";
 
 interface ShareProjDialogProps {
-  open: boolean;
-  title: String;
-  onClose: () => void;
-  id: string;
+  open?: boolean;
+  title?: String;
+  id?: string;
 }
 
+function CollaboratorList({
+  collaborators,
+  setStatus,
+  setMessage,
+  setInfoOpen,
+}) {
+  const store = useContext(RepoContext);
+  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const apolloClient = useApolloClient();
+  const role = useStore(store, (state) => state.role);
+  const deleteCollaborator = useStore(
+    store,
+    (state) => state.deleteCollaborator
+  );
+
+  if (!collaborators || collaborators?.length === 0) {
+    return (
+      <List dense={true}>
+        <ListSubheader sx={{ fontWeight: "bold" }}>Collaborators</ListSubheader>
+        <ListItem>
+          <ListItemIcon>
+            <GroupAddIcon />
+          </ListItemIcon>
+          <ListItemText
+            primary="No collaborators yet?"
+            secondary="Invite a friend right now!"
+            key="no-collaborators"
+          />
+        </ListItem>
+      </List>
+    );
+  }
+
+  async function handleDeleteCollaborator(userId) {
+    const { success, error } = await deleteCollaborator(apolloClient, userId);
+    if (success) {
+      setStatus("success");
+      setMessage("Remove the collaborator successfully");
+    } else {
+      setStatus("error");
+      setMessage(error.message);
+    }
+    setInfoOpen(true);
+  }
+
+  return (
+    <List
+      sx={{
+        maxHeight: 300,
+        overflow: "auto",
+      }}
+      dense={true}
+    >
+      <ListSubheader sx={{ fontWeight: "bold" }}>Collaborators</ListSubheader>
+      {collaborators?.map((collab) => (
+        <ListItem
+          secondaryAction={
+            role === RoleType.OWNER && (
+              <IconButton
+                edge="end"
+                aria-label="delete"
+                onClick={() => handleDeleteCollaborator(collab.id)}
+              >
+                <CloseIcon />
+              </IconButton>
+            )
+          }
+          sx={{ "&:hover": { backgroundColor: "#f5f5f5" } }}
+          key={collab.id}
+        >
+          <ListItemAvatar>
+            <Avatar> {collab.firstname[0] + collab.lastname[0]} </Avatar>
+          </ListItemAvatar>
+          <ListItemText
+            primary={collab.firstname + " " + collab.lastname}
+            secondary={collab.email}
+            key={collab.id}
+          />
+        </ListItem>
+      ))}
+    </List>
+  );
+}
+
+const infoAboutPublicOrPrivate =
+  "A private project is only visible to you and collaborators, while a public project is visible to everyone. For both of them, only the owner can invite collaborators by their email addresses, and only collaborators can edit the project. The owner can change the visibility of a project at any time.";
+
 export function ShareProjDialog({
-  open,
-  title,
-  onClose,
-  id,
+  open = false,
+  title = "Untitled",
+  id = "",
 }: ShareProjDialogProps) {
-  const [email, setEmail] = useState("");
+  const store = useContext(RepoContext);
+  if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const [status, setStatus] = useState<AlertColor>("info");
   const [message, setMessage] = useState("inviting...");
   const [infoOpen, setInfoOpen] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
+  const apolloClient = useApolloClient();
+  const isPublic = useStore(store, (state) => state.isPublic);
+  const collaborators = useStore(store, (state) => state.collaborators);
+  const setShareOpen = useStore(store, (state) => state.setShareOpen);
+  const updateVisibility = useStore(store, (state) => state.updateVisibility);
+  const addCollaborator = useStore(store, (state) => state.addCollaborator);
+  const role = useStore(store, (state) => state.role);
+  const url = `${window.location.protocol}//${window.location.host}/repo/${id}`;
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
-  const query = gql`
-    mutation addCollaborator($repoId: String, $email: String) {
-      addCollaborator(repoId: $repoId, email: $email)
+  async function flipVisibility() {
+    if (await updateVisibility(apolloClient, !isPublic)) {
+      setStatus("success");
+      setMessage("Visibility changed successfully");
+    } else {
+      setStatus("error");
+      setMessage("Visibility change failed");
     }
-  `;
-  const [addEmail] = useMutation(query);
-
-  const onChange = (e) => {
-    setEmail(e.target.value);
-  };
+    setInfoOpen(true);
+  }
 
   async function onShare() {
+    const email = inputRef?.current?.value;
     setInfoOpen(true);
-    if (email === "") {
+    if (!email) {
       setStatus("error");
       setMessage("Please enter an email address");
       return;
     }
-    try {
-      const { data } = await addEmail({
-        variables: {
-          repoId: id,
-          email,
-        },
-      });
+    const { success, error } = await addCollaborator(apolloClient, email);
+    if (success) {
       setStatus("success");
-      setMessage(`Invitation sent to ${email} successfully`);
-      // show the success message for 1 second before closing the dialog
-      console.log(status, message);
-      onCloseHandler();
-    } catch (error: any) {
-      setStatus("error"); // just in case
+      setMessage("Invited successfully");
+    } else {
+      setStatus("error");
       setMessage(error?.message || "Unknown error");
     }
-  }
-
-  function onCloseHandler() {
-    setEmail("");
-    onClose();
   }
 
   function onCloseAlert(event: React.SyntheticEvent | Event, reason?: string) {
@@ -88,14 +180,86 @@ export function ShareProjDialog({
 
   return (
     <>
-      <Dialog open={open} onClose={onCloseHandler}>
-        <DialogTitle> Share Project {title} with</DialogTitle>
-
+      <Dialog open={open} onClose={() => setShareOpen(false)}>
+        <DialogTitle>
+          Share Project:{" "}
+          <span style={{ fontFamily: "monospace" }}>{title || "Untitled"}</span>
+          <IconButton
+            aria-label="close"
+            onClick={() => setShareOpen(false)}
+            sx={{ position: "absolute", right: 8, top: 8 }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
         <DialogContent>
+          <TextField
+            id="link"
+            type="text"
+            variant="standard"
+            label="Link"
+            defaultValue={url}
+            fullWidth
+            InputProps={{
+              readOnly: true,
+              endAdornment: (
+                <CopyToClipboard
+                  text={url}
+                  onCopy={() => {
+                    setStatus("success");
+                    setMessage("Link Copied");
+                    setInfoOpen(true);
+                  }}
+                >
+                  <Tooltip title="Copy link">
+                    <IconButton>
+                      <FileCopyIcon />
+                    </IconButton>
+                  </Tooltip>
+                </CopyToClipboard>
+              ),
+            }}
+          ></TextField>
+
+          <DialogContentText>
+            The project is currently {isPublic ? "public" : "private"}.
+            <IconButton
+              onClick={() => setShowHelp((prev) => !prev)}
+              color={showHelp ? "primary" : "inherit"}
+              sx={{ marginBottom: 1, marginLeft: 0 }}
+            >
+              <HelpOutlineOutlinedIcon fontSize="small" />
+            </IconButton>
+            {role === RoleType.OWNER && (
+              <Button sx={{ float: "right" }} onClick={flipVisibility}>
+                Make it {isPublic ? "private" : "public"}
+              </Button>
+            )}
+          </DialogContentText>
+
+          {showHelp && (
+            <DialogContentText
+              color="primary"
+              variant="body2"
+              fontSize="small"
+              sx={{ maxWidth: 500 }}
+            >
+              {infoAboutPublicOrPrivate}
+            </DialogContentText>
+          )}
+
+          <CollaboratorList
+            collaborators={collaborators}
+            setStatus={setStatus}
+            setMessage={setMessage}
+            setInfoOpen={setInfoOpen}
+          />
+
           <DialogContentText>
             Enter the email address of the person you want to share this project
             with.
           </DialogContentText>
+
           <TextField
             autoFocus
             margin="dense"
@@ -104,13 +268,12 @@ export function ShareProjDialog({
             type="email"
             variant="standard"
             fullWidth
-            onChange={onChange}
+            inputRef={inputRef}
           />
           <DialogActions>
             <Button
               onClick={() => {
-                setInfoOpen(false);
-                onCloseHandler();
+                setShareOpen(false);
               }}
             >
               Cancel
@@ -119,7 +282,12 @@ export function ShareProjDialog({
           </DialogActions>
         </DialogContent>
       </Dialog>
-      <Snackbar open={infoOpen} autoHideDuration={3000} onClose={onCloseAlert}>
+      <Snackbar
+        open={infoOpen}
+        autoHideDuration={3000}
+        onClose={onCloseAlert}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      >
         <Alert severity={status} onClose={onCloseAlert}>
           {message}
         </Alert>

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -4,6 +4,8 @@ import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
+import ShareIcon from "@mui/icons-material/Share";
+import Button from "@mui/material/Button";
 import { gql, useApolloClient, useMutation } from "@apollo/client";
 
 import { useEffect, useState, useRef, useContext } from "react";
@@ -70,8 +72,6 @@ function RepoWrapper({ children, id }) {
         <Header
           open={open}
           drawerWidth={DrawerWidth}
-          inRepo={true}
-          setShareOpen={() => setShareOpen(true)}
           breadcrumbItem={
             <Stack direction="row">
               <TextField
@@ -95,6 +95,15 @@ function RepoWrapper({ children, id }) {
               />
               {error && <Box>ERROR: {error.message}</Box>}
             </Stack>
+          }
+          shareButton={
+            <Button
+              endIcon={<ShareIcon />}
+              onClick={() => setShareOpen(true)}
+              variant="contained"
+            >
+              Share
+            </Button>
           }
         />
         <Box

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -31,6 +31,7 @@ function RepoWrapper({ children, id }) {
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const repoName = useStore(store, (state) => state.repoName);
   const setRepoName = useStore(store, (state) => state.setRepoName);
+  const setShareOpen = useStore(store, (state) => state.setShareOpen);
 
   const [updateRepo, { error }] = useMutation(
     gql`
@@ -69,6 +70,8 @@ function RepoWrapper({ children, id }) {
         <Header
           open={open}
           drawerWidth={DrawerWidth}
+          inRepo={true}
+          setShareOpen={() => setShareOpen(true)}
           breadcrumbItem={
             <Stack direction="row">
               <TextField

--- a/ui/src/pages/repos.tsx
+++ b/ui/src/pages/repos.tsx
@@ -162,7 +162,7 @@ function RepoLine({ repo, deletable, sharable, runtimeInfo }) {
             </IconButton>
           </Tooltip>
         ) : null}
-        {sharable && (
+        {/* {sharable && (
           <>
             <Tooltip title="Share">
               <IconButton size="small" onClick={() => setOpen(true)}>
@@ -176,7 +176,7 @@ function RepoLine({ repo, deletable, sharable, runtimeInfo }) {
               id={repo.id}
             />
           </>
-        )}
+        )} */}
       </TableCell>
     </TableRow>
   );

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2637,6 +2637,13 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
+"@types/react-copy-to-clipboard@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.4.tgz#558f2c38a97f53693e537815f6024f1e41e36a7e"
+  integrity sha512-otTJsJpofYAeaIeOwV5xBUGpo6exXG2HX7X4nseToCB2VgPEBxGBHCm/FecZ676doNR7HCSTVtmohxfG2b3/yQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@^18.0.0":
   version "18.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3955,6 +3955,13 @@ cookie@0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
+copy-to-clipboard@^3.3.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz#55ac43a1db8ae639a4bd99511c148cdd1b83a1b0"
+  integrity sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-js-compat@^3.25.1:
   version "3.25.5"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.25.5.tgz#0016e8158c904f7b059486639e6e82116eafa7d9"
@@ -8444,6 +8451,14 @@ react-app-rewired@^2.2.1:
   dependencies:
     semver "^5.6.0"
 
+react-copy-to-clipboard@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz#09aae5ec4c62750ccb2e6421a58725eabc41255c"
+  integrity sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==
+  dependencies:
+    copy-to-clipboard "^3.3.1"
+    prop-types "^15.8.1"
+
 react-css-styled@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/react-css-styled/-/react-css-styled-1.0.4.tgz#236ce398232dc152084bbf20540df1c971534174"
@@ -9691,6 +9706,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==
 
 toidentifier@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Change:

1. Remove the share-buttons on the dashboard, add it on the repo page.

![image](https://user-images.githubusercontent.com/10118462/207838869-5c8c604d-8de0-4270-a026-b6b80c8938e6.png)

2. Polish the share-project dialog, everyone accessing the repo can click the share-button (and the share option in right-click menu) to see the dialog, but the privilege levels vary: 

![image](https://user-images.githubusercontent.com/10118462/207839164-25134a4d-0935-41fc-baff-d6ed5e062200.png)
  - A read-only URL field to copy 
  - An owner can switch the visibility (public or private) by a button (ref:https://github.com/codepod-io/codepod/pull/142#issuecomment-1348105998)
  - Explanation about the visibility when clicking the help icon
  - Fetch a list of current collaborators, the owner can **delete any of them** by clicking the button
  - Invite others by collaborators (if you are not the owner, it doesn't work)
  - Change of the visibility  (`isPublic` and the list of collaborators) loads immediately after actions.

By the way, if there are no collaborators now, it looks like:

![image](https://user-images.githubusercontent.com/10118462/207841738-f168c426-9ddd-41c5-a693-b467d8a02396.png)

**Please test carefully before merging.**

Related to-do list:

1. Code involving error displaying looks quite messy, consider restructuring it via `useReducer` if I have time.
2. Recover the share-button on the dashboard if possible. I remove it mainly because the timer for TTL results in re-rendering dialog every second and hard to write those remote queries without store. But it is very inconvenient to share a project by entering it first.
3. Consider completely hiding/disabling the invitation context for non-owner user in the future. I just remain it and throw the access error when submitting for now.

