### PR TITLE
proper scope highlighting

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -79,8 +79,7 @@
   box-shadow: 0px 0px 12px 0px rgba(100, 100, 100, 0.9);
 }
 
-.react-flow__node-scope.selected,
-.react-flow__node-scope:hover {
+.react-flow__node-scope.selected {
   box-shadow: 0px 0px 8px 0px rgba(100, 100, 100, 0.5);
 }
 

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -497,6 +497,7 @@ function CanvasImpl() {
     store,
     (state) => state.removeDragHighlight
   );
+  const updateView = useStore(store, (state) => state.updateView);
 
   const addNode = useStore(store, (state) => state.addNode);
   const reactFlowInstance = useReactFlow();
@@ -584,7 +585,7 @@ function CanvasImpl() {
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
           onNodeDragStop={(event, node) => {
-            // removeDragHighlight();
+            removeDragHighlight();
             let mousePos = project({ x: event.clientX, y: event.clientY });
             // check if the mouse is still inside this node. If not, the user
             // has beenn trying to move a pod out.
@@ -601,11 +602,14 @@ function CanvasImpl() {
             if (scope && scope.id !== node.parentNode) {
               moveIntoScope(node.id, scope.id);
             }
+            // update view manually to remove the drag highlight.
+            updateView();
           }}
           onNodeDrag={(event, node) => {
             let mousePos = project({ x: event.clientX, y: event.clientY });
             let scope = getScopeAtPos(mousePos, node.id);
             if (scope) {
+              // The view is updated at the node position change.
               setDragHighlight(scope.id);
             } else {
               removeDragHighlight();


### PR DESCRIPTION
"Highlighting a scope" currently means adding a box-shadow. A scope is highlighted when:

1. it is "selected" by clicking on its header bar
2. the user move a pod over it, indicating the recipient scope

Specifically, this PR:
1. remove the hovering highlight because it's confusing and too eye-catching
2. fix the logic of removing the highlighting at the dragging end.