### PR TITLE
Feat: cross-page single-pod copy-paste in mouse-bound `ctrl`-`v` way

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -1233,9 +1233,11 @@ export function Canvas() {
   }, [pasteCodePod]);
 
   useEffect(() => {
-    if (!pasting || !reactFlowWrapper.current) return;
+    if (!pasting || !reactFlowWrapper.current) {
+      return;
+    }
+
     const mouseMove = (event) => {
-      console.log("mousemove", event);
       const reactFlowBounds = reactFlowWrapper.current.getBoundingClientRect();
       const position = reactFlowInstance.project({
         x: event.clientX - reactFlowBounds.left,
@@ -1247,7 +1249,6 @@ export function Canvas() {
       nodesMap.set(pasting, node);
     };
     const mouseClick = (event) => {
-      console.log("mouseclick", event);
       const node = nodesMap.get(pasting);
       if (!node) return;
       const newNode = {
@@ -1274,8 +1275,8 @@ export function Canvas() {
       setPasting(null);
     };
     const keyDown = (event) => {
-      console.log("escapeDown", event);
       if (event.key !== "Escape") return;
+      console.log("escapeDown", event);
       event.preventDefault();
       // delete the temporary node
       nodesMap.delete(pasting);
@@ -1285,11 +1286,11 @@ export function Canvas() {
     };
     reactFlowWrapper.current.addEventListener("mousemove", mouseMove);
     reactFlowWrapper.current.addEventListener("click", mouseClick);
-    document.addEventListener("keydown", keyDown);
+    reactFlowWrapper.current.addEventListener("keydown", keyDown);
     return () => {
       reactFlowWrapper.current.removeEventListener("mousemove", mouseMove);
       reactFlowWrapper.current.removeEventListener("click", mouseClick);
-      document.removeEventListener("keydown", keyDown);
+      reactFlowWrapper.current.removeEventListener("keydown", keyDown);
     };
   }, [
     pasting,

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -1223,7 +1223,7 @@ export function Canvas() {
     };
     const handlePaste = (event) => {
       // avoid duplicated pastes
-      if (pasting) return;
+      if (pasting || role === RoleType.GUEST) return;
 
       // only paste when the pane is focused
       if (

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -390,6 +390,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const getPod = useStore(store, (state) => state.getPod);
   const setCurrentEditor = useStore(store, (state) => state.setCurrentEditor);
   const setPodContent = useStore(store, (state) => state.setPodContent);
+  const initPodContent = useStore(store, (state) => state.initPodContent);
   const clearResults = useStore(store, (s) => s.clearResults);
   const wsRun = useStore(store, (state) => state.wsRun);
   const setPodFocus = useStore(store, (state) => state.setPodFocus);
@@ -485,7 +486,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
         ytext.insert(0, value);
       } else {
         // init the pasted pod content by the code on the yjs server
-        setPodContent({ id, content: ytext.toString() });
+        initPodContent({ id, content: ytext.toString() });
       }
     };
 

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -483,6 +483,9 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
     const init = () => {
       if (!ytext._start && ytext.length === 0) {
         ytext.insert(0, value);
+      } else {
+        // init the pasted pod content by the code on the yjs server
+        setPodContent({ id, content: ytext.toString() });
       }
     };
 

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -111,8 +111,7 @@ export function useNodesStateSynced(nodeList) {
       YMapEvent.changes.keys.forEach((change, key) => {
         if (change.action === "add") {
           const node = nodesMap.get(key);
-          if (!node || node.data?.clientID || getPod(key)) return;
-          console.log("toadd", node);
+          if (!node || node.data?.clientId || getPod(key)) return;
           addPod(null, {
             id: node.id,
             parent: "ROOT",
@@ -128,7 +127,6 @@ export function useNodesStateSynced(nodeList) {
           });
         } else if (change.action === "delete") {
           const node = change.oldValue;
-          if (node.data?.clientId === clientId) return;
           console.log("todelete", node);
           deletePod(null, { id: node.id, toDelete: [] });
         }

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -30,6 +30,10 @@ export function useNodesStateSynced(nodeList) {
   const role = useStore(store, (state) => state.role);
   const ydoc = useStore(store, (state) => state.ydoc);
   const nodesMap = ydoc.getMap<Node>("pods");
+  const clientId = useStore(
+    store,
+    (state) => state.provider?.awareness?.clientID
+  );
 
   const [nodes, setNodes] = useState(nodeList);
   // const setNodeId = useStore((state) => state.setSelectNode);
@@ -107,7 +111,8 @@ export function useNodesStateSynced(nodeList) {
       YMapEvent.changes.keys.forEach((change, key) => {
         if (change.action === "add") {
           const node = nodesMap.get(key);
-          if (!node) return;
+          if (!node || node.data?.clientID || getPod(key)) return;
+          console.log("toadd", node);
           addPod(null, {
             id: node.id,
             parent: "ROOT",
@@ -118,9 +123,12 @@ export function useNodesStateSynced(nodeList) {
             y: node.position.y,
             width: node.style?.width,
             height: node.style?.height,
+            name: node.data?.name,
+            dirty: false,
           });
         } else if (change.action === "delete") {
           const node = change.oldValue;
+          if (node.data?.clientId === clientId) return;
           console.log("todelete", node);
           deletePod(null, { id: node.id, toDelete: [] });
         }
@@ -129,6 +137,11 @@ export function useNodesStateSynced(nodeList) {
       // TOFIX: a node may be shadowed behind its parent, due to the order to render reactflow node, to fix this, comment out the following sorted method, which brings in a large overhead.
       setNodes(
         Array.from(nodesMap.values())
+          .filter(
+            (node) =>
+              !node.data.hasOwnProperty("clientId") ||
+              node.data.clientId === clientId
+          )
           .sort((a: Node & { level }, b: Node & { level }) => a.level - b.level)
           .map((node) => ({ ...node, selected: selectedPods.has(node.id) }))
       );

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -178,6 +178,7 @@ export interface RepoSlice {
   unfoldAll: () => void;
   setPodName: ({ id, name }: { id: string; name: string }) => void;
   setPodContent: ({ id, content }: { id: string; content: string }) => void;
+  initPodContent: ({ id, content }: { id: string; content: string }) => void;
   addPod: (
     client: ApolloClient<object> | null,
     {
@@ -565,6 +566,16 @@ const createRepoSlice: StateCreator<
       false,
       // @ts-ignore
       "setPodContent"
+    ),
+  initPodContent: ({ id, content }) =>
+    set(
+      produce((state) => {
+        let pod = state.pods[id];
+        pod.content = content;
+      }),
+      false,
+      // @ts-ignore
+      "initPodContent"
     ),
   setPodRender: ({ id, value }) =>
     set(

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -180,7 +180,24 @@ export interface RepoSlice {
   setPodContent: ({ id, content }: { id: string; content: string }) => void;
   addPod: (
     client: ApolloClient<object> | null,
-    { parent, anchor, shift, id, type, lang, x, y, width, height }: any
+    {
+      parent,
+      anchor,
+      shift,
+      id,
+      type,
+      lang,
+      x,
+      y,
+      width,
+      height,
+      name,
+      content,
+      error,
+      result,
+      stdout,
+      dirty,
+    }: any
   ) => void;
   deletePod: (
     client: ApolloClient<object> | null,
@@ -288,7 +305,24 @@ const createRepoSlice: StateCreator<
   setCurrentEditor: (id) => set({ currentEditor: id }),
   addPod: async (
     client,
-    { parent, anchor, shift, id, type, lang, x, y, width, height }
+    {
+      parent,
+      anchor,
+      shift,
+      id,
+      type,
+      lang,
+      x,
+      y,
+      width,
+      height,
+      name = "",
+      content = "",
+      stdout = "",
+      error = null,
+      result = null,
+      dirty = true,
+    }
   ) => {
     if (!parent) {
       parent = "ROOT";
@@ -296,16 +330,17 @@ const createRepoSlice: StateCreator<
     // update all other siblings' index
     // FIXME this might cause other pods to be re-rendered
     const pod: Pod = {
-      content: "",
+      content,
       column: 1,
-      stdout: "",
-      error: null,
+      stdout,
+      error,
       lang: "python",
       raw: false,
       fold: false,
       thundar: false,
       utility: false,
-      name: "",
+      name,
+      result,
       ispublic: false,
       symbolTable: {},
       exports: {},
@@ -330,6 +365,7 @@ const createRepoSlice: StateCreator<
       width,
       height,
     };
+    console.log("add pod", pod);
     set(
       produce((state: BearState) => {
         // 1. do local update
@@ -348,7 +384,7 @@ const createRepoSlice: StateCreator<
       })
     );
     // 2. do remote update
-    if (client) {
+    if (client && dirty) {
       await doRemoteAddPod(client, {
         repoId: get().repoId,
         parent,

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -197,7 +197,6 @@ export interface RepoSlice {
       error,
       result,
       stdout,
-      dirty,
     }: any
   ) => void;
   deletePod: (
@@ -322,7 +321,6 @@ const createRepoSlice: StateCreator<
       stdout = "",
       error = null,
       result = null,
-      dirty = true,
     }
   ) => {
     if (!parent) {
@@ -366,7 +364,6 @@ const createRepoSlice: StateCreator<
       width,
       height,
     };
-    console.log("add pod", pod);
     set(
       produce((state: BearState) => {
         // 1. do local update
@@ -385,7 +382,7 @@ const createRepoSlice: StateCreator<
       })
     );
     // 2. do remote update
-    if (client && dirty) {
+    if (client) {
       await doRemoteAddPod(client, {
         repoId: get().repoId,
         parent,


### PR DESCRIPTION
[Done] This PR is finished, ready to review now.

(Only support one single code pod by now, `Ctrl-C` is not supported yet)

Related to: https://github.com/codepod-io/codepod/issues/155

I gave up `clipboard.read/write`, removed the paste option in right-click menu, tested on Chrome, Edges, and Firefox, all works well.

![1671534645391](https://user-images.githubusercontent.com/10118462/208655740-60ed6d3c-f6c0-47c6-acba-8dc489856706.gif)


How to use:
1. Copy a pod (either in this page or other pages) via the copy button
2. Click (or right-click) on the canvas (pane) once to make sure the pane is focused
3. Press `Ctrl` -`V`, a duplicated pod shows up in the center of the canvas (FIXME: because the cursor may not be in the canvas when pasting, so I just choose the center as the initial position, we can discuss the detailed rule for the initial position later)
4. Move your mouse inside the canvas, the half-transparent pasted pod will move together, but the collaborator will never see this half-transparent pod. (To be exactly, the top-left corner position of this pod comes following the mouse, we may discuss the anchor point later, which point do you prefer? The center of the pod? Or the top-left?)
5. Click on the destination position, then the pasted pod completely shows up, others can also see it on their pages.


~~Don't merge, just a demo to convey my idea and for test usages from others. The code is too dirty now, if you agree on this idea, I can continue to improve the implementation.~~



