### PR TITLE
add run-norewrite button

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -38,6 +38,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import ContentCutIcon from "@mui/icons-material/ContentCut";
 import Grid from "@mui/material/Grid";
 import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
+import PlayDisabledIcon from "@mui/icons-material/PlayDisabled";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ViewComfyIcon from "@mui/icons-material/ViewComfy";
 import { CopyToClipboard } from "react-copy-to-clipboard";
@@ -228,6 +229,7 @@ function FloatingToolbar({ id }) {
   const devMode = useStore(store, (state) => state.devMode);
   // const pod = useStore(store, (state) => state.pods[id]);
   const wsRun = useStore(store, (state) => state.wsRun);
+  const wsRunNoRewrite = useStore(store, (state) => state.wsRunNoRewrite);
   const clearResults = useStore(store, (s) => s.clearResults);
   // right, bottom
   const [layout, setLayout] = useState("bottom");
@@ -275,6 +277,19 @@ function FloatingToolbar({ id }) {
             }}
           >
             <PlayCircleOutlineIcon fontSize="inherit" />
+          </IconButton>
+        </Tooltip>
+      )}
+      {!isGuest && (
+        <Tooltip title="Run without rewrite">
+          <IconButton
+            size="small"
+            onClick={() => {
+              clearResults(id);
+              wsRunNoRewrite(id);
+            }}
+          >
+            <PlayDisabledIcon fontSize="inherit" />
           </IconButton>
         </Tooltip>
       )}


### PR DESCRIPTION
This PR adds a new button, "run without rewrite".  This is only a **temporary workaround** to execute a class definition as the class name is not handled by the symbol-rewrite algorithm yet.

<img width="322" alt="Screenshot 2023-03-01 at 12 22 15 PM" src="https://user-images.githubusercontent.com/4576201/222044765-0b1f9503-8c44-44ea-b078-63c1c28cc53b.png">

So, for now, if you need to execute a class definition, use this "run without rewrite" button. This will be removed once the classname-symbol-rewrite feature is implemented.