### PR TITLE
fix repo name sync time and UI

### DIFF
--- a/ui/src/lib/store/repoMetaSlice.tsx
+++ b/ui/src/lib/store/repoMetaSlice.tsx
@@ -4,6 +4,7 @@ import produce from "immer";
 import { Doc } from "yjs";
 import { WebsocketProvider } from "y-websocket";
 import { MyState } from ".";
+import { gql } from "@apollo/client";
 
 let serverURL;
 if (window.location.protocol === "http:") {
@@ -15,9 +16,12 @@ console.log("yjs server url: ", serverURL);
 
 export interface RepoMetaSlice {
   repoName: string | null;
+  repoNameSyncing: boolean;
+  repoNameDirty: boolean;
   repoId: string | null;
   setRepo: (repoId: string) => void;
   setRepoName: (name: string) => void;
+  remoteUpdateRepoName: (client) => void;
 }
 
 export const createRepoMetaSlice: StateCreator<
@@ -28,6 +32,8 @@ export const createRepoMetaSlice: StateCreator<
 > = (set, get) => ({
   repoId: null,
   repoName: null,
+  repoNameSyncing: false,
+  repoNameDirty: false,
   setRepo: (repoId: string) =>
     set(
       produce((state: MyState) => {
@@ -51,8 +57,43 @@ export const createRepoMetaSlice: StateCreator<
     ),
   setRepoName: (name) => {
     set(
-      produce((state) => {
+      produce((state: MyState) => {
         state.repoName = name;
+        state.repoNameDirty = true;
+      })
+    );
+  },
+  remoteUpdateRepoName: async (client) => {
+    if (get().repoNameSyncing) return;
+    if (!get().repoNameDirty) return;
+    let { repoId, repoName } = get();
+    if (!repoId || !repoName) return;
+    // Prevent double syncing.
+    set(
+      produce((state: MyState) => {
+        state.repoNameSyncing = true;
+      })
+    );
+    // Do the actual syncing.
+    await client.mutate({
+      mutation: gql`
+        mutation UpdateRepo($id: ID!, $name: String) {
+          updateRepo(id: $id, name: $name)
+        }
+      `,
+      variables: {
+        id: repoId,
+        name: repoName,
+      },
+      refetchQueries: ["GetRepos", "GetCollabRepos"],
+    });
+    set((state) =>
+      produce(state, (state) => {
+        state.repoNameSyncing = false;
+        // Set it as synced IF the name is still the same.
+        if (state.repoName === repoName) {
+          state.repoNameDirty = false;
+        }
       })
     );
   },

--- a/ui/src/lib/store/repoMetaSlice.tsx
+++ b/ui/src/lib/store/repoMetaSlice.tsx
@@ -67,7 +67,7 @@ export const createRepoMetaSlice: StateCreator<
     if (get().repoNameSyncing) return;
     if (!get().repoNameDirty) return;
     let { repoId, repoName } = get();
-    if (!repoId || !repoName) return;
+    if (!repoId) return;
     // Prevent double syncing.
     set(
       produce((state: MyState) => {

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -52,7 +52,6 @@ const HeaderItem = memo<any>(({ id }) => {
       remoteUpdateRepoName(apolloClient);
     }, 1000);
     return () => {
-      console.log("removing interval");
       clearInterval(intervalId);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -8,7 +8,9 @@ import ShareIcon from "@mui/icons-material/Share";
 import Button from "@mui/material/Button";
 import { gql, useApolloClient, useMutation } from "@apollo/client";
 
-import { useEffect, useState, useRef, useContext } from "react";
+import { useEffect, useState, useRef, useContext, memo } from "react";
+
+import * as React from "react";
 
 import { useStore } from "zustand";
 
@@ -19,12 +21,118 @@ import { Canvas } from "../components/Canvas";
 import { Header } from "../components/Header";
 import { Sidebar } from "../components/Sidebar";
 import { useLocalStorage } from "../hooks/useLocalStorage";
-import { Stack, TextField } from "@mui/material";
+import { Stack, TextField, Tooltip } from "@mui/material";
 import { useAuth } from "../lib/auth";
 import { initParser } from "../lib/parser";
 
+import { usePrompt } from "../lib/prompt";
+
 const DrawerWidth = 240;
 const SIDEBAR_KEY = "sidebar";
+
+const HeaderItem = memo<any>(({ id }) => {
+  const store = useContext(RepoContext)!;
+  const repoName = useStore(store, (state) => state.repoName);
+  const repoNameDirty = useStore(store, (state) => state.repoNameDirty);
+  const setRepoName = useStore(store, (state) => state.setRepoName);
+  const apolloClient = useApolloClient();
+  const remoteUpdateRepoName = useStore(
+    store,
+    (state) => state.remoteUpdateRepoName
+  );
+  const role = useStore(store, (state) => state.role);
+
+  usePrompt(
+    "Repo name not saved. Do you want to leave this page?",
+    repoNameDirty
+  );
+
+  useEffect(() => {
+    let intervalId = setInterval(() => {
+      remoteUpdateRepoName(apolloClient);
+    }, 1000);
+    return () => {
+      console.log("removing interval");
+      clearInterval(intervalId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const [focus, setFocus] = useState(false);
+  const [enter, setEnter] = useState(false);
+
+  const textfield = (
+    <TextField
+      hiddenLabel
+      placeholder="Untitled"
+      value={repoName || ""}
+      size="small"
+      variant={focus ? undefined : "standard"}
+      onFocus={() => {
+        setFocus(true);
+      }}
+      onKeyDown={(e) => {
+        if (["Enter", "Escape"].includes(e.key)) {
+          e.preventDefault();
+          setFocus(false);
+        }
+      }}
+      onMouseEnter={() => {
+        setEnter(true);
+      }}
+      onMouseLeave={() => {
+        setEnter(false);
+      }}
+      autoFocus={focus ? true : false}
+      onBlur={() => {
+        setFocus(false);
+      }}
+      InputProps={{
+        ...(focus
+          ? {}
+          : {
+              disableUnderline: true,
+            }),
+      }}
+      sx={{
+        maxWidth: "100%",
+        border: "none",
+      }}
+      disabled={role !== RoleType.OWNER}
+      onChange={(e) => {
+        const name = e.target.value;
+        setRepoName(name);
+      }}
+    />
+  );
+
+  return (
+    <Stack
+      direction="row"
+      sx={{
+        alignItems: "center",
+      }}
+      spacing={1}
+    >
+      {!focus && enter ? (
+        <Tooltip
+          title="Edit"
+          sx={{
+            margin: 0,
+            padding: 0,
+          }}
+          // placement="right"
+          followCursor
+        >
+          {textfield}
+        </Tooltip>
+      ) : (
+        textfield
+      )}
+      {repoNameDirty && <Box>saving..</Box>}
+    </Stack>
+  );
+});
 
 function RepoWrapper({ children, id }) {
   // this component is used to provide a foldable layout
@@ -32,19 +140,8 @@ function RepoWrapper({ children, id }) {
 
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const repoName = useStore(store, (state) => state.repoName);
-  const setRepoName = useStore(store, (state) => state.setRepoName);
-  const setShareOpen = useStore(store, (state) => state.setShareOpen);
-  const role = useStore(store, (state) => state.role);
 
-  const [updateRepo, { error }] = useMutation(
-    gql`
-      mutation UpdateRepo($id: ID!, $name: String) {
-        updateRepo(id: $id, name: $name)
-      }
-    `,
-    { refetchQueries: ["GetRepos", "GetCollabRepos"] }
-  );
+  const setShareOpen = useStore(store, (state) => state.setShareOpen);
 
   return (
     <Box
@@ -74,31 +171,7 @@ function RepoWrapper({ children, id }) {
         <Header
           open={open}
           drawerWidth={DrawerWidth}
-          breadcrumbItem={
-            <Stack direction="row">
-              <TextField
-                hiddenLabel
-                placeholder="Untitled"
-                value={repoName || ""}
-                size="small"
-                sx={{
-                  maxWidth: "100%",
-                }}
-                disabled={role !== RoleType.OWNER}
-                onChange={(e) => {
-                  const name = e.target.value;
-                  setRepoName(name);
-                  updateRepo({
-                    variables: {
-                      id,
-                      name,
-                    },
-                  });
-                }}
-              />
-              {error && <Box>ERROR: {error.message}</Box>}
-            </Stack>
-          }
+          breadcrumbItem={<HeaderItem id={id} />}
           shareButton={
             <Button
               endIcon={<ShareIcon />}


### PR DESCRIPTION
1. now sync repo name every second instead of every keystroke
2. the repo name on the repo list page will be up-to-date
3. UI changes: show an "edit" tooltip on hover, and show editable textfield when focused.

Screenshot:

<img src="https://user-images.githubusercontent.com/4576201/210100597-f1543269-24b4-41be-a7c6-472c037a6e0f.gif" width="500"/>
