### PR TITLE
add devMode

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -45,9 +45,31 @@ function SidebarSettings() {
     store,
     (state) => state.setShowAnnotations
   );
+  const devMode = useStore(store, (state) => state.devMode);
+  const setDevMode = useStore(store, (state) => state.setDevMode);
   return (
     <Box>
       <Box>
+        <Tooltip
+          title={"Enable DevMode, e.g., show pod IDs"}
+          disableInteractive
+        >
+          <FormGroup>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={devMode}
+                  size="small"
+                  color="warning"
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setDevMode(event.target.checked);
+                  }}
+                />
+              }
+              label="Dev Mode"
+            />
+          </FormGroup>
+        </Tooltip>
         <Tooltip title={"Enable Scoped Variables"} disableInteractive>
           <FormGroup>
             <FormControlLabel

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -233,6 +233,7 @@ export const CodeNode = memo<Props>(function ({
 }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const devMode = useStore(store, (state) => state.devMode);
   // const pod = useStore(store, (state) => state.pods[id]);
   const wsRun = useStore(store, (state) => state.wsRun);
   const clearResults = useStore(store, (s) => s.clearResults);
@@ -369,6 +370,20 @@ export const CodeNode = memo<Props>(function ({
       />
       {/* The header of code pods. */}
       <Box className="custom-drag-handle">
+        {devMode && (
+          <Box
+            sx={{
+              position: "absolute",
+              top: "-48px",
+              width: "50%",
+              userSelect: "text",
+              cursor: "auto",
+            }}
+            className="nodrag"
+          >
+            <pre>{id}</pre>
+          </Box>
+        )}
         <Box
           sx={{
             position: "absolute",

--- a/ui/src/lib/store/settingSlice.tsx
+++ b/ui/src/lib/store/settingSlice.tsx
@@ -6,6 +6,8 @@ export interface SettingSlice {
   setScopedVars: (b: boolean) => void;
   showAnnotations?: boolean;
   setShowAnnotations: (b: boolean) => void;
+  devMode?: boolean;
+  setDevMode: (b: boolean) => void;
 }
 
 export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
@@ -29,5 +31,14 @@ export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
     set({ showAnnotations: b });
     // also write to local storage
     localStorage.setItem("showAnnotations", JSON.stringify(b));
+  },
+  devMode: localStorage.getItem("devMode")
+    ? JSON.parse(localStorage.getItem("devMode")!)
+    : false,
+  setDevMode: (b: boolean) => {
+    // set it
+    set({ devMode: b });
+    // also write to local storage
+    localStorage.setItem("devMode", JSON.stringify(b));
   },
 });


### PR DESCRIPTION
Add a new "dev mode" switch in the sidebar. When it is on, the ID of all code pods will be displayed.

<img width="649" alt="Screenshot 2023-01-04 at 11 00 31 AM" src="https://user-images.githubusercontent.com/4576201/210630195-2022832f-20ba-4af6-b5c0-f9fa69444718.png">
