### PR TITLE
refactor resolvers; enforce graphQL api required fields

### DIFF
--- a/api/src/resolver.ts
+++ b/api/src/resolver.ts
@@ -1,100 +1,19 @@
-import {
-  login,
-  loginWithGoogle,
-  me,
-  signup,
-  updateUser,
-  users,
-} from "./resolver_user";
-import {
-  createRepo,
-  deletePod,
-  deleteRepo,
-  deleteCollaborator,
-  myRepos,
-  myCollabRepos,
-  getVisibility,
-  updateVisibility,
-  addCollaborator,
-  addPods,
-  pod,
-  repo,
-  repos,
-  updatePod,
-  updateRepo,
-} from "./resolver_repo";
-import { listAllRuntimes } from "./resolver_runtime";
-
-// chooes between docker and k8s spawners
-import {
-  spawnRuntime as spawnRuntime_docker,
-  killRuntime as killRuntime_docker,
-  infoRuntime as infoRuntime_docker,
-  loopKillInactiveRoutes as loopKillInactiveRoutes_docker,
-  initRoutes as initRoutes_docker,
-} from "./spawner-docker";
-import {
-  spawnRuntime as spawnRuntime_k8s,
-  killRuntime as killRuntime_k8s,
-  infoRuntime as infoRuntime_k8s,
-  loopKillInactiveRoutes as loopKillInactiveRoutes_k8s,
-  initRoutes as initRoutes_k8s,
-} from "./spawner-k8s";
+import UserResolver from "./resolver_user";
+import RepoResolver from "./resolver_repo";
+import RuntimeResolver from "./resolver_runtime";
 
 export const resolvers = {
   Query: {
     hello: () => {
       return "Hello world!";
     },
-    users,
-    me,
-    repos,
-    myRepos,
-    repo,
-    pod,
-    listAllRuntimes,
-    getVisibility,
-    myCollabRepos,
-
-    ...(process.env.RUNTIME_SPAWNER === "k8s"
-      ? {
-          infoRuntime: infoRuntime_k8s,
-        }
-      : {
-          infoRuntime: infoRuntime_docker,
-        }),
+    ...UserResolver.Query,
+    ...RepoResolver.Query,
+    ...RuntimeResolver.Query,
   },
   Mutation: {
-    signup,
-    updateUser,
-    login,
-    loginWithGoogle,
-    createRepo,
-    updateRepo,
-    deleteRepo,
-    clearUser: () => {},
-    updatePod,
-    addPods,
-    deletePod,
-    addCollaborator,
-    updateVisibility,
-    deleteCollaborator,
-    ...(process.env.RUNTIME_SPAWNER === "k8s"
-      ? {
-          spawnRuntime: spawnRuntime_k8s,
-          killRuntime: killRuntime_k8s,
-        }
-      : {
-          spawnRuntime: spawnRuntime_docker,
-          killRuntime: killRuntime_docker,
-        }),
+    ...UserResolver.Mutation,
+    ...RepoResolver.Mutation,
+    ...RuntimeResolver.Mutation,
   },
 };
-
-if (process.env.RUNTIME_SPAWNER !== "k8s") {
-  initRoutes_docker();
-  loopKillInactiveRoutes_docker();
-} else {
-  initRoutes_k8s();
-  loopKillInactiveRoutes_k8s();
-}

--- a/api/src/resolver_repo.ts
+++ b/api/src/resolver_repo.ts
@@ -44,17 +44,7 @@ async function ensurePodEditAccess({ id, userId }) {
   }
 }
 
-export async function repos() {
-  throw new Error("Deprecated");
-  const repos = await prisma.repo.findMany({
-    include: {
-      owner: true,
-    },
-  });
-  return repos;
-}
-
-export async function myRepos(_, __, { userId }) {
+async function myRepos(_, __, { userId }) {
   if (!userId) throw Error("Unauthenticated");
   const repos = await prisma.repo.findMany({
     where: {
@@ -66,7 +56,7 @@ export async function myRepos(_, __, { userId }) {
   return repos;
 }
 
-export async function myCollabRepos(_, __, { userId }) {
+async function myCollabRepos(_, __, { userId }) {
   if (!userId) throw Error("Unauthenticated");
   const repos = await prisma.repo.findMany({
     where: {
@@ -78,7 +68,7 @@ export async function myCollabRepos(_, __, { userId }) {
   return repos;
 }
 
-export async function repo(_, { id }, { userId }) {
+async function repo(_, { id }, { userId }) {
   // a user can only access a private repo if he is the owner or a collaborator
   const repo = await prisma.repo.findFirst({
     where: {
@@ -106,16 +96,7 @@ export async function repo(_, { id }, { userId }) {
   return repo;
 }
 
-export async function pod(_, { id }) {
-  throw new Error("Deprecated");
-  return await prisma.pod.findFirst({
-    where: {
-      id: id,
-    },
-  });
-}
-
-export async function createRepo(_, { id, name, isPublic }, { userId }) {
+async function createRepo(_, { id, name, isPublic }, { userId }) {
   if (!userId) throw Error("Unauthenticated");
   const repo = await prisma.repo.create({
     data: {
@@ -133,7 +114,7 @@ export async function createRepo(_, { id, name, isPublic }, { userId }) {
   return repo;
 }
 
-export async function getVisibility(_, { repoId }, { userId }) {
+async function getVisibility(_, { repoId }, { userId }) {
   if (!userId) throw Error("Unauthenticated");
   const repo = await prisma.repo.findFirst({
     where: {
@@ -148,7 +129,7 @@ export async function getVisibility(_, { repoId }, { userId }) {
   return { collaborators: repo.collaborators, isPublic: repo.public };
 }
 
-export async function updateVisibility(_, { repoId, isPublic }, { userId }) {
+async function updateVisibility(_, { repoId, isPublic }, { userId }) {
   if (!userId) throw Error("Unauthenticated");
   const repo = await prisma.repo.findFirst({
     where: {
@@ -168,7 +149,7 @@ export async function updateVisibility(_, { repoId, isPublic }, { userId }) {
   return true;
 }
 
-export async function updateRepo(_, { id, name }, { userId }) {
+async function updateRepo(_, { id, name }, { userId }) {
   if (!userId) throw Error("Unauthenticated");
   const repo = await prisma.repo.findFirst({
     where: {
@@ -190,7 +171,7 @@ export async function updateRepo(_, { id, name }, { userId }) {
   return true;
 }
 
-export async function deleteRepo(_, { id }, { userId }) {
+async function deleteRepo(_, { id }, { userId }) {
   if (!userId) throw Error("Unauthenticated");
   const user = await prisma.user.findFirst({
     where: {
@@ -222,7 +203,7 @@ export async function deleteRepo(_, { id }, { userId }) {
   return true;
 }
 
-export async function addCollaborator(_, { repoId, email }, { userId }) {
+async function addCollaborator(_, { repoId, email }, { userId }) {
   // make sure the repo is writable by this user
   if (!userId) throw new Error("Not authenticated.");
   // 1. find the repo
@@ -258,11 +239,7 @@ export async function addCollaborator(_, { repoId, email }, { userId }) {
   return true;
 }
 
-export async function deleteCollaborator(
-  _,
-  { repoId, collaboratorId },
-  { userId }
-) {
+async function deleteCollaborator(_, { repoId, collaboratorId }, { userId }) {
   if (!userId) throw new Error("Not authenticated.");
   // 1. find the repo
   const repo = await prisma.repo.findFirst({
@@ -284,7 +261,7 @@ export async function deleteCollaborator(
   return true;
 }
 
-export async function updatePod(_, { id, repoId, input }, { userId }) {
+async function updatePod(_, { id, repoId, input }, { userId }) {
   if (!userId) throw new Error("Not authenticated.");
   await ensureRepoEditAccess({ repoId, userId });
   // if repoId has id, just update
@@ -320,7 +297,7 @@ export async function updatePod(_, { id, repoId, input }, { userId }) {
   return true;
 }
 
-export async function addPods(_, { repoId, pods }, { userId }) {
+async function addPods(_, { repoId, pods }, { userId }) {
   if (!userId) throw new Error("Not authenticated.");
   await ensureRepoEditAccess({ repoId, userId });
   // notice: we keep the field "children", "parent", "repo" empty when first insertion the repo. Because if we insist on filling them, we must specify children, parent and repo by prisma.create.pod. Regardless of what order we insert them, we can't make sure both children and parent exist in the DB, the insertion must fail.
@@ -336,7 +313,7 @@ export async function addPods(_, { repoId, pods }, { userId }) {
   return true;
 }
 
-export async function deletePod(_, { id, toDelete }, { userId }) {
+async function deletePod(_, { id, toDelete }, { userId }) {
   if (!userId) throw new Error("Not authenticated.");
   await ensurePodEditAccess({ id, userId });
   // find all children of this ID
@@ -381,3 +358,23 @@ export async function deletePod(_, { id, toDelete }, { userId }) {
   });
   return true;
 }
+
+export default {
+  Query: {
+    myRepos,
+    repo,
+    myCollabRepos,
+    getVisibility,
+  },
+  Mutation: {
+    addPods,
+    createRepo,
+    updateRepo,
+    deleteRepo,
+    updatePod,
+    deletePod,
+    addCollaborator,
+    updateVisibility,
+    deleteCollaborator,
+  },
+};

--- a/api/src/resolver_user.ts
+++ b/api/src/resolver_user.ts
@@ -13,13 +13,7 @@ const { PrismaClient } = Prisma;
 
 const prisma = new PrismaClient();
 
-export async function users(_, __, { userId }) {
-  if (!userId) throw Error("Unauthenticated");
-  const allUsers = await prisma.user.findMany();
-  return allUsers;
-}
-
-export async function me(_, __, { userId }) {
+async function me(_, __, { userId }) {
   if (!userId) throw Error("Unauthenticated");
   const user = await prisma.user.findFirst({
     where: {
@@ -30,7 +24,7 @@ export async function me(_, __, { userId }) {
   return user;
 }
 
-export async function signup(_, { email, password, firstname, lastname }) {
+async function signup(_, { email, password, firstname, lastname }) {
   const salt = await bcrypt.genSalt(10);
   const hashed = await bcrypt.hash(password, salt);
   const user = await prisma.user.create({
@@ -49,11 +43,7 @@ export async function signup(_, { email, password, firstname, lastname }) {
   };
 }
 
-export async function updateUser(
-  _,
-  { email, firstname, lastname },
-  { userId }
-) {
+async function updateUser(_, { email, firstname, lastname }, { userId }) {
   if (!userId) throw Error("Unauthenticated");
   let user = await prisma.user.findFirst({
     where: {
@@ -78,7 +68,7 @@ export async function updateUser(
   return true;
 }
 
-export async function login(_, { email, password }) {
+async function login(_, { email, password }) {
   // FIXME findUnique seems broken https://github.com/prisma/prisma/issues/5071
   const user = await prisma.user.findFirst({
     where: {
@@ -103,7 +93,7 @@ export async function login(_, { email, password }) {
 
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
-export async function loginWithGoogle(_, { idToken }) {
+async function loginWithGoogle(_, { idToken }) {
   const ticket = await client.verifyIdToken({
     idToken: idToken,
     audience: process.env.GOOGLE_CLIENT_ID, // Specify the CLIENT_ID of the app that accesses the backend
@@ -139,3 +129,15 @@ export async function loginWithGoogle(_, { idToken }) {
     }),
   };
 }
+
+export default {
+  Query: {
+    me,
+  },
+  Mutation: {
+    login,
+    loginWithGoogle,
+    signup,
+    updateUser,
+  },
+};

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -13,6 +13,7 @@ import {
 
 import { typeDefs } from "./typedefs";
 import { resolvers } from "./resolver";
+import { initRoutes, loopKillInactiveRoutes } from "./resolver_runtime";
 
 interface TokenInterface {
   id: string;
@@ -46,6 +47,9 @@ async function startServer() {
 
   await apollo.start();
   apollo.applyMiddleware({ app: expapp });
+
+  await initRoutes();
+  loopKillInactiveRoutes();
 
   const port = process.env.PORT || 4000;
   http_server.listen({ port }, () => {

--- a/api/src/typedefs.ts
+++ b/api/src/typedefs.ts
@@ -97,35 +97,35 @@ export const typeDefs = gql`
     pod(id: ID!): Pod
     myRepos: [Repo]
     activeSessions: [String]
-    getVisibility(repoId: String): Visibility
+    getVisibility(repoId: String!): Visibility
     listAllRuntimes: [RuntimeInfo]
     myCollabRepos: [Repo]
     infoRuntime(sessionId: String!): RuntimeInfo
   }
 
   type Mutation {
-    login(email: String, password: String): AuthData
+    login(email: String!, password: String!): AuthData
     signup(
-      email: String
-      password: String
-      firstname: String
-      lastname: String
+      email: String!
+      password: String!
+      firstname: String!
+      lastname: String!
     ): AuthData
-    loginWithGoogle(idToken: String): AuthData
-    updateUser(email: String, firstname: String, lastname: String): Boolean
+    loginWithGoogle(idToken: String!): AuthData
+    updateUser(email: String!, firstname: String!, lastname: String!): Boolean
     createRepo: Repo
-    updateRepo(id: ID, name: String): Boolean
-    deleteRepo(id: ID): Boolean
-    deletePod(id: String, toDelete: [String]): Boolean
-    addPods(repoId: String, pods: [PodInput]): Boolean
-    updatePod(id: String, repoId: String, input: PodInput): Boolean
+    updateRepo(id: ID!, name: String!): Boolean
+    deleteRepo(id: ID!): Boolean
+    deletePod(id: String!, toDelete: [String]): Boolean
+    addPods(repoId: String!, pods: [PodInput]): Boolean
+    updatePod(id: String!, repoId: String!, input: PodInput): Boolean
     clearUser: Boolean
     clearRepo: Boolean
     clearPod: Boolean
-    spawnRuntime(sessionId: String): Boolean
+    spawnRuntime(sessionId: String!): Boolean
     killRuntime(sessionId: String!): Boolean
-    updateVisibility(repoId: String, isPublic: Boolean): Boolean
-    addCollaborator(repoId: String, email: String): Boolean
-    deleteCollaborator(repoId: String, collaboratorId: String): Boolean
+    updateVisibility(repoId: String!, isPublic: Boolean!): Boolean
+    addCollaborator(repoId: String!, email: String!): Boolean
+    deleteCollaborator(repoId: String!, collaboratorId: String!): Boolean
   }
 `;

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -208,7 +208,7 @@ function serializePodInput(pod) {
 
 export async function doRemoteDeletePod(client, { id, toDelete }) {
   const mutation = gql`
-    mutation deletePod($id: String, $toDelete: [String]) {
+    mutation deletePod($id: String!, $toDelete: [String]) {
       deletePod(id: $id, toDelete: $toDelete)
     }
   `;
@@ -225,7 +225,7 @@ export async function doRemoteDeletePod(client, { id, toDelete }) {
 export async function doRemoteUpdatePod(client, { repoId, pod }) {
   const result = await client.mutate({
     mutation: gql`
-      mutation updatePod($id: String, $repoId: String, $input: PodInput) {
+      mutation updatePod($id: String!, $repoId: String!, $input: PodInput) {
         updatePod(id: $id, repoId: $repoId, input: $input)
       }
     `,
@@ -241,7 +241,7 @@ export async function doRemoteUpdatePod(client, { repoId, pod }) {
 export async function doRemoteAddPods(client, { repoId, pods }) {
   const result = await client.mutate({
     mutation: gql`
-      mutation createAddPods($repoId: String, $input: [PodInput]) {
+      mutation createAddPods($repoId: String!, $input: [PodInput]) {
         addPods(repoId: $repoId, pods: $input)
       }
     `,
@@ -255,7 +255,7 @@ export async function doRemoteAddPods(client, { repoId, pods }) {
 
 export async function doRemoteLoadVisibility(client, { repoId }) {
   const query = gql`
-    query ExampleQuery($repoId: String) {
+    query ExampleQuery($repoId: String!) {
       getVisibility(repoId: $repoId) {
         collaborators {
           id
@@ -283,7 +283,7 @@ export async function doRemoteLoadVisibility(client, { repoId }) {
 
 export async function doRemoteUpdateVisibility(client, { repoId, isPublic }) {
   const mutation = gql`
-    mutation updateVisibility($repoId: String, $isPublic: Boolean) {
+    mutation updateVisibility($repoId: String!, $isPublic: Boolean!) {
       updateVisibility(repoId: $repoId, isPublic: $isPublic)
     }
   `;
@@ -299,7 +299,7 @@ export async function doRemoteUpdateVisibility(client, { repoId, isPublic }) {
 
 export async function doRemoteAddCollaborator(client, { repoId, email }) {
   const mutation = gql`
-    mutation addCollaborator($repoId: String, $email: String) {
+    mutation addCollaborator($repoId: String!, $email: String!) {
       addCollaborator(repoId: $repoId, email: $email)
     }
   `;
@@ -322,7 +322,7 @@ export async function doRemoteDeleteCollaborator(
   { repoId, collaboratorId }
 ) {
   const mutation = gql`
-    mutation deleteCollaborator($repoId: String, $collaboratorId: String) {
+    mutation deleteCollaborator($repoId: String!, $collaboratorId: String!) {
       deleteCollaborator(repoId: $repoId, collaboratorId: $collaboratorId)
     }
   `;

--- a/ui/src/lib/store/repoMetaSlice.tsx
+++ b/ui/src/lib/store/repoMetaSlice.tsx
@@ -54,7 +54,7 @@ export const createRepoMetaSlice: StateCreator<
     // Do the actual syncing.
     await client.mutate({
       mutation: gql`
-        mutation UpdateRepo($id: ID!, $name: String) {
+        mutation UpdateRepo($id: ID!, $name: String!) {
           updateRepo(id: $id, name: $name)
         }
       `,

--- a/ui/src/pages/repos.tsx
+++ b/ui/src/pages/repos.tsx
@@ -32,7 +32,7 @@ function RepoLine({ repo, deletable, sharable, runtimeInfo }) {
   const { me } = useMe();
   const [deleteRepo] = useMutation(
     gql`
-      mutation deleteRepo($id: ID) {
+      mutation deleteRepo($id: ID!) {
         deleteRepo(id: $id)
       }
     `,


### PR DESCRIPTION
1. resolvers now import Query and Mutation from sub files:

```js
import UserResolver from "./resolver_user";
import RepoResolver from "./resolver_repo";
import RuntimeResolver from "./resolver_runtime";
import ExportResolver from "./resolver_export";

export const resolvers = {
  Query: {
    ...UserResolver.Query,
    ...RepoResolver.Query,
    ...RuntimeResolver.Query,
  },
  Mutation: {
    ...UserResolver.Mutation,
    ...RepoResolver.Mutation,
    ...RuntimeResolver.Mutation,
  },
};

```

2. enforce the required fields of many GraphQL APIs so that missing of the fields will throw explicit errors, e.g.,

<img width="655" alt="Screenshot 2023-02-23 at 5 28 49 PM" src="https://user-images.githubusercontent.com/4576201/220868584-a205c69f-68a3-4673-8bf3-46fb3ef395dc.png">

