### PR TITLE
fix: delete user repo data before deleting a repo

### DIFF
--- a/api/src/resolver_repo.ts
+++ b/api/src/resolver_repo.ts
@@ -315,6 +315,18 @@ async function deleteRepo(_, { id }, { userId }) {
       },
     },
   });
+  // 2. delete UserRepoData
+  await prisma.userRepoData.deleteMany({
+    where: {
+      repo: {
+        id: repo.id,
+      },
+      user: {
+        id: userId,
+      }
+    },
+  });
+  // 3. delete the repo itself
   await prisma.repo.delete({
     where: {
       id: repo.id,


### PR DESCRIPTION
Fix a bug when deleting a repo, introduced by adding the userRepoData in #219.

![Screenshot from 2023-04-21 18-26-29](https://user-images.githubusercontent.com/4576201/233754637-274595a2-8961-4f64-9c10-f1f583b744de.png)
