### PR TITLE
Feat: single-pod cut-n-paste support

### DIFF
--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -141,7 +141,11 @@ export function useNodesStateSynced(nodeList) {
               node.data.clientId === clientId
           )
           .sort((a: Node & { level }, b: Node & { level }) => a.level - b.level)
-          .map((node) => ({ ...node, selected: selectedPods.has(node.id) }))
+          .map((node) => ({
+            ...node,
+            selected: selectedPods.has(node.id),
+            hidden: node.data?.hidden === clientId,
+          }))
       );
 
       // setNodes(Array.from(nodesMap.values()));

--- a/ui/src/lib/store.tsx
+++ b/ui/src/lib/store.tsx
@@ -92,6 +92,7 @@ const initialState = {
   collaborators: [],
   isPublic: false,
   shareOpen: false,
+  cutting: null,
   scopedVars: localStorage.getItem("scopedVars")
     ? JSON.parse(localStorage.getItem("scopedVars")!)
     : true,
@@ -147,6 +148,7 @@ export interface RepoSlice {
   role: RoleType;
   collaborators: any[];
   shareOpen: boolean;
+  cutting: string | null;
   // sessionId?: string;
 
   resetState: () => void;
@@ -253,6 +255,7 @@ export interface RepoSlice {
   deleteCollaborator: (client: ApolloClient<object>, id: string) => any;
   loadVisibility: (client: ApolloClient<object>, repoId: string) => void;
   setShareOpen: (open: boolean) => void;
+  setCutting: (id: string | null) => void;
 }
 
 type BearState = RepoSlice & RuntimeSlice;
@@ -954,6 +957,7 @@ const createRepoSlice: StateCreator<
     }
     return { success, error };
   },
+  setCutting: (id: string | null) => set({ cutting: id }),
 });
 
 export const createRepoStore = () =>


### PR DESCRIPTION
~~Don't merge now, this is just a demo to align the idea of cut-n-paste functionality and tests. The code is too dirty now, clean-up is required after we agree on the idea.~~

Update: clean-up & ready for review.

How to use:

1. Click on the cut button of a pod, then the pod become half-transparent immediately.
2. This half-transparent pod will follow your mouse like pasting behavior.
3. Choose a destination location, click on it, the new pasted pod is located here and become solid.
4. If you don't want to proceed anymore, press <kbd>Esc</kbd>, the half-transparent pod disappears and the origin pod shows up again.

Note:

1. Like copying, the data will be written in your clipboard, you can still paste it into any repos even if your cutting procedure ends, until you copy new contents.
2. During the whole cut-n-paste procedure, that is, before canceled by <kbd>Esc</kbd> or confirmed by clicking, collaborators   won't observe any clues. They can't see the half-transparent pods, the origin pod remains on their side.

![](https://user-images.githubusercontent.com/10118462/209392829-431d650e-2358-4005-8136-bcff017cdbd2.gif)

Any test and suggestion are welcome.
