### PR TITLE
Fix: unselect all nodes when richnode is focused & disable repo name editing by non-owner users

### DIFF
--- a/ui/src/components/RichNode.tsx
+++ b/ui/src/components/RichNode.tsx
@@ -49,6 +49,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import ViewComfyIcon from "@mui/icons-material/ViewComfy";
 import RectangleIcon from "@mui/icons-material/Rectangle";
 import DisabledByDefaultIcon from "@mui/icons-material/DisabledByDefault";
+import { resetSelection } from "../lib/nodes";
 
 import {
   BoldExtension,
@@ -156,6 +157,7 @@ const MyEditor = ({
   const setPodContent = useStore(store, (state) => state.setPodContent);
   // initial content
   const getPod = useStore(store, (state) => state.getPod);
+  const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
   const pod = getPod(id);
   const { manager, state, setState } = useRemirror({
     extensions: () => [
@@ -192,9 +194,13 @@ const MyEditor = ({
   return (
     <Box
       className="remirror-theme"
+      onFocus={() => {
+        if (resetSelection()) nodesMap.set(id, nodesMap.get(id) as Node);
+      }}
       sx={{
         cursor: "text",
       }}
+      overflow="auto"
     >
       <AllStyledComponent>
         <ThemeProvider>
@@ -203,6 +209,10 @@ const MyEditor = ({
               manager={manager}
               // initialContent={state}
               state={state}
+              // FIXME: onFocus is not working
+              // onFocus={() => {
+              //   console.log("onFocus");
+              // }}
               onChange={(parameter) => {
                 let nextState = parameter.state;
                 setState(nextState);
@@ -464,19 +474,6 @@ export const RichNode = memo<Props>(function ({
           className="nodrag"
         >
           {role !== RoleType.GUEST && (
-            <Tooltip title="Run (shift-enter)">
-              <IconButton
-                size="small"
-                onClick={() => {
-                  clearResults(id);
-                  wsRun(id);
-                }}
-              >
-                <PlayCircleOutlineIcon fontSize="inherit" />
-              </IconButton>
-            </Tooltip>
-          )}
-          {role !== RoleType.GUEST && (
             <Tooltip title="Delete">
               <IconButton
                 size="small"
@@ -488,16 +485,6 @@ export const RichNode = memo<Props>(function ({
               </IconButton>
             </Tooltip>
           )}
-          <Tooltip title="Change layout">
-            <IconButton
-              size="small"
-              onClick={() => {
-                setLayout(layout === "bottom" ? "right" : "bottom");
-              }}
-            >
-              <ViewComfyIcon fontSize="inherit" />
-            </IconButton>
-          </Tooltip>
         </Box>
       </Box>
       <Box>

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState, useRef, useContext } from "react";
 
 import { useStore } from "zustand";
 
-import { createRepoStore, RepoContext } from "../lib/store";
+import { createRepoStore, RepoContext, RoleType } from "../lib/store";
 
 import useMe from "../lib/me";
 import { Canvas } from "../components/Canvas";
@@ -35,6 +35,7 @@ function RepoWrapper({ children, id }) {
   const repoName = useStore(store, (state) => state.repoName);
   const setRepoName = useStore(store, (state) => state.setRepoName);
   const setShareOpen = useStore(store, (state) => state.setShareOpen);
+  const role = useStore(store, (state) => state.role);
 
   const [updateRepo, { error }] = useMutation(
     gql`
@@ -83,6 +84,7 @@ function RepoWrapper({ children, id }) {
                 sx={{
                   maxWidth: "100%",
                 }}
+                disabled={role !== RoleType.OWNER}
                 onChange={(e) => {
                   const name = e.target.value;
                   setRepoName(name);


### PR DESCRIPTION
1. unselect all nodes when a RichNode is focused
2. remove run&change layout button for RichNodes
3. disable editing repo name for non-owner users

close https://github.com/codepod-io/codepod/issues/166