### PR TITLE
Fix: some miscellaneous & tiny bugs 

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -808,8 +808,6 @@ function CanvasImpl() {
           multiSelectionKeyCode={isMac ? "Meta" : "Control"}
           // TODO restore previous viewport
           defaultViewport={{ zoom: 1, x: 0, y: 0 }}
-          // prevent the nodes selected by space or enter
-          nodesFocusable={false}
         >
           <Box>
             <MiniMap

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -130,7 +130,7 @@ function useCopyPaste(reactFlowWrapper) {
 
   const getPod = useStore(store, (state) => state.getPod);
   const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
-  const isGuest = useStore(store, (state) => state.isGuest());
+  const isGuest = useStore(store, (state) => state.role === "GUEST");
 
   const reactFlowInstance = useReactFlow();
 
@@ -701,7 +701,7 @@ function CanvasImpl() {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const repoId = useStore(store, (state) => state.repoId);
-  const isGuest = useStore(store, (state) => state.isGuest());
+  const isGuest = useStore(store, (state) => state.role === "GUEST");
 
   const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
   const shareOpen = useStore(store, (state) => state.shareOpen);

--- a/ui/src/components/CanvasContextMenu.tsx
+++ b/ui/src/components/CanvasContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useStore } from "zustand";
-import { RepoContext, RoleType } from "../lib/store";
+import { RepoContext } from "../lib/store";
 import Box from "@mui/material/Box";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
@@ -40,11 +40,11 @@ export function CanvasContextMenu(props) {
     store,
     (state) => state.flipShowLineNumbers
   );
-  const role = useStore(store, (state) => state.role);
+  const isGuest = useStore(store, (state) => state.isGuest());
   return (
     <Box sx={paneMenuStyle(props.x, props.y)}>
       <MenuList className="paneContextMenu">
-        {role !== RoleType.GUEST && (
+        {!isGuest && (
           <MenuItem onClick={props.addCode} sx={ItemStyle}>
             <ListItemIcon>
               <CodeIcon />
@@ -52,7 +52,7 @@ export function CanvasContextMenu(props) {
             <ListItemText>New Code</ListItemText>
           </MenuItem>
         )}
-        {role !== RoleType.GUEST && (
+        {!isGuest && (
           <MenuItem onClick={props.addRich} sx={ItemStyle}>
             <ListItemIcon>
               <NoteIcon />
@@ -60,7 +60,7 @@ export function CanvasContextMenu(props) {
             <ListItemText>New Note</ListItemText>
           </MenuItem>
         )}
-        {role !== RoleType.GUEST && (
+        {!isGuest && (
           <MenuItem onClick={props.addScope} sx={ItemStyle}>
             <ListItemIcon>
               <PostAddIcon />

--- a/ui/src/components/CanvasContextMenu.tsx
+++ b/ui/src/components/CanvasContextMenu.tsx
@@ -40,7 +40,7 @@ export function CanvasContextMenu(props) {
     store,
     (state) => state.flipShowLineNumbers
   );
-  const isGuest = useStore(store, (state) => state.isGuest());
+  const isGuest = useStore(store, (state) => state.role === "GUEST");
   return (
     <Box sx={paneMenuStyle(props.x, props.y)}>
       <MenuList className="paneContextMenu">

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -3,7 +3,7 @@ import { useState, useContext, memo, useCallback, useEffect } from "react";
 import MonacoEditor, { MonacoDiffEditor } from "react-monaco-editor";
 import { monaco } from "react-monaco-editor";
 import { useStore } from "zustand";
-import { RepoContext, RoleType } from "../lib/store";
+import { RepoContext } from "../lib/store";
 import { MonacoBinding } from "y-monaco";
 import { resetSelection } from "../lib/nodes";
 import { useReactFlow } from "reactflow";
@@ -385,7 +385,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   console.debug("[perf] rendering MyMonaco", id);
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const readOnly = useStore(store, (state) => state.role === RoleType.GUEST);
+  const readOnly = useStore(store, (state) => state.isGuest());
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const getPod = useStore(store, (state) => state.getPod);
   const setCurrentEditor = useStore(store, (state) => state.setCurrentEditor);

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -385,7 +385,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   console.debug("[perf] rendering MyMonaco", id);
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const readOnly = useStore(store, (state) => state.isGuest());
+  const readOnly = useStore(store, (state) => state.role === "GUEST");
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const getPod = useStore(store, (state) => state.getPod);
   const setCurrentEditor = useStore(store, (state) => state.setCurrentEditor);

--- a/ui/src/components/ShareProjDialog.tsx
+++ b/ui/src/components/ShareProjDialog.tsx
@@ -25,7 +25,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import React, { useContext, useReducer } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { useStore } from "zustand";
-import { RepoContext, RoleType } from "../lib/store";
+import { RepoContext } from "../lib/store";
 import { useApolloClient } from "@apollo/client";
 
 const initialState = { showInfo: false, status: "info", message: "wait..." };
@@ -199,7 +199,7 @@ export function ShareProjDialog({
   const setShareOpen = useStore(store, (state) => state.setShareOpen);
   const updateVisibility = useStore(store, (state) => state.updateVisibility);
   const addCollaborator = useStore(store, (state) => state.addCollaborator);
-  const isOwner = useStore(store, (state) => state.role === RoleType.OWNER);
+  const isOwner = useStore(store, (state) => state.isOwner());
   const title = useStore(store, (state) => state.repoName || "Untitled");
   const url = `${window.location.protocol}//${window.location.host}/repo/${id}`;
   const inputRef = React.useRef<HTMLInputElement>(null);

--- a/ui/src/components/ShareProjDialog.tsx
+++ b/ui/src/components/ShareProjDialog.tsx
@@ -199,7 +199,7 @@ export function ShareProjDialog({
   const setShareOpen = useStore(store, (state) => state.setShareOpen);
   const updateVisibility = useStore(store, (state) => state.updateVisibility);
   const addCollaborator = useStore(store, (state) => state.addCollaborator);
-  const isOwner = useStore(store, (state) => state.isOwner());
+  const isOwner = useStore(store, (state) => state.role === "OWNER");
   const title = useStore(store, (state) => state.repoName || "Untitled");
   const url = `${window.location.protocol}//${window.location.host}/repo/${id}`;
   const inputRef = React.useRef<HTMLInputElement>(null);

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -347,7 +347,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   // FIXME: improve the implementation logic
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const isGuest = useStore(store, (state) => state.isGuest());
+  const isGuest = useStore(store, (state) => state.role === "GUEST");
   return (
     <>
       <Box

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -19,7 +19,7 @@ import { useStore } from "zustand";
 
 import { usePrompt } from "../lib/prompt";
 
-import { RepoContext, RoleType } from "../lib/store";
+import { RepoContext } from "../lib/store";
 
 import useMe from "../lib/me";
 import { FormControlLabel, FormGroup, Stack, Switch } from "@mui/material";
@@ -347,7 +347,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   // FIXME: improve the implementation logic
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const role = useStore(store, (state) => state.role);
+  const isGuest = useStore(store, (state) => state.isGuest());
   return (
     <>
       <Box
@@ -400,7 +400,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           }}
         >
           <Grid container spacing={2}>
-            {role === RoleType.GUEST ? (
+            {isGuest ? (
               <>
                 <Grid item xs={12}>
                   <Box> Read-only Mode: You are a guest. </Box>

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -238,7 +238,7 @@ export const CodeNode = memo<Props>(function ({
   const getPod = useStore(store, (state) => state.getPod);
   const setCutting = useStore(store, (state) => state.setCutting);
   const pod = getPod(id);
-  const isGuest = useStore(store, (state) => state.isGuest());
+  const isGuest = useStore(store, (state) => state.role === "GUEST");
   const width = useStore(store, (state) => state.pods[id]?.width);
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
   const index = useStore(

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -46,7 +46,7 @@ import Ansi from "ansi-to-react";
 
 import { useStore } from "zustand";
 
-import { RepoContext, RoleType } from "../../lib/store";
+import { RepoContext } from "../../lib/store";
 
 import { MyMonaco } from "../MyMonaco";
 import { useApolloClient } from "@apollo/client";
@@ -238,7 +238,7 @@ export const CodeNode = memo<Props>(function ({
   const getPod = useStore(store, (state) => state.getPod);
   const setCutting = useStore(store, (state) => state.setCutting);
   const pod = getPod(id);
-  const role = useStore(store, (state) => state.role);
+  const isGuest = useStore(store, (state) => state.isGuest());
   const width = useStore(store, (state) => state.pods[id]?.width);
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
   const index = useStore(
@@ -305,7 +305,7 @@ export const CodeNode = memo<Props>(function ({
 
   // onsize is banned for a guest, FIXME: ugly code
   const Wrap = (child) =>
-    role === RoleType.GUEST ? (
+    isGuest ? (
       <>{child}</>
     ) : (
       <ResizableBox
@@ -375,7 +375,7 @@ export const CodeNode = memo<Props>(function ({
             inputRef={inputRef}
             className="nodrag"
             defaultValue={data.name || ""}
-            disabled={role === RoleType.GUEST}
+            disabled={isGuest}
             onBlur={(e) => {
               const name = e.target.value;
               if (name === data.name) return;
@@ -426,7 +426,7 @@ export const CodeNode = memo<Props>(function ({
             }
           }}
         >
-          {role !== RoleType.GUEST && (
+          {!isGuest && (
             <Tooltip title="Run (shift-enter)">
               <IconButton
                 size="small"
@@ -449,19 +449,21 @@ export const CodeNode = memo<Props>(function ({
               </IconButton>
             </Tooltip>
           </CopyToClipboard>
-          <CopyToClipboard
-            text="dummy"
-            options={
-              { debug: true, format: "text/plain", onCopy: onCut } as any
-            }
-          >
-            <Tooltip title="Cut">
-              <IconButton size="small">
-                <ContentCutIcon fontSize="inherit" />
-              </IconButton>
-            </Tooltip>
-          </CopyToClipboard>
-          {role !== RoleType.GUEST && (
+          {!isGuest && (
+            <CopyToClipboard
+              text="dummy"
+              options={
+                { debug: true, format: "text/plain", onCopy: onCut } as any
+              }
+            >
+              <Tooltip title="Cut">
+                <IconButton size="small">
+                  <ContentCutIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+            </CopyToClipboard>
+          )}
+          {!isGuest && (
             <Tooltip title="Delete">
               <IconButton
                 size="small"

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -195,7 +195,7 @@ const MyEditor = ({
     <Box
       className="remirror-theme"
       onFocus={() => {
-        // FIXEME: it's a dummy update in nodesMap to trigger the local update to clear all selection
+        // FIXME: it's a dummy update in nodesMap to trigger the local update to clear all selection
         if (resetSelection()) nodesMap.set(id, nodesMap.get(id) as Node);
       }}
       sx={{

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -158,7 +158,7 @@ const MyEditor = ({
   const getPod = useStore(store, (state) => state.getPod);
   const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
   const pod = getPod(id);
-  const isGuest = useStore(store, (state) => state.isGuest());
+  const isGuest = useStore(store, (state) => state.role === "GUEST");
   const { manager, state, setState } = useRemirror({
     extensions: () => [
       new PlaceholderExtension({ placeholder }),
@@ -283,7 +283,7 @@ export const RichNode = memo<Props>(function ({
   const setPodName = useStore(store, (state) => state.setPodName);
   const getPod = useStore(store, (state) => state.getPod);
   const pod = getPod(id);
-  const isGuest = useStore(store, (state) => state.isGuest());
+  const isGuest = useStore(store, (state) => state.role === "GUEST");
   const width = useStore(store, (state) => state.pods[id]?.width);
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
   const index = useStore(

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -14,7 +14,7 @@ import { ResizableBox } from "react-resizable";
 import { useApolloClient } from "@apollo/client";
 
 import { useStore } from "zustand";
-import { RepoContext, RoleType } from "../../lib/store";
+import { RepoContext } from "../../lib/store";
 
 import ReactFlow, {
   addEdge,
@@ -158,6 +158,7 @@ const MyEditor = ({
   const getPod = useStore(store, (state) => state.getPod);
   const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
   const pod = getPod(id);
+  const isGuest = useStore(store, (state) => state.isGuest());
   const { manager, state, setState } = useRemirror({
     extensions: () => [
       new PlaceholderExtension({ placeholder }),
@@ -194,6 +195,7 @@ const MyEditor = ({
     <Box
       className="remirror-theme"
       onFocus={() => {
+        // FIXEME: it's a dummy update in nodesMap to trigger the local update to clear all selection
         if (resetSelection()) nodesMap.set(id, nodesMap.get(id) as Node);
       }}
       sx={{
@@ -208,6 +210,7 @@ const MyEditor = ({
               manager={manager}
               // initialContent={state}
               state={state}
+              editable={!isGuest}
               // FIXME: onFocus is not working
               // onFocus={() => {
               //   console.log("onFocus");
@@ -280,7 +283,7 @@ export const RichNode = memo<Props>(function ({
   const setPodName = useStore(store, (state) => state.setPodName);
   const getPod = useStore(store, (state) => state.getPod);
   const pod = getPod(id);
-  const role = useStore(store, (state) => state.role);
+  const isGuest = useStore(store, (state) => state.isGuest());
   const width = useStore(store, (state) => state.pods[id]?.width);
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
   const index = useStore(
@@ -311,7 +314,7 @@ export const RichNode = memo<Props>(function ({
 
   // onsize is banned for a guest, FIXME: ugly code
   const Wrap = (child) =>
-    role === RoleType.GUEST ? (
+    isGuest ? (
       <>{child}</>
     ) : (
       <ResizableBox
@@ -385,7 +388,7 @@ export const RichNode = memo<Props>(function ({
             inputRef={inputRef}
             className="nodrag"
             defaultValue={data.name || ""}
-            disabled={role === RoleType.GUEST}
+            disabled={isGuest}
             onBlur={(e) => {
               const name = e.target.value;
               if (name === data.name) return;
@@ -417,7 +420,7 @@ export const RichNode = memo<Props>(function ({
           }}
           className="nodrag"
         >
-          {role !== RoleType.GUEST && (
+          {!isGuest && (
             <Tooltip title="Delete">
               <IconButton
                 size="small"

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -34,7 +34,7 @@ import Moveable from "react-moveable";
 
 import { useStore } from "zustand";
 
-import { RepoContext, RoleType } from "../../lib/store";
+import { RepoContext } from "../../lib/store";
 
 interface Props {
   data: any;
@@ -65,7 +65,7 @@ export const ScopeNode = memo<Props>(function ScopeNode({
     translate: [0, 0],
   });
   // const selected = useStore(store, (state) => state.pods[id]?.selected);
-  const role = useStore(store, (state) => state.role);
+  const isGuest = useStore(store, (state) => state.isGuest());
   const inputRef = useRef<HTMLInputElement>(null);
 
   const onResize = useCallback(({ width, height, offx, offy }) => {
@@ -115,7 +115,7 @@ export const ScopeNode = memo<Props>(function ScopeNode({
           justifyContent: "center",
         }}
       >
-        {role !== RoleType.GUEST && (
+        {!isGuest && (
           <Tooltip title="Delete" className="nodrag">
             <IconButton
               size="small"
@@ -176,7 +176,7 @@ export const ScopeNode = memo<Props>(function ScopeNode({
                   // setPodName({ id, name });
                 }}
                 inputRef={inputRef}
-                disabled={role === RoleType.GUEST}
+                disabled={isGuest}
                 inputProps={{
                   style: {
                     padding: "0px",
@@ -208,7 +208,7 @@ export const ScopeNode = memo<Props>(function ScopeNode({
         id="right"
         isConnectable={isConnectable}
       />
-      {selected && role !== RoleType.GUEST && (
+      {selected && !isGuest && (
         <Moveable
           target={target}
           resizable={true}

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -65,7 +65,7 @@ export const ScopeNode = memo<Props>(function ScopeNode({
     translate: [0, 0],
   });
   // const selected = useStore(store, (state) => state.pods[id]?.selected);
-  const isGuest = useStore(store, (state) => state.isGuest());
+  const isGuest = useStore(store, (state) => state.role === "GUEST");
   const inputRef = useRef<HTMLInputElement>(null);
 
   const onResize = useCallback(({ width, height, offx, offy }) => {

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useContext } from "react";
 import { applyNodeChanges, Node } from "reactflow";
-import { RepoContext, RoleType } from "./store";
+import { RepoContext } from "./store";
 import { nodetype2dbtype } from "./utils";
 import { useStore } from "zustand";
 import { useApolloClient } from "@apollo/client";
@@ -27,8 +27,7 @@ export function useNodesStateSynced() {
   const deletePod = useStore(store, (state) => state.deletePod);
   const setPodGeo = useStore(store, (state) => state.setPodGeo);
   const apolloClient = useApolloClient();
-  const role = useStore(store, (state) => state.role);
-  const isGuest = useStore(store, (state) => state.isGuest());
+  const isGuest = useStore(store, (state) => state.role === "GUEST");
   const ydoc = useStore(store, (state) => state.ydoc);
   const nodesMap = ydoc.getMap<Node>("pods");
   const clientId = useStore(
@@ -105,7 +104,7 @@ export function useNodesStateSynced() {
         }
       });
     },
-    [nodesMap, role, selectPod]
+    [nodesMap, isGuest, selectPod]
   );
 
   useEffect(() => {

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, useContext } from "react";
 import { applyNodeChanges, Node } from "reactflow";
 import { RepoContext, RoleType } from "./store";
+import { nodetype2dbtype } from "./utils";
 import { useStore } from "zustand";
 import { useApolloClient } from "@apollo/client";
 import { Transaction, YEvent } from "yjs";
@@ -122,13 +123,13 @@ export function useNodesStateSynced() {
                 id: node.id,
                 children: [],
                 parent: "ROOT",
-                type: node.type === "code" ? "CODE" : "DECK",
+                type: nodetype2dbtype(node.type || ""),
                 lang: "python",
                 x: node.position.x,
                 y: node.position.y,
                 width: node.width!,
                 height: node.height!,
-                name: node.data?.name,
+                name: node.data?.name || "",
                 dirty: false,
               });
             }

--- a/ui/src/lib/store/index.tsx
+++ b/ui/src/lib/store/index.tsx
@@ -9,12 +9,6 @@ import { SettingSlice, createSettingSlice } from "./settingSlice";
 import { RepoStateSlice, createRepoStateSlice } from "./repoStateSlice";
 import { RuntimeSlice, createRuntimeSlice } from "./runtimeSlice";
 
-export enum RoleType {
-  OWNER,
-  COLLABORATOR,
-  GUEST,
-}
-
 export type Pod = {
   id: string;
   name?: string;

--- a/ui/src/lib/store/repoStateSlice.tsx
+++ b/ui/src/lib/store/repoStateSlice.tsx
@@ -21,7 +21,7 @@ import { createRuntimeSlice, RuntimeSlice } from "./runtimeSlice";
 import { ApolloClient } from "@apollo/client";
 import { addAwarenessStyle } from "../styles";
 import { Annotation } from "../parser";
-import { MyState, Pod, RoleType } from ".";
+import { MyState, Pod } from ".";
 
 let serverURL;
 if (window.location.protocol === "http:") {
@@ -53,7 +53,7 @@ export interface RepoStateSlice {
   setShareOpen: (open: boolean) => void;
   setCutting: (id: string | null) => void;
   loadError: any;
-  role: RoleType;
+  role: "OWNER" | "COLLABORATOR" | "GUEST";
   isPublic: boolean;
   updateVisibility: (
     client: ApolloClient<object>,
@@ -71,8 +71,6 @@ export interface RepoStateSlice {
   yjsConnecting: boolean;
   connectYjs: () => void;
   disconnectYjs: () => void;
-  isOwner: () => boolean;
-  isGuest: () => boolean;
 }
 
 export const createRepoStateSlice: StateCreator<
@@ -96,7 +94,7 @@ export const createRepoStateSlice: StateCreator<
   clients: new Map(),
 
   loadError: null,
-  role: RoleType.GUEST,
+  role: "GUEST",
   collaborators: [],
   isPublic: false,
   shareOpen: false,
@@ -236,8 +234,6 @@ export const createRepoStateSlice: StateCreator<
         state.ydoc.destroy();
       })
     ),
-  isGuest: () => get().role === RoleType.GUEST,
-  isOwner: () => get().role === RoleType.OWNER,
 });
 
 function loadRepo(set, get) {
@@ -259,17 +255,17 @@ function loadRepo(set, get) {
         state.collaborators = collaborators;
         // set the user role in this repo
         if (userId === state.user.id) {
-          state.role = RoleType.OWNER;
+          state.role = "OWNER";
         } else if (
           state.user &&
           collaborators.findIndex(({ id }) => state.user.id === id) >= 0
         ) {
-          state.role = RoleType.COLLABORATOR;
+          state.role = "COLLABORATOR";
         } else {
-          state.role = RoleType.GUEST;
+          state.role = "GUEST";
         }
         // only set the local awareness when the user is an owner or a collaborator
-        if (state.provider && state.role !== RoleType.GUEST) {
+        if (state.provider && state.role !== "GUEST") {
           console.log("set awareness", state.user.firstname);
           const awareness = state.provider.awareness;
           awareness.setLocalStateField("user", {

--- a/ui/src/lib/store/repoStateSlice.tsx
+++ b/ui/src/lib/store/repoStateSlice.tsx
@@ -71,6 +71,8 @@ export interface RepoStateSlice {
   yjsConnecting: boolean;
   connectYjs: () => void;
   disconnectYjs: () => void;
+  isOwner: () => boolean;
+  isGuest: () => boolean;
 }
 
 export const createRepoStateSlice: StateCreator<
@@ -234,6 +236,8 @@ export const createRepoStateSlice: StateCreator<
         state.ydoc.destroy();
       })
     ),
+  isGuest: () => get().role === RoleType.GUEST,
+  isOwner: () => get().role === RoleType.OWNER,
 });
 
 function loadRepo(set, get) {

--- a/ui/src/lib/utils.tsx
+++ b/ui/src/lib/utils.tsx
@@ -34,3 +34,36 @@ export function getUpTime(startedAt: string) {
   let prettyTime = prettyPrintTime(diff);
   return prettyTime;
 }
+
+/**
+ * For historical reason, the state.pod.type and DB schema pod.type are "CODE",
+ * "DECK", "WYSIWYG", while the node types in react-flow are "code", "scope",
+ * "rich". These two functions document this and handle the conversion.
+ * @param dbtype
+ * @returns
+ */
+export function dbtype2nodetype(dbtype: string) {
+  switch (dbtype) {
+    case "CODE":
+      return "code";
+    case "DECK":
+      return "scope";
+    case "WYSIWYG":
+      return "rich";
+    default:
+      throw new Error(`unknown dbtype ${dbtype}`);
+  }
+}
+
+export function nodetype2dbtype(nodetype: string) {
+  switch (nodetype) {
+    case "code":
+      return "CODE";
+    case "scope":
+      return "DECK";
+    case "rich":
+      return "WYSIWYG";
+    default:
+      throw new Error(`unknown nodetype ${nodetype}`);
+  }
+}

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -37,7 +37,7 @@ const HeaderItem = memo<any>(({ id }) => {
     store,
     (state) => state.remoteUpdateRepoName
   );
-  const isOwner = useStore(store, (state) => state.isOwner());
+  const isOwner = useStore(store, (state) => state.role === "OWNER");
 
   usePrompt(
     "Repo name not saved. Do you want to leave this page?",

--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -14,7 +14,7 @@ import * as React from "react";
 
 import { useStore } from "zustand";
 
-import { createRepoStore, RepoContext, RoleType } from "../lib/store";
+import { createRepoStore, RepoContext } from "../lib/store";
 
 import useMe from "../lib/me";
 import { Canvas } from "../components/Canvas";
@@ -37,7 +37,7 @@ const HeaderItem = memo<any>(({ id }) => {
     store,
     (state) => state.remoteUpdateRepoName
   );
-  const role = useStore(store, (state) => state.role);
+  const isOwner = useStore(store, (state) => state.isOwner());
 
   usePrompt(
     "Repo name not saved. Do you want to leave this page?",
@@ -95,7 +95,7 @@ const HeaderItem = memo<any>(({ id }) => {
         maxWidth: "100%",
         border: "none",
       }}
-      disabled={role !== RoleType.OWNER}
+      disabled={!isOwner}
       onChange={(e) => {
         const name = e.target.value;
         setRepoName(name);


### PR DESCRIPTION
1. disable `richNode` editing & `codeNode` copying for guest users
2. fix the bug: a guest user sees the pasted pod increases on its size endlessly. 
3. fix the bug: a pasted pod's position is not up-to-date when adding.
4. extend node types when observing adding nodes in `nodesMap`
5. refactor the code about the privilege management in front-end, hide the detailed role info to simplify the code

More details can be found in comments.

Suggestions:
- Many functions in `canvas.tsx` can be moved into `lib/utils.tsx` like `dbtype2nodetype` to make `canvas.tsx` more clear.
- For a guest user, the runtime should not be loaded from the beginning, it wastes resource.

Other works on the way:

- Figure out a way to prevent selecting node by `Space` or `Enter` (see https://github.com/codepod-io/codepod/issues/166)