### PR TITLE
fix: stable retry connect for runtime and yjs sockets

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -100,7 +100,7 @@ function SidebarRuntime() {
   const { loading, me } = useMe();
   let { id: repoId } = useParams();
   // get runtime information
-  const { data } = useQuery(gql`
+  const { data, error } = useQuery(gql`
     query GetRuntimeInfo {
       infoRuntime(sessionId: "${me.id}_${repoId}") {
         startedAt
@@ -110,13 +110,13 @@ function SidebarRuntime() {
   // update time every second
   let [uptime, setUptime] = useState("");
   useEffect(() => {
-    if (data?.infoRuntime.startedAt) {
+    if (data?.infoRuntime?.startedAt) {
       setUptime(getUpTime(data.infoRuntime.startedAt));
     }
   }, [data]);
   useEffect(() => {
     const interval = setInterval(() => {
-      if (data?.infoRuntime.startedAt) {
+      if (data?.infoRuntime?.startedAt) {
         setUptime(getUpTime(data.infoRuntime.startedAt));
       }
     }, 1000);

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -96,22 +96,9 @@ function SidebarRuntime() {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const runtimeConnected = useStore(store, (state) => state.runtimeConnected);
-  const wsConnect = useStore(store, (state) => state.wsConnect);
-  const client = useApolloClient();
+  const runtimeConnecting = useStore(store, (state) => state.runtimeConnecting);
   const { loading, me } = useMe();
   let { id: repoId } = useParams();
-  // periodically check if the runtime is still connected
-  useEffect(() => {
-    if (me && !runtimeConnected) {
-      wsConnect(client, `${me.id}_${repoId}`);
-    }
-    const interval = setInterval(() => {
-      if (me && !runtimeConnected) {
-        wsConnect(client, `${me.id}_${repoId}`);
-      }
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [client, me, repoId, runtimeConnected, wsConnect]);
   // get runtime information
   const { data } = useQuery(gql`
     query GetRuntimeInfo {
@@ -140,7 +127,7 @@ function SidebarRuntime() {
   return (
     <Box>
       <Box>
-        {runtimeConnected ? (
+        {runtimeConnected && (
           <Stack>
             <Box>
               Runtime{" "}
@@ -151,19 +138,8 @@ function SidebarRuntime() {
             <Box>Uptime: {uptime}</Box>
             <SidebarKernel />
           </Stack>
-        ) : (
-          <Box>
-            connecting ..
-            {/* <Button
-              size="small"
-              onClick={() => {
-                wsConnect(client, `${me.id}_${repoId}`);
-              }}
-            >
-              Connect
-            </Button> */}
-          </Box>
         )}
+        {runtimeConnecting && <Box>connecting ..</Box>}
       </Box>
     </Box>
   );

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -100,17 +100,13 @@ function SidebarRuntime() {
   const client = useApolloClient();
   const { loading, me } = useMe();
   let { id: repoId } = useParams();
-  useEffect(() => {
-    if (me) {
-      console.log("Connecting to runtime at the beginning ..");
-      wsConnect(client, `${me.id}_${repoId}`);
-    }
-  }, [client, me, repoId, wsConnect]);
   // periodically check if the runtime is still connected
   useEffect(() => {
+    if (me && !runtimeConnected) {
+      wsConnect(client, `${me.id}_${repoId}`);
+    }
     const interval = setInterval(() => {
       if (me && !runtimeConnected) {
-        console.log("Runtime disconnected, reconnecting ...");
         wsConnect(client, `${me.id}_${repoId}`);
       }
     }, 1000);
@@ -249,14 +245,12 @@ function SyncStatus() {
   );
 
   useEffect(() => {
-    console.log("Setting interval");
     let id = setInterval(() => {
       // websocket resets after 60s of idle by most firewalls
       console.log("periodically saving ..");
       remoteUpdateAllPods(client);
     }, 1000);
     return () => {
-      console.log("removing interval");
       clearInterval(id);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -48,6 +48,7 @@ const HeaderItem = memo<any>(({ id }) => {
   );
 
   useEffect(() => {
+    remoteUpdateRepoName(apolloClient);
     let intervalId = setInterval(() => {
       remoteUpdateRepoName(apolloClient);
     }, 1000);
@@ -261,7 +262,6 @@ function RepoImpl() {
   useEffect(() => {
     if (provider) {
       const awareness = provider.awareness;
-      console.log(awareness);
       awareness.on("update", (change) => {
         const states = awareness.getStates();
         const nodes = change.added.concat(change.updated);
@@ -345,10 +345,16 @@ export default function Repo() {
   useEffect(() => {
     setRepo(id!);
     connectYjs();
-    // const provider = useStore(store, (state) => state.provider);
-    // clean up the connected provider after exiting the page
-    return disconnectYjs;
-  }, [connectYjs, disconnectYjs, id, setRepo, store]);
+
+    let intervalId = setInterval(() => {
+      connectYjs();
+    }, 1000);
+    return () => {
+      clearInterval(intervalId);
+      // clean up the connected provider after exiting the page
+      disconnectYjs();
+    };
+  }, [connectYjs, disconnectYjs, id, setRepo]);
   return (
     <RepoContext.Provider value={store}>
       <RepoImpl />


### PR DESCRIPTION
Properly set `connecting` and `connected`, and retry (every second) if not `connected` and not `connecting` (so that there won't be duplicated connection retries.