### PR TITLE
feat: add auto-run setting for auto-layout

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -568,6 +568,7 @@ function CanvasImpl() {
   }, [setShowContextMenu, setPaneFocus, setPaneBlur]);
 
   const getScopeAtPos = useStore(store, (state) => state.getScopeAtPos);
+  const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
 
   return (
     <Box
@@ -604,8 +605,10 @@ function CanvasImpl() {
             }
             // update view manually to remove the drag highlight.
             updateView();
-            // TODO run auto layout
-            // autoForceGlobal();
+            // run auto layout on drag stop
+            if (autoRunLayout) {
+              autoForceGlobal();
+            }
           }}
           onNodeDrag={(event, node) => {
             let mousePos = project({ x: event.clientX, y: event.clientY });

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -48,6 +48,8 @@ function SidebarSettings() {
   );
   const devMode = useStore(store, (state) => state.devMode);
   const setDevMode = useStore(store, (state) => state.setDevMode);
+  const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
+  const setAutoRunLayout = useStore(store, (state) => state.setAutoRunLayout);
   return (
     <Box>
       <Box>
@@ -68,6 +70,26 @@ function SidebarSettings() {
                 />
               }
               label="Debug Mode"
+            />
+          </FormGroup>
+        </Tooltip>
+        <Tooltip
+          title={"Automatically run auto-layout at the end of node dragging."}
+          disableInteractive
+        >
+          <FormGroup>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={autoRunLayout}
+                  size="small"
+                  color="warning"
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setAutoRunLayout(event.target.checked);
+                  }}
+                />
+              }
+              label="Auto Run Layout"
             />
           </FormGroup>
         </Tooltip>

--- a/ui/src/lib/store/settingSlice.tsx
+++ b/ui/src/lib/store/settingSlice.tsx
@@ -8,6 +8,8 @@ export interface SettingSlice {
   setShowAnnotations: (b: boolean) => void;
   devMode?: boolean;
   setDevMode: (b: boolean) => void;
+  autoRunLayout?: boolean;
+  setAutoRunLayout: (b: boolean) => void;
 }
 
 export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
@@ -40,5 +42,13 @@ export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
     set({ devMode: b });
     // also write to local storage
     localStorage.setItem("devMode", JSON.stringify(b));
+  },
+  autoRunLayout: localStorage.getItem("autoRunLayout")
+    ? JSON.parse(localStorage.getItem("autoRunLayout")!)
+    : true,
+  setAutoRunLayout: (b: boolean) => {
+    set({ autoRunLayout: b });
+    // also write to local storage
+    localStorage.setItem("autoRunLayout", JSON.stringify(b));
   },
 });


### PR DESCRIPTION
Add a new setting, "auto-run layout". If it is switched on, the d3-force layout algorithm will run automatically when:
* at the end of node dragging
* adding a new node

The setting:

<img width=250 src="https://user-images.githubusercontent.com/4576201/235276698-ffcc4c75-5b19-4c60-94cb-e47e8724e830.jpg"/>



Before adding a node:
![Screenshot from 2023-04-28 18-10-43](https://user-images.githubusercontent.com/4576201/235275819-769cacb7-2744-4150-af72-372ced493357.png)

After:
![Screenshot from 2023-04-28 18-11-03](https://user-images.githubusercontent.com/4576201/235275833-51ee02f8-9c78-4654-80d0-6c05bf7a3f91.png)

