### PR TITLE
Refine Arrow connection UI

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -42,7 +42,7 @@
     "react-resizable": "^3.0.4",
     "react-router-dom": "^6.4.2",
     "react-scripts": "5.0.1",
-    "reactflow": "^11.4.0",
+    "reactflow": "^11.5.6",
     "remirror": "^2.0.21",
     "slate": "^0.82.1",
     "slate-history": "^0.66.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.10.5",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.10",
-    "@reactflow/node-resizer": "^1.2.0",
+    "@reactflow/node-resizer": "^2.0.1",
     "@remirror/extension-react-tables": "^2.2.9",
     "@remirror/extension-sub": "^2.0.9",
     "@remirror/extension-text-highlight": "^2.0.10",

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -87,3 +87,7 @@
 .react-flow__node-scope.selected {
   border-width: 2px;
 }
+
+.react-flow__handle {
+  z-index: 100;
+}

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -42,8 +42,13 @@ import { RichNode } from "./nodes/Rich";
 import { CodeNode } from "./nodes/Code";
 import { ScopeNode } from "./nodes/Scope";
 import { YMap } from "yjs/dist/src/types/YMap";
+import FloatingEdge from "./nodes/FloatingEdge";
+import CustomConnectionLine from "./nodes/CustomConnectionLine";
 
 const nodeTypes = { scope: ScopeNode, code: CodeNode, rich: RichNode };
+const edgeTypes = {
+  floating: FloatingEdge,
+};
 
 /**
  * This hook will load nodes from zustand store into Yjs nodesMap using setNodes.
@@ -529,6 +534,23 @@ function CanvasImpl() {
           minZoom={0.1}
           onPaneContextMenu={onPaneContextMenu}
           nodeTypes={nodeTypes}
+          // custom edge for easy connect
+          edgeTypes={edgeTypes}
+          defaultEdgeOptions={{
+            style: { strokeWidth: 3, stroke: "black" },
+            type: "floating",
+            markerEnd: {
+              type: MarkerType.ArrowClosed,
+              color: "black",
+            },
+          }}
+          connectionLineComponent={CustomConnectionLine}
+          connectionLineStyle={{
+            strokeWidth: 3,
+            stroke: "black",
+          }}
+          // end custom edge
+
           zoomOnScroll={false}
           panOnScroll={true}
           connectionMode={ConnectionMode.Loose}

--- a/ui/src/components/nodes/CustomConnectionLine.tsx
+++ b/ui/src/components/nodes/CustomConnectionLine.tsx
@@ -1,0 +1,32 @@
+import { ConnectionLineComponentProps, getStraightPath } from "reactflow";
+
+function CustomConnectionLine({
+  fromX,
+  fromY,
+  toX,
+  toY,
+  connectionLineStyle,
+}: ConnectionLineComponentProps) {
+  const [edgePath] = getStraightPath({
+    sourceX: fromX,
+    sourceY: fromY,
+    targetX: toX,
+    targetY: toY,
+  });
+
+  return (
+    <g>
+      <path style={connectionLineStyle} fill="none" d={edgePath} />
+      <circle
+        cx={toX}
+        cy={toY}
+        fill="black"
+        r={3}
+        stroke="black"
+        strokeWidth={1.5}
+      />
+    </g>
+  );
+}
+
+export default CustomConnectionLine;

--- a/ui/src/components/nodes/FloatingEdge.tsx
+++ b/ui/src/components/nodes/FloatingEdge.tsx
@@ -1,0 +1,38 @@
+import { useCallback } from "react";
+import { useStore, getStraightPath, EdgeProps } from "reactflow";
+
+import { getEdgeParams } from "./utils";
+
+function FloatingEdge({ id, source, target, markerEnd, style }: EdgeProps) {
+  const sourceNode = useStore(
+    useCallback((store) => store.nodeInternals.get(source), [source])
+  );
+  const targetNode = useStore(
+    useCallback((store) => store.nodeInternals.get(target), [target])
+  );
+
+  if (!sourceNode || !targetNode) {
+    return null;
+  }
+
+  const { sx, sy, tx, ty } = getEdgeParams(sourceNode, targetNode);
+
+  const [edgePath] = getStraightPath({
+    sourceX: sx,
+    sourceY: sy,
+    targetX: tx,
+    targetY: ty,
+  });
+
+  return (
+    <path
+      id={id}
+      className="react-flow__edge-path"
+      d={edgePath}
+      markerEnd={markerEnd}
+      style={style}
+    />
+  );
+}
+
+export default FloatingEdge;

--- a/ui/src/components/nodes/utils.tsx
+++ b/ui/src/components/nodes/utils.tsx
@@ -1,3 +1,5 @@
+import { Node, Position, MarkerType, XYPosition } from "reactflow";
+
 export function ResizeIcon() {
   return (
     <svg
@@ -19,4 +21,76 @@ export function ResizeIcon() {
       <line x1="4" y1="4" x2="10" y2="10" />
     </svg>
   );
+}
+
+// this helper function returns the intersection point
+// of the line between the center of the intersectionNode and the target node
+function getNodeIntersection(intersectionNode: Node, targetNode: Node) {
+  // https://math.stackexchange.com/questions/1724792/an-algorithm-for-finding-the-intersection-point-between-a-center-of-vision-and-a
+  const {
+    width: intersectionNodeWidth,
+    height: intersectionNodeHeight,
+    positionAbsolute: intersectionNodePosition,
+  } = intersectionNode;
+  const targetPosition = targetNode.positionAbsolute!;
+
+  const w = intersectionNodeWidth! / 2;
+  const h = intersectionNodeHeight! / 2;
+
+  const x2 = intersectionNodePosition!.x + w;
+  const y2 = intersectionNodePosition!.y + h;
+  const x1 = targetPosition.x + w;
+  const y1 = targetPosition.y + h;
+
+  const xx1 = (x1 - x2) / (2 * w) - (y1 - y2) / (2 * h);
+  const yy1 = (x1 - x2) / (2 * w) + (y1 - y2) / (2 * h);
+  const a = 1 / (Math.abs(xx1) + Math.abs(yy1));
+  const xx3 = a * xx1;
+  const yy3 = a * yy1;
+  const x = w * (xx3 + yy3) + x2;
+  const y = h * (-xx3 + yy3) + y2;
+
+  return { x, y };
+}
+
+// returns the position (top,right,bottom or right) passed node compared to the intersection point
+function getEdgePosition(node: Node, intersectionPoint: XYPosition) {
+  const n = { ...node.positionAbsolute, ...node };
+  const nx = Math.round(n.x!);
+  const ny = Math.round(n.y!);
+  const px = Math.round(intersectionPoint.x);
+  const py = Math.round(intersectionPoint.y);
+
+  if (px <= nx + 1) {
+    return Position.Left;
+  }
+  if (px >= nx + n.width! - 1) {
+    return Position.Right;
+  }
+  if (py <= ny + 1) {
+    return Position.Top;
+  }
+  if (py >= n.y! + n.height! - 1) {
+    return Position.Bottom;
+  }
+
+  return Position.Top;
+}
+
+// returns the parameters (sx, sy, tx, ty, sourcePos, targetPos) you need to create an edge
+export function getEdgeParams(source: Node, target: Node) {
+  const sourceIntersectionPoint = getNodeIntersection(source, target);
+  const targetIntersectionPoint = getNodeIntersection(target, source);
+
+  const sourcePos = getEdgePosition(source, sourceIntersectionPoint);
+  const targetPos = getEdgePosition(target, targetIntersectionPoint);
+
+  return {
+    sx: sourceIntersectionPoint.x,
+    sy: sourceIntersectionPoint.y,
+    tx: targetIntersectionPoint.x,
+    ty: targetIntersectionPoint.y,
+    sourcePos,
+    targetPos,
+  };
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2062,23 +2062,21 @@
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
 
-"@reactflow/background@11.1.0":
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/@reactflow/background/-/background-11.1.0.tgz#943c799d9f251340e9867ad8f4c6ac291163e401"
-  integrity sha512-EgDn3rhK+l8jKmE6KGUZvesRjdh7fOqsz5Hj7STUU5/uGsvgN9KFuudY/Ka8m+yCQxqNK8MAJcRMOZd0mvNFMQ==
+"@reactflow/background@11.1.8":
+  version "11.1.8"
+  resolved "https://registry.yarnpkg.com/@reactflow/background/-/background-11.1.8.tgz#e804eb82ade6f70ab5f218dc767051083497c0f7"
+  integrity sha512-NYZwiEeKVc1qJbDRrRX5RgHbMMzofhzOAqz3teWtUIGju5d+kEf/vcx/35bLM+CZuhucL+OvJpRgCjKmViiTIw==
   dependencies:
-    "@babel/runtime" "^7.18.9"
-    "@reactflow/core" "11.4.0"
+    "@reactflow/core" "11.5.5"
     classcat "^5.0.3"
-    zustand "^4.1.1"
+    zustand "^4.3.1"
 
-"@reactflow/controls@11.1.0":
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/@reactflow/controls/-/controls-11.1.0.tgz#6d6f6dd6e53557579c6cfcea3c7376d2d00c2953"
-  integrity sha512-5nH1TQ9mkveUOnq7QgohzeAdGR4WwKQJMrWjb5u3Dnm5D5+oRxTE3eGBoaw6B6nYaK1rDrPCcMAuGmEPdEC+Mg==
+"@reactflow/controls@11.1.8":
+  version "11.1.8"
+  resolved "https://registry.yarnpkg.com/@reactflow/controls/-/controls-11.1.8.tgz#43c3756a53479382e34d495f4b123f45b8cf658f"
+  integrity sha512-QCG4q52HS/zmuBAFzmTFh4wkR6thmNDxSKHQPxTwfVIuQtV/oGpfz7zMaoU0ZSN84qSWl5UdzmV4PAC50tOAkQ==
   dependencies:
-    "@babel/runtime" "^7.18.9"
-    "@reactflow/core" "11.4.0"
+    "@reactflow/core" "11.5.5"
     classcat "^5.0.3"
 
 "@reactflow/core@11.4.0":
@@ -2096,19 +2094,33 @@
     d3-zoom "^3.0.0"
     zustand "^4.1.1"
 
-"@reactflow/minimap@11.3.0":
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/@reactflow/minimap/-/minimap-11.3.0.tgz#2f89dbab4c10b754c452f70857172d959cca60aa"
-  integrity sha512-nvb4qmbsogjhrn7GWXpvLMtmAyE7mjs0BXvtbpcFVpKqQ3Lbf76zCa8c2krUMnBBqu+9yF0Ftkn7mMCTV2gPLQ==
+"@reactflow/core@11.5.5":
+  version "11.5.5"
+  resolved "https://registry.yarnpkg.com/@reactflow/core/-/core-11.5.5.tgz#bced11d76fc200b4dc301f2f2b882c4f4ec3dad3"
+  integrity sha512-/FPnpvO9I4E6/mmfZInbsVusR214gzIZ2e2xgl9XJdBo90cWaqHgo0c5F2YPXX19R3mItzxveN+WlENFEOvdPg==
   dependencies:
-    "@babel/runtime" "^7.18.9"
-    "@reactflow/core" "11.4.0"
+    "@types/d3" "^7.4.0"
+    "@types/d3-drag" "^3.0.1"
+    "@types/d3-selection" "^3.0.3"
+    "@types/d3-zoom" "^3.0.1"
+    classcat "^5.0.3"
+    d3-drag "^3.0.0"
+    d3-selection "^3.0.0"
+    d3-zoom "^3.0.0"
+    zustand "^4.3.1"
+
+"@reactflow/minimap@11.3.8":
+  version "11.3.8"
+  resolved "https://registry.yarnpkg.com/@reactflow/minimap/-/minimap-11.3.8.tgz#f2324c2f038d75bf9f8b27d46d782f488038f341"
+  integrity sha512-hOW3FVP/ObRK3oZxvKSSKIIR/DRe1OR4KU+3AIHxTK6K2kt/D48zQU37fOmEasfohjBjsqEopK7Ux8tapTT0EA==
+  dependencies:
+    "@reactflow/core" "11.5.5"
     "@types/d3-selection" "^3.0.3"
     "@types/d3-zoom" "^3.0.1"
     classcat "^5.0.3"
     d3-selection "^3.0.0"
     d3-zoom "^3.0.0"
-    zustand "^4.1.1"
+    zustand "^4.3.1"
 
 "@reactflow/node-resizer@^1.2.0":
   version "1.2.0"
@@ -2121,15 +2133,14 @@
     d3-selection "^3.0.0"
     zustand "^4.1.1"
 
-"@reactflow/node-toolbar@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@reactflow/node-toolbar/-/node-toolbar-1.1.0.tgz#c7de2fb5c7aef02a1e575ce12a35d23cd45c18bd"
-  integrity sha512-kibrTGGvwhFGndVSgwr9E6l9Uddr44csr06X+PJ7FJ0SXgeOHbSw4MaM/9dSFxkFoCi77fPXSdMONNTReSBnIg==
+"@reactflow/node-toolbar@1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@reactflow/node-toolbar/-/node-toolbar-1.1.8.tgz#36a97fb390b8c622fa98e7ffaf1b03c2f75f812a"
+  integrity sha512-/Aj5dfarrBRvPeyDk+CZef7InP4LXlhMnlMPw6hnT/P9lVVChe02knzzkeKiVGmiWKXWL/gOCDXBFp9tMtIAsQ==
   dependencies:
-    "@babel/runtime" "^7.18.9"
-    "@reactflow/core" "11.4.0"
+    "@reactflow/core" "11.5.5"
     classcat "^5.0.3"
-    zustand "^4.1.1"
+    zustand "^4.3.1"
 
 "@remirror/core-constants@^2.0.0":
   version "2.0.0"
@@ -10506,16 +10517,16 @@ reactcss@^1.2.0:
   dependencies:
     lodash "^4.0.1"
 
-reactflow@^11.4.0:
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/reactflow/-/reactflow-11.4.0.tgz#aeb4b030ba93e8e656094f59226e55ec538f55b4"
-  integrity sha512-Y+LZ3XZX7UejW4vukeyLwDDfqNT0RxyNNSHD1FJOIu2IvyVMkj+wKTcbp3ehm7brBkMOOaPyugcEWlLwFXcrjg==
+reactflow@^11.5.6:
+  version "11.5.6"
+  resolved "https://registry.yarnpkg.com/reactflow/-/reactflow-11.5.6.tgz#744e2aa6cfb2c376b560633377063c2a576f3eec"
+  integrity sha512-my4LUKT7H7t2mK/qy4n+bfAMgjqhHOhYGYrvzSWB4yPhOhamPGjs0Ted9G8JWEw15Svn7pHf8DppTHUfk5zH2g==
   dependencies:
-    "@reactflow/background" "11.1.0"
-    "@reactflow/controls" "11.1.0"
-    "@reactflow/core" "11.4.0"
-    "@reactflow/minimap" "11.3.0"
-    "@reactflow/node-toolbar" "1.1.0"
+    "@reactflow/background" "11.1.8"
+    "@reactflow/controls" "11.1.8"
+    "@reactflow/core" "11.5.5"
+    "@reactflow/minimap" "11.3.8"
+    "@reactflow/node-toolbar" "1.1.8"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -12719,5 +12730,12 @@ zustand@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.1.3.tgz#72bc4c0ed8ed906fbd92c7c20cde8dd6114c018f"
   integrity sha512-AdFyr6+4sVD6xlyc/ArQaOrleqzxJEBbAXglufZ5lgvisoz8GUN3icOrKOnX1uRSxmpmdVUQPen9hhymWIzhBg==
+  dependencies:
+    use-sync-external-store "1.2.0"
+
+zustand@^4.3.1:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.3.tgz#c9113499074dde2d6d99c1b5f591e9329572c224"
+  integrity sha512-x2jXq8S0kfLGNwGh87nhRfEc2eZy37tSatpSoSIN+O6HIaBhgQHSONV/F9VNrNcBcKQu/E80K1DeHDYQC/zCrQ==
   dependencies:
     use-sync-external-store "1.2.0"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2079,22 +2079,7 @@
     "@reactflow/core" "11.5.5"
     classcat "^5.0.3"
 
-"@reactflow/core@11.4.0":
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/@reactflow/core/-/core-11.4.0.tgz#9af0c812eb9968b75cf55427c6be4a9205d0db48"
-  integrity sha512-AfFp685kmxWs2Iiq35TatG9Q8u5W+eftXECQ0ea55Oi37nrMe5jfWhjnGnnl3bSFcHqAe6avqNiFDwqugU6kzQ==
-  dependencies:
-    "@types/d3" "^7.4.0"
-    "@types/d3-drag" "^3.0.1"
-    "@types/d3-selection" "^3.0.3"
-    "@types/d3-zoom" "^3.0.1"
-    classcat "^5.0.3"
-    d3-drag "^3.0.0"
-    d3-selection "^3.0.0"
-    d3-zoom "^3.0.0"
-    zustand "^4.1.1"
-
-"@reactflow/core@11.5.5":
+"@reactflow/core@11.5.5", "@reactflow/core@^11.3.3":
   version "11.5.5"
   resolved "https://registry.yarnpkg.com/@reactflow/core/-/core-11.5.5.tgz#bced11d76fc200b4dc301f2f2b882c4f4ec3dad3"
   integrity sha512-/FPnpvO9I4E6/mmfZInbsVusR214gzIZ2e2xgl9XJdBo90cWaqHgo0c5F2YPXX19R3mItzxveN+WlENFEOvdPg==
@@ -2122,16 +2107,16 @@
     d3-zoom "^3.0.0"
     zustand "^4.3.1"
 
-"@reactflow/node-resizer@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@reactflow/node-resizer/-/node-resizer-1.2.0.tgz#8096d6b5ae00c106c745405ff385c5d35852ed4d"
-  integrity sha512-keDWyX9gQB7ak7gPXb7yPeTDCfMtvgZWiP3MP9HIAKiDmpXKEtyi5P6X67Rcdx8saPQIJ4vU9k1q4snljz4UnQ==
+"@reactflow/node-resizer@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@reactflow/node-resizer/-/node-resizer-2.0.1.tgz#45d4fe18b3fa2d92029e2c1bd32283763c3737b8"
+  integrity sha512-07PNFkv4lH07SEthuz5l87YtFIms+8SFkYVsMhe6Cfdej1tPuIa4f6Xmy0ILOLjBU0B2TRrbw0+T+cJ62zcofQ==
   dependencies:
-    "@reactflow/core" "11.4.0"
+    "@reactflow/core" "^11.3.3"
     classcat "^5.0.4"
     d3-drag "^3.0.0"
     d3-selection "^3.0.0"
-    zustand "^4.1.1"
+    zustand "^4.3.1"
 
 "@reactflow/node-toolbar@1.1.8":
   version "1.1.8"
@@ -12718,13 +12703,6 @@ zen-observable@0.8.15:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
-
-zustand@^4.1.1:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.1.4.tgz#b0286da4cc9edd35e91c96414fa54bfa4652a54d"
-  integrity sha512-k2jVOlWo8p4R83mQ+/uyB8ILPO2PCJOf+QVjcL+1PbMCk1w5OoPYpAIxy9zd93FSfmJqoH6lGdwzzjwqJIRU5A==
-  dependencies:
-    use-sync-external-store "1.2.0"
 
 zustand@^4.1.3:
   version "4.1.3"


### PR DESCRIPTION
1. Make the arrow handle stand out. Previously the right and bottom handles were covered by the Monaco editor and were hard to select.
2. Use undirectional floating edge. Previously the arrows are anchored at the 4 handles, which are not meaningful as we just need to know which nodes are the source/target. That also creates intermingled arrow connections. Now, the anchor of the arrow will move with the pods. Ref: https://reactflow.dev/docs/examples/nodes/easy-connect/
3. auto-hide the toolbar when the mouse is not over the pods.

Before:

<img width="926" alt="Screenshot 2023-02-26 at 6 50 15 PM" src="https://user-images.githubusercontent.com/4576201/221405951-9595a369-ee6a-4f88-b891-e705eebb43c4.png">


After:


<img width="926" alt="Screenshot 2023-02-26 at 6 49 24 PM" src="https://user-images.githubusercontent.com/4576201/221405925-8426fb59-ebbd-4d08-940c-f3d2af1a38d7.png">


