### PR TITLE
[WIP] generate a sharable image/png when copying

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -531,18 +531,35 @@ const CodeNode = memo<Props>(function ({
     }
   }, [data.parent, setPodParent, id]);
 
+  const getPicture = async (pod) => {
+    const requesOptions = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: pod.content }),
+      mode: "no-cors" as RequestMode,
+      accept: "image/png",
+    };
+    const res = await fetch("http://localhost:3099/api/cook", requesOptions);
+    const pic = await res.blob();
+    // navigator.clipboard.write([new ClipboardItem({ "image/png": pic })]);
+  };
+
   const onCopy = useCallback(
-    (clipboardData: any) => {
+    async (clipboardData: any) => {
       const pod = getPod(id);
       if (!pod) return;
-      clipboardData.setData("text/plain", pod.content);
-      clipboardData.setData(
-        "application/json",
-        JSON.stringify({
-          type: "pod",
-          data: pod,
-        })
-      );
+
+      clipboardData.setData("text/plain", "");
+      // clipboardData.clearData();
+      // clipboardData.setData(
+      //   "application/json",
+      //   JSON.stringify({
+      //     type: "pod",
+      //     data: pod,
+      //   })
+      // );
+      getPicture(pod);
+      console.log("copied", clipboardData);
     },
     [getPod, id]
   );


### PR DESCRIPTION
I use this API of [carbon](https://carbon.now.sh/): https://github.com/petersolopov/carbonara

Notice that `localhost` doesn't allow [CROS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS), we can't send a request of `application/json` payload to `localhost:3099/api/cook`, the actual request body is in `text/plain` format. So you may need to skip the content type checking by deleting this line https://github.com/petersolopov/carbonara/blob/master/src/utils.js#L118, and then run the deployment command of this api by:

```
git clone https://github.com/petersolopov/carbonara
cd carbonara
docker build -t local/carbonara .
docker run -p 3099:3000 local/carbonara -it
```

To try if the api running normally, run a `cURL` command:

```sh
curl -L http://127.0.0.1:3099/api/cook \
-X POST \
-H 'Content-Type: application/json' \
-d '{
        "code": "sum(range(114))"
    }' \
> test.png
```


![image](https://user-images.githubusercontent.com/10118462/209452701-9e594ebc-4d24-4641-bca4-1abb4a7c3f37.png)


Now, the fetch request can be viewed with correct preview in devtools, I just wonder how to take it out.

![image](https://user-images.githubusercontent.com/10118462/209452736-8dc3e9f7-105b-4250-a317-caa0f4891a0a.png)
