### PR TITLE
Fix (better drag-n-drop): Scope Handler & Scope right-click Menu for adding new nodes

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -524,10 +524,22 @@ function CanvasImpl() {
   const [showContextMenu, setShowContextMenu] = useState(false);
   const [points, setPoints] = useState({ x: 0, y: 0 });
   const [client, setClient] = useState({ x: 0, y: 0 });
+  const [parentNode, setParentNode] = useState("ROOT");
 
   const onPaneContextMenu = (event) => {
     event.preventDefault();
     setShowContextMenu(true);
+    setParentNode("ROOT");
+    setPoints({ x: event.pageX, y: event.pageY });
+    setClient({ x: event.clientX, y: event.clientY });
+  };
+
+  const onNodeContextMenu = (event, node) => {
+    if (node?.type !== "scope") return;
+
+    event.preventDefault();
+    setShowContextMenu(true);
+    setParentNode(node.id);
     setPoints({ x: event.pageX, y: event.pageY });
     setClient({ x: event.clientX, y: event.clientY });
   };
@@ -603,6 +615,7 @@ function CanvasImpl() {
           maxZoom={10}
           minZoom={0.1}
           onPaneContextMenu={onPaneContextMenu}
+          onNodeContextMenu={onNodeContextMenu}
           nodeTypes={nodeTypes}
           // custom edge for easy connect
           edgeTypes={edgeTypes}
@@ -657,17 +670,22 @@ function CanvasImpl() {
             x={points.x}
             y={points.y}
             addCode={() =>
-              addNode("code", project({ x: client.x, y: client.y }))
+              addNode("code", project({ x: client.x, y: client.y }), parentNode)
             }
             addScope={() =>
-              addNode("scope", project({ x: client.x, y: client.y }))
+              addNode(
+                "scope",
+                project({ x: client.x, y: client.y }),
+                parentNode
+              )
             }
             addRich={() =>
-              addNode("rich", project({ x: client.x, y: client.y }))
+              addNode("rich", project({ x: client.x, y: client.y }), parentNode)
             }
             onShareClick={() => {
               setShareOpen(true);
             }}
+            parentNode={null}
           />
         )}
         {shareOpen && <ShareProjDialog open={shareOpen} id={repoId || ""} />}

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -113,7 +113,6 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
         border: isCutting ? "dashed 2px red" : "solid 1px #d6dee6",
         borderRadius: "4px",
       }}
-      className="custom-drag-handle"
     >
       {/* <NodeResizer color="#ff0071" minWidth={100} minHeight={30} /> */}
       <NodeResizeControl
@@ -194,6 +193,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
       <Box
         // bgcolor={"rgb(225,225,225)"}
         sx={{ display: "flex" }}
+        className="custom-drag-handle"
       >
         {devMode && (
           <Box

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -177,7 +177,6 @@ function getNodePositionInsideScope(
   let [dx, dy] = getAbsPos(scope, nodesMap);
   x -= dx;
   y -= dy;
-  console.log("pos", x, y, dx, dy);
   // auto-align the node to, keep it bound in the scope
   // FIXME: it assumes the scope must be larger than the node
   x = Math.max(x, 0);
@@ -407,7 +406,6 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
       dirty: true,
       pending: true,
     });
-    console.log("add node", node.height);
     if (parent !== "ROOT") {
       // we don't assign its parent when created, because we have to adjust its position to make it inside its parent.
       get().moveIntoScope(node.id, parent);
@@ -630,7 +628,6 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
       nodesMap,
       nodeHeight
     );
-    console.log("position", position);
     let newNode: Node = {
       ...node,
       position,

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -169,20 +169,22 @@ function getScopeAt(
 function getNodePositionInsideScope(
   node: Node,
   scope: Node,
-  nodesMap
+  nodesMap,
+  nodeHeight: number = 0
 ): XYPosition {
   // compute the actual position
   let [x, y] = getAbsPos(node, nodesMap);
   let [dx, dy] = getAbsPos(scope, nodesMap);
   x -= dx;
   y -= dy;
+  console.log("pos", x, y, dx, dy);
   // auto-align the node to, keep it bound in the scope
   // FIXME: it assumes the scope must be larger than the node
-
   x = Math.max(x, 0);
   x = Math.min(x, scope.width! - node.width!);
   y = Math.max(y, 0);
-  y = Math.min(y, scope.height! - node.height!);
+  // FIXME: node.height can be undefined
+  y = Math.min(y, scope.height! - nodeHeight);
   return { x, y };
 }
 
@@ -250,7 +252,11 @@ export interface CanvasSlice {
   setPaneFocus: () => void;
   setPaneBlur: () => void;
 
-  addNode: (type: "code" | "scope" | "rich", position: XYPosition) => void;
+  addNode: (
+    type: "code" | "scope" | "rich",
+    position: XYPosition,
+    parent: string
+  ) => void;
 
   pastingNodes?: Node[];
   headPastingNodes?: Set<string>;
@@ -390,7 +396,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     get().addPod({
       id: node.id,
       children: [],
-      parent,
+      parent: "ROOT",
       type: nodetype2dbtype(node.type || ""),
       lang: "python",
       x: node.position.x,
@@ -401,6 +407,11 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
       dirty: true,
       pending: true,
     });
+    console.log("add node", node.height);
+    if (parent !== "ROOT") {
+      // we don't assign its parent when created, because we have to adjust its position to make it inside its parent.
+      get().moveIntoScope(node.id, parent);
+    }
     get().updateView();
   },
 
@@ -610,7 +621,16 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     }
     // let [x, y] = getAbsPos(node, nodesMap);
     // let position = getNodePositionInsideParent(node, scope, { x, y });
-    let position = getNodePositionInsideScope(node, scope, nodesMap);
+
+    // FIXME: since richNode and codeNode doesn't have height when it's created, we have to pass its height manually in case crash.
+    const nodeHeight = get().getPod(nodeId)?.height || 0;
+    let position = getNodePositionInsideScope(
+      node,
+      scope,
+      nodesMap,
+      nodeHeight
+    );
+    console.log("position", position);
     let newNode: Node = {
       ...node,
       position,


### PR DESCRIPTION
1. Limit the draggable area of a scope to only the title bar (the same position as code nodes)
2. Right-click Menu in a scope node, you can create new nodes right in this scope instead of creating them outside and then dragging them into

<img width="767" alt="image" src="https://user-images.githubusercontent.com/10118462/233294855-01fd37b2-dd51-41c9-aff2-af8e1551f7b8.png">

Note: To make sure the created node totally inside the scope, it will adjust the position of the new created node like how you drag an existing node into a scope. However, the adjustment is pretty limited because we still lack an auto-layout logic of all nodes. Something funny may happen if you create a scope in a newly-created scope because they have the exact size (default size), you can hardly separate them then. **Refactoring is required after auto-layout/resize is implemented**.
