### PR TITLE
fix floating toolbar anchorEl warning

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -559,8 +559,7 @@ export const CodeNode = memo<NodeProps>(function ({
         </Box>
         <Box
           sx={{
-            // display: "flex",
-            display: showToolbar ? "flex" : "none",
+            opacity: showToolbar ? 1 : 0,
             marginLeft: "10px",
             borderRadius: "4px",
             position: "absolute",


### PR DESCRIPTION
The "floating toolbar" appears when the mouse enters the pod. To hide the toolbar, previously, we set `display: none`. This seems to trigger a warning of MUI's Tooltip component. This PR sets `opacity: 0` to hide the toolbar instead.

![Screenshot from 2023-04-21 10-46-50](https://user-images.githubusercontent.com/4576201/233702444-3a62c6e2-c02b-4c3f-b9a2-fd784caeca58.png)
