### PR TITLE
fix: scoped func/var annotation re-rendering on switch

### DIFF
--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -399,6 +399,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const { setNodes } = useReactFlow();
   const annotations = useStore(store, (state) => state.pods[id].annotations);
   const showAnnotations = useStore(store, (state) => state.showAnnotations);
+  const scopedVars = useStore(store, (state) => state.scopedVars);
 
   const value = getPod(id).content || "";
   let lang = getPod(id).lang || "javascript";
@@ -415,10 +416,13 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   }, [clearResults, store, wsRun]);
 
   useEffect(() => {
-    if (editor && showAnnotations) {
+    if (!editor) return;
+    if (showAnnotations) {
       highlightAnnotations(editor, annotations || []);
+    } else {
+      highlightAnnotations(editor, []);
     }
-  }, [annotations, editor, showAnnotations]);
+  }, [annotations, editor, showAnnotations, scopedVars]);
 
   if (lang === "racket") {
     lang = "scheme";

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import Grid from "@mui/material/Grid";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import Typography from "@mui/material/Typography";
 import { useSnackbar, VariantType } from "notistack";
 
 import { gql, useQuery, useMutation, useApolloClient } from "@apollo/client";
@@ -46,7 +47,6 @@ function SidebarSettings() {
   );
   return (
     <Box>
-      Settings
       <Box>
         <FormGroup>
           <FormControlLabel
@@ -435,6 +435,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   <SidebarRuntime />
                 </Grid>
                 <Grid item xs={12}>
+                  <Divider />
+                  <Typography variant="h6">Site Settings</Typography>
                   <SidebarSettings />
                 </Grid>
                 <ToastError />

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -48,36 +48,40 @@ function SidebarSettings() {
   return (
     <Box>
       <Box>
-        <FormGroup>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={scopedVars}
-                size="small"
-                color="warning"
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setScopedVars(event.target.checked);
-                }}
-              />
-            }
-            label="Scoped Variables"
-          />
-        </FormGroup>
-        <FormGroup>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={showAnnotations}
-                size="small"
-                color="warning"
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setShowAnnotations(event.target.checked);
-                }}
-              />
-            }
-            label="Enable Annotations"
-          />
-        </FormGroup>
+        <Tooltip title={"Enable Scoped Variables"} disableInteractive>
+          <FormGroup>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={scopedVars}
+                  size="small"
+                  color="warning"
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setScopedVars(event.target.checked);
+                  }}
+                />
+              }
+              label="Scoped Variables"
+            />
+          </FormGroup>
+        </Tooltip>
+        <Tooltip title={"Show Annotations in Editor"} disableInteractive>
+          <FormGroup>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={showAnnotations}
+                  size="small"
+                  color="warning"
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setShowAnnotations(event.target.checked);
+                  }}
+                />
+              }
+              label="Enable Annotations"
+            />
+          </FormGroup>
+        </Tooltip>
         {showAnnotations && (
           <Stack spacing={0.5}>
             <Box className="myDecoration-function">Function Definition</Box>

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -60,7 +60,7 @@ function SidebarSettings() {
                 }}
               />
             }
-            label="Scoped Vars"
+            label="Scoped Variables"
           />
         </FormGroup>
         <FormGroup>
@@ -75,16 +75,16 @@ function SidebarSettings() {
                 }}
               />
             }
-            label="Show Anotations"
+            label="Enable Annotations"
           />
         </FormGroup>
         {showAnnotations && (
           <Stack spacing={0.5}>
-            <Box className="myDecoration-function">Function Def</Box>
-            <Box className="myDecoration-vardef">Variable Def</Box>
-            <Box className="myDecoration-varuse">Function/Var Use</Box>
+            <Box className="myDecoration-function">Function Definition</Box>
+            <Box className="myDecoration-vardef">Variable Definition</Box>
+            <Box className="myDecoration-varuse">Function/Variable Use</Box>
             <Box className="myDecoration-varuse my-underline">
-              Undefined Vars
+              Undefined Variable
             </Box>
           </Stack>
         )}


### PR DESCRIPTION
Now when you toggle the "Scoped Variable" and "Enable Annotation" switches in sidebar, the editor annotations will change in real-time.

Also added tooltips.

<img width="600" alt="Screenshot 2023-01-03 at 9 08 53 PM" src="https://user-images.githubusercontent.com/4576201/210488342-97919f66-84e8-405d-97e7-65c4ccf778ee.png">
