### PR TITLE
smooth runtime connection with restart button

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import Drawer from "@mui/material/Drawer";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import Grid from "@mui/material/Grid";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { useSnackbar, VariantType } from "notistack";
 
 import { gql, useQuery, useMutation, useApolloClient } from "@apollo/client";
@@ -98,6 +99,8 @@ function SidebarRuntime() {
   const runtimeConnected = useStore(store, (state) => state.runtimeConnected);
   const runtimeConnecting = useStore(store, (state) => state.runtimeConnecting);
   const { loading, me } = useMe();
+  const client = useApolloClient();
+  const restartRuntime = useStore(store, (state) => state.restartRuntime);
   let { id: repoId } = useParams();
   // get runtime information
   const { data, error } = useQuery(gql`
@@ -134,12 +137,29 @@ function SidebarRuntime() {
               <Box component="span" color="green">
                 connected
               </Box>
+              <Tooltip title="restart">
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    restartRuntime(client, `${me.id}_${repoId}`);
+                  }}
+                >
+                  <RestartAltIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
             </Box>
             <Box>Uptime: {uptime}</Box>
+
             <SidebarKernel />
           </Stack>
         )}
-        {runtimeConnecting && <Box>connecting ..</Box>}
+        {runtimeConnecting && <Box>Runtime connecting ..</Box>}
+        {!runtimeConnected && !runtimeConnecting && (
+          // NOTE: on restart runtime, the first several ws connection will
+          // fail. Since we re-connect every second, here are showing the same
+          // message to user.
+          <Box>Runtime connecting ..</Box>
+        )}
       </Box>
     </Box>
   );
@@ -177,7 +197,7 @@ function SidebarKernel() {
                   wsRequestStatus({ lang });
                 }}
               >
-                <RefreshIcon />
+                <RefreshIcon fontSize="inherit" />
               </IconButton>
             </Tooltip>
             <Tooltip title="interrupt">
@@ -187,7 +207,7 @@ function SidebarKernel() {
                   wsInterruptKernel({ lang });
                 }}
               >
-                <StopIcon />
+                <StopIcon fontSize="inherit" />
               </IconButton>
             </Tooltip>
           </Box>

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -237,6 +237,7 @@ function useRuntime() {
   const runtimeConnected = useStore(store, (state) => state.runtimeConnected);
   const wsConnect = useStore(store, (state) => state.wsConnect);
   const client = useApolloClient();
+  const socket = useStore(store, (state) => state.socket);
   const { loading, me } = useMe();
   let { id: repoId } = useParams();
   // periodically check if the runtime is still connected
@@ -251,6 +252,17 @@ function useRuntime() {
     }, 1000);
     return () => clearInterval(interval);
   }, [client, me, repoId, runtimeConnected, wsConnect]);
+  // Periodically send ping to the server to keep the connection alive.
+  // websocket resets after 60s of idle by most firewalls
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (socket) {
+        console.log("sending ping to keep runtime alive ..");
+        socket.send(JSON.stringify({ type: "ping" }));
+      }
+    }, 30000);
+    return () => clearInterval(interval);
+  }, [socket]);
 }
 
 function RepoImpl() {


### PR DESCRIPTION
Now the runtime connection feedback will be more smooth (no blinking). There's a restart button in the sidebar to restart the kernel.