### PR TITLE
properly delete connected edges when deleting pods

### DIFF
--- a/api/src/typedefs.ts
+++ b/api/src/typedefs.ts
@@ -124,7 +124,7 @@ export const typeDefs = gql`
     createRepo: Repo
     updateRepo(id: ID!, name: String!): Boolean
     deleteRepo(id: ID!): Boolean
-    deletePod(id: String!, toDelete: [String]): Boolean
+    deletePods(ids: [String]): Boolean
     addPods(repoId: String!, pods: [PodInput]): Boolean
     updatePod(id: String!, repoId: String!, input: PodInput): Boolean
     addEdge(source: ID!, target: ID!): Boolean

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -305,6 +305,7 @@ function FloatingToolbar({ id }) {
           <IconButton
             size="small"
             onClick={() => {
+              // Delete all edges connected to the node.
               reactFlowInstance.deleteElements({ nodes: [{ id }] });
             }}
           >

--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -215,17 +215,19 @@ function serializePodInput(pod) {
   }))(pod);
 }
 
-export async function doRemoteDeletePod(client, { id, toDelete }) {
+export async function doRemoteDeletePod(
+  client: ApolloClient<any>,
+  ids: string[]
+) {
   const mutation = gql`
-    mutation deletePod($id: String!, $toDelete: [String]) {
-      deletePod(id: $id, toDelete: $toDelete)
+    mutation deletePods($ids: [String]) {
+      deletePods(ids: $ids)
     }
   `;
   await client.mutate({
     mutation,
     variables: {
-      id,
-      toDelete,
+      ids,
     },
   });
   return true;

--- a/ui/src/lib/store/podSlice.tsx
+++ b/ui/src/lib/store/podSlice.tsx
@@ -300,7 +300,7 @@ function deletePod(set, get) {
     { id }: { id: string }
   ) => {
     const pods = get().pods;
-    const toDelete: string[] = [];
+    const ids: string[] = [];
 
     // get all ids to delete. Gathering them here is easier than on the server
 
@@ -309,13 +309,13 @@ function deletePod(set, get) {
     const dfs = (id) => {
       const pod = pods[id];
       if (pod) {
-        toDelete.push(id);
+        ids.push(id);
         pod.children.forEach(dfs);
       }
     };
 
     dfs(id);
-    // pop in toDelete
+    // pop in ids
     set(
       produce((state: MyState) => {
         // delete the link to parent
@@ -326,13 +326,13 @@ function deletePod(set, get) {
           // remove all
           parent.children.splice(index, 1);
         }
-        toDelete.forEach((id) => {
+        ids.forEach((id) => {
           delete state.pods[id];
         });
       })
     );
     if (client) {
-      await doRemoteDeletePod(client, { id, toDelete });
+      await doRemoteDeletePod(client, ids);
     }
   };
 }


### PR DESCRIPTION
Previously, when a pod is deleted:
1. the `deletePods` GraphQL API call is fired.
2. the `deleteEdge` GraphQL API call is fired for all connected edges.

However, the `deletePods` operation might be executed before the edges are deleted, causing errors.

Now, this PR makes `deletePods` delete connected edges as well before the actual deleting of pods.