### PR TITLE
persist arrows to db

### DIFF
--- a/api/prisma/migrations/20230227022751_refine_edge/migration.sql
+++ b/api/prisma/migrations/20230227022751_refine_edge/migration.sql
@@ -1,0 +1,37 @@
+/*
+  Warnings:
+
+  - The primary key for the `Edge` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `fromId` on the `Edge` table. All the data in the column will be lost.
+  - You are about to drop the column `toId` on the `Edge` table. All the data in the column will be lost.
+  - You are about to drop the column `podsId` on the `Repo` table. All the data in the column will be lost.
+  - Added the required column `sourceId` to the `Edge` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `targetId` to the `Edge` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Edge" DROP CONSTRAINT "Edge_fromId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Edge" DROP CONSTRAINT "Edge_toId_fkey";
+
+-- AlterTable
+ALTER TABLE "Edge" DROP CONSTRAINT "Edge_pkey",
+DROP COLUMN "fromId",
+DROP COLUMN "toId",
+ADD COLUMN     "repoId" TEXT,
+ADD COLUMN     "sourceId" TEXT NOT NULL,
+ADD COLUMN     "targetId" TEXT NOT NULL,
+ADD CONSTRAINT "Edge_pkey" PRIMARY KEY ("sourceId", "targetId");
+
+-- AlterTable
+ALTER TABLE "Repo" DROP COLUMN "podsId";
+
+-- AddForeignKey
+ALTER TABLE "Edge" ADD CONSTRAINT "Edge_sourceId_fkey" FOREIGN KEY ("sourceId") REFERENCES "Pod"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Edge" ADD CONSTRAINT "Edge_targetId_fkey" FOREIGN KEY ("targetId") REFERENCES "Pod"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Edge" ADD CONSTRAINT "Edge_repoId_fkey" FOREIGN KEY ("repoId") REFERENCES "Repo"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -69,7 +69,7 @@ model Repo {
     owner         User           @relation("OWNER", fields: [userId], references: [id])
     userId        String
     pods          Pod[]          @relation("BELONG")
-    podsId        String[]
+    edges         Edge[]
     public        Boolean        @default(false)
     collaborators User[]         @relation("COLLABORATOR")
     createdAt     DateTime       @default(now())
@@ -88,12 +88,14 @@ enum PodType {
 }
 
 model Edge {
-    from   Pod    @relation("FROM", fields: [fromId], references: [id])
-    fromId String
-    to     Pod    @relation("TO", fields: [toId], references: [id])
-    toId   String
+    source   Pod     @relation("SOURCE", fields: [sourceId], references: [id])
+    sourceId String
+    target   Pod     @relation("TARGET", fields: [targetId], references: [id])
+    targetId String
+    repo     Repo?   @relation(fields: [repoId], references: [id])
+    repoId   String?
 
-    @@id([fromId, toId])
+    @@id([sourceId, targetId])
 }
 
 model Pod {
@@ -146,6 +148,6 @@ model Pod {
 
     repoId String
     // this is just a place holder. Not useful
-    to     Edge[] @relation("TO")
-    from   Edge[] @relation("FROM")
+    source Edge[] @relation("SOURCE")
+    target Edge[] @relation("TARGET")
 }

--- a/api/src/typedefs.ts
+++ b/api/src/typedefs.ts
@@ -23,11 +23,17 @@ export const typeDefs = gql`
     id: ID!
     name: String
     pods: [Pod]
+    edges: [Edge]
     userId: ID!
     collaborators: [User]
     public: Boolean
     createdAt: String
     updatedAt: String
+  }
+
+  type Edge {
+    source: String!
+    target: String!
   }
 
   type Pod {
@@ -121,6 +127,8 @@ export const typeDefs = gql`
     deletePod(id: String!, toDelete: [String]): Boolean
     addPods(repoId: String!, pods: [PodInput]): Boolean
     updatePod(id: String!, repoId: String!, input: PodInput): Boolean
+    addEdge(source: ID!, target: ID!): Boolean
+    deleteEdge(source: ID!, target: ID!): Boolean
     clearUser: Boolean
     clearRepo: Boolean
     clearPod: Boolean

--- a/ui/src/components/nodes/FloatingEdge.tsx
+++ b/ui/src/components/nodes/FloatingEdge.tsx
@@ -3,7 +3,14 @@ import { useStore, getStraightPath, EdgeProps } from "reactflow";
 
 import { getEdgeParams } from "./utils";
 
-function FloatingEdge({ id, source, target, markerEnd, style }: EdgeProps) {
+function FloatingEdge({
+  id,
+  source,
+  target,
+  markerEnd,
+  style,
+  selected,
+}: EdgeProps) {
   const sourceNode = useStore(
     useCallback((store) => store.nodeInternals.get(source), [source])
   );
@@ -30,7 +37,7 @@ function FloatingEdge({ id, source, target, markerEnd, style }: EdgeProps) {
       className="react-flow__edge-path"
       d={edgePath}
       markerEnd={markerEnd}
-      style={style}
+      style={selected ? { ...style, stroke: "red" } : style}
     />
   );
 }

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -23,6 +23,10 @@ export async function doRemoteLoadRepo(client: ApolloClient<any>, id: string) {
           lastname
         }
         public
+        edges {
+          source
+          target
+        }
         pods {
           id
           type
@@ -70,8 +74,10 @@ export async function doRemoteLoadRepo(client: ApolloClient<any>, id: string) {
     await client.refetchQueries({ include: ["GetRepos", "GetCollabRepos"] });
     // We need to do a deep copy here, because apollo client returned immutable objects.
     let pods = res.data.repo.pods.map((pod) => ({ ...pod }));
+    let edges = res.data.repo.edges;
     return {
       pods,
+      edges,
       name: res.data.repo.name,
       error: null,
       userId: res.data.repo.userId,
@@ -82,6 +88,7 @@ export async function doRemoteLoadRepo(client: ApolloClient<any>, id: string) {
     console.log(e);
     return {
       pods: [],
+      edges: [],
       name: "",
       error: e,
       userId: null,

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useContext } from "react";
-import { applyNodeChanges, Node } from "reactflow";
+import { applyNodeChanges, Edge, Node } from "reactflow";
 import { RepoContext } from "./store";
 import { nodetype2dbtype } from "./utils";
 import { useStore } from "zustand";
@@ -77,4 +77,30 @@ export function useYjsObserver() {
       resetSelection();
     };
   }, [addPod, deletePod, nodesMap, resetSelection, setPodGeo, updateView]);
+}
+
+export function useEdgesYjsObserver() {
+  const store = useContext(RepoContext);
+  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const addPod = useStore(store, (state) => state.addPod);
+  const deletePod = useStore(store, (state) => state.deletePod);
+  const setPodGeo = useStore(store, (state) => state.setPodGeo);
+  const ydoc = useStore(store, (state) => state.ydoc);
+  const edgesMap = ydoc.getMap<Edge>("edges");
+  const updateEdgeView = useStore(store, (state) => state.updateEdgeView);
+  const resetSelection = useStore(store, (state) => state.resetSelection);
+
+  useEffect(() => {
+    const observer = (YMapEvent: YEvent<any>, transaction: Transaction) => {
+      if (transaction.local) return;
+      // console.log("== Edge observer", transaction);
+      updateEdgeView();
+    };
+
+    edgesMap.observe(observer);
+
+    return () => {
+      edgesMap.unobserve(observer);
+    };
+  }, [addPod, deletePod, edgesMap, resetSelection, setPodGeo, updateEdgeView]);
 }

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -755,7 +755,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     });
     // FIXME this will create edge with IDs. But I probably would love to control the IDs to save in DB.
     changes.forEach((change) => {
-      // console.log("=== change", change.type, change);
+      // console.log("=== onEdgeChange", change.type, change);
       // TODO update nodesMap to sync with remote peers
       switch (change.type) {
         case "add":

--- a/ui/src/lib/store/repoStateSlice.tsx
+++ b/ui/src/lib/store/repoStateSlice.tsx
@@ -32,6 +32,8 @@ console.log("yjs server url: ", serverURL);
 
 export interface RepoStateSlice {
   pods: Record<string, Pod>;
+  // From source pod id to target pod id.
+  arrows: { source: string; target: string }[];
   id2parent: Record<string, string>;
   id2children: Record<string, string[]>;
   setSessionId: (sessionId: string) => void;
@@ -81,6 +83,7 @@ export const createRepoStateSlice: StateCreator<
   RepoStateSlice
 > = (set, get) => ({
   pods: {},
+  arrows: [],
   id2parent: {},
   id2children: {},
   error: null,
@@ -284,7 +287,7 @@ export const createRepoStateSlice: StateCreator<
 
 function loadRepo(set, get) {
   return async (client, id) => {
-    const { pods, name, error, userId, collaborators, isPublic } =
+    const { pods, edges, name, error, userId, collaborators, isPublic } =
       await doRemoteLoadRepo(client, id);
     set(
       produce((state: MyState) => {
@@ -296,6 +299,7 @@ function loadRepo(set, get) {
           return;
         }
         state.pods = normalize(pods);
+        state.arrows = edges;
         state.repoName = name;
         state.isPublic = isPublic;
         state.collaborators = collaborators;


### PR DESCRIPTION
close #210 

Now arrows will be saved to the remote database and reloaded on refresh.

Also, the arrow can now be selected, and its color will turn **red**. Pressing the `delete` key will delete the arrow.

TODO:
- [x] support Yjs sync for remote peers

<img width="772" alt="Screenshot 2023-02-27 at 12 54 56 PM" src="https://user-images.githubusercontent.com/4576201/221477622-5a18e46d-f730-4540-bdb6-54757c42e98e.png">

