### PR TITLE
feat: auto hide edge handles

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -490,30 +490,37 @@ export const CodeNode = memo<NodeProps>(function ({
       >
         <ResizeIcon />
       </NodeResizeControl> */}
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="top"
-        isConnectable={isConnectable}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottom"
-        isConnectable={isConnectable}
-      />
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="left"
-        isConnectable={isConnectable}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="right"
-        isConnectable={isConnectable}
-      />
+      <Box
+        sx={{
+          opacity: showToolbar ? 1 : 0,
+        }}
+      >
+        <Handle
+          type="source"
+          position={Position.Top}
+          id="top"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          id="bottom"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Left}
+          id="left"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="right"
+          isConnectable={isConnectable}
+        />
+      </Box>
+
       {/* The header of code pods. */}
       <Box className="custom-drag-handle">
         {devMode && (

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -217,12 +217,36 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
       >
         <MyFloatingToolbar id={id} />
       </Box>
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="top"
-        isConnectable={isConnectable}
-      />
+      <Box
+        sx={{
+          opacity: showToolbar ? 1 : 0,
+        }}
+      >
+        <Handle
+          type="source"
+          position={Position.Top}
+          id="top"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          id="bottom"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Left}
+          id="left"
+          isConnectable={isConnectable}
+        />
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="right"
+          isConnectable={isConnectable}
+        />
+      </Box>
       {/* The header of scope nodes. */}
       <Box
         // bgcolor={"rgb(225,225,225)"}
@@ -287,24 +311,6 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
           <Grid item xs={4}></Grid>
         </Grid>
       </Box>
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottom"
-        isConnectable={isConnectable}
-      />
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="left"
-        isConnectable={isConnectable}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="right"
-        isConnectable={isConnectable}
-      />
     </Box>
   );
 });


### PR DESCRIPTION
Now the edge handles will only appear when you move over a pod or a scope.

![Screenshot from 2023-04-28 14-59-48](https://user-images.githubusercontent.com/4576201/235261410-f5e4419c-299e-414e-9099-a4342696275a.png)
