### PR TITLE
fix potential pod syncing with pod.isSyncing

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -251,7 +251,7 @@ function SyncStatus() {
     let res: string[] = [];
     if (state.repoLoaded) {
       for (const id in state.pods) {
-        if (state.pods[id].dirty) {
+        if (state.pods[id].dirty || state.pods[id].isSyncing) {
           res.push(id);
         }
       }

--- a/ui/src/lib/store/index.tsx
+++ b/ui/src/lib/store/index.tsx
@@ -15,6 +15,7 @@ export type Pod = {
   type: string;
   content?: string;
   dirty?: boolean;
+  isSyncing?: boolean;
   children: { id: string; type: string }[];
   parent: string;
   result?: { html?: string; text?: string; count: number; image?: string };


### PR DESCRIPTION
In the past, when we mark a pod `dirty`, it will sync (every second) with the remote server; once finished, clear the `dirty` flag. E.g.,

```dot
[update1] -> dirty=true -> sync1 -> sync1-return -> dirty=false
```

However, if a user updates the pod again before the sync finishes, this new update's `dirty` flag might be cleared by the sync request. E.g.,

```dot
[update1] -> dirty=true -> sync1 -> [update2] -> dirty=true -> sync1-return -> dirty=false
```

Also, there might be multiple sync requests for the same pod if the network lag is more than 1 second.

This PR adds a `pod.isSyncing` flag. The `dirty` flag is cleared immediately for the sync. The `isSyncing` flag is cleared once the sync request finishes.
