### PR TITLE
feat: add drag handles; remove Remirror's scrollbar

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -90,3 +90,8 @@
 .react-flow__handle {
   z-index: 100;
 }
+
+/* Remove the right scrollbar on Remirror. */
+.remirror-editor.ProseMirror {
+  overflow-y: hidden !important;
+}

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -42,6 +42,8 @@ import KeyboardDoubleArrowRightIcon from "@mui/icons-material/KeyboardDoubleArro
 import PlayDisabledIcon from "@mui/icons-material/PlayDisabled";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ViewComfyIcon from "@mui/icons-material/ViewComfy";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import Moveable from "react-moveable";
 import { ResizableBox } from "react-resizable";
@@ -266,7 +268,9 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
   );
 
   return (
-    <Box>
+    <Box
+      sx={{ display: "flex", alignItems: "center", justifyContent: "center" }}
+    >
       {!isGuest && (
         <Tooltip title="Run (shift-enter)">
           <IconButton
@@ -348,6 +352,9 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
           <ViewComfyIcon fontSize="inherit" />
         </IconButton>
       </Tooltip>
+      <Box className="custom-drag-handle">
+        <DragIndicatorIcon fontSize="small" />
+      </Box>
     </Box>
   );
 }
@@ -375,10 +382,6 @@ export const CodeNode = memo<NodeProps>(function ({
   const pod = getPod(id);
   const isGuest = useStore(store, (state) => state.role === "GUEST");
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
-  const index = useStore(
-    store,
-    (state) => state.pods[id]?.result?.count || " "
-  );
   const inputRef = useRef<HTMLInputElement>(null);
   const updateView = useStore(store, (state) => state.updateView);
   const isCutting = useStore(store, (state) => state.cuttingIds.has(id));
@@ -531,7 +534,7 @@ export const CodeNode = memo<NodeProps>(function ({
             </Box>
 
             {/* The header of code pods. */}
-            <Box className="custom-drag-handle">
+            <Box>
               {devMode && (
                 <Box
                   sx={{
@@ -579,16 +582,6 @@ export const CodeNode = memo<NodeProps>(function ({
               </Box>
               <Box
                 sx={{
-                  color: "#8b8282",
-                  textAlign: "left",
-                  paddingLeft: "5px",
-                  fontSize: "12px",
-                }}
-              >
-                [{index}]
-              </Box>
-              <Box
-                sx={{
                   opacity: showToolbar ? 1 : 0,
                   marginLeft: "10px",
                   borderRadius: "4px",
@@ -600,7 +593,6 @@ export const CodeNode = memo<NodeProps>(function ({
                   zIndex: 250,
                   justifyContent: "center",
                 }}
-                className="nodrag"
               >
                 <MyFloatingToolbar
                   id={id}
@@ -612,6 +604,7 @@ export const CodeNode = memo<NodeProps>(function ({
             <Box
               sx={{
                 height: "90%",
+                py: 1,
               }}
             >
               <MyMonaco id={id} gitvalue="" />

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -49,6 +49,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import ViewComfyIcon from "@mui/icons-material/ViewComfy";
 import RectangleIcon from "@mui/icons-material/Rectangle";
 import DisabledByDefaultIcon from "@mui/icons-material/DisabledByDefault";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 
 import {
   BoldExtension,
@@ -286,6 +287,9 @@ function MyFloatingToolbar({ id }: { id: string }) {
           </IconButton>
         </Tooltip>
       )}
+      <Box className="custom-drag-handle">
+        <DragIndicatorIcon fontSize="small" />
+      </Box>
     </>
   );
 }
@@ -455,7 +459,7 @@ export const RichNode = memo<Props>(function ({
                 isConnectable={isConnectable}
               />
             </Box>
-            <Box className="custom-drag-handle">
+            <Box>
               {devMode && (
                 <Box
                   sx={{
@@ -473,13 +477,7 @@ export const RichNode = memo<Props>(function ({
               )}
               <Box
                 sx={{
-                  height: "1em",
-                }}
-              ></Box>
-              <Box
-                sx={{
                   position: "absolute",
-
                   top: "-24px",
                   width: "50%",
                 }}
@@ -521,8 +519,8 @@ export const RichNode = memo<Props>(function ({
                   background: "white",
                   zIndex: 250,
                   justifyContent: "center",
+                  alignItems: "center",
                 }}
-                className="nodrag"
               >
                 <MyFloatingToolbar id={id} />
               </Box>

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -36,6 +36,8 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
 import ViewTimelineOutlinedIcon from "@mui/icons-material/ViewTimelineOutlined";
 import CompressIcon from "@mui/icons-material/Compress";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+
 import Moveable from "react-moveable";
 
 import { useStore } from "zustand";
@@ -86,7 +88,12 @@ function MyFloatingToolbar({ id }: { id: string }) {
   const autoLayout = useStore(store, (state) => state.autoLayout);
   const autoForce = useStore(store, (state) => state.autoForce);
   return (
-    <Box>
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+      }}
+    >
       {!isGuest && (
         <Tooltip title="Run (shift-enter)">
           <IconButton
@@ -167,6 +174,9 @@ function MyFloatingToolbar({ id }: { id: string }) {
           </IconButton>
         </Tooltip>
       )}
+      <Box className="custom-drag-handle">
+        <DragIndicatorIcon fontSize="small" />
+      </Box>
     </Box>
   );
 }
@@ -247,7 +257,6 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
           zIndex: 250,
           justifyContent: "center",
         }}
-        className="nodrag"
       >
         <MyFloatingToolbar id={id} />
       </Box>
@@ -285,7 +294,6 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
       <Box
         // bgcolor={"rgb(225,225,225)"}
         sx={{ display: "flex" }}
-        className="custom-drag-handle"
       >
         {devMode && (
           <Box
@@ -295,7 +303,6 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
               userSelect: "text",
               cursor: "auto",
             }}
-            className="nodrag"
           >
             {id} at ({xPos}, {yPos}), w: {pod.width}, h: {pod.height} level:{" "}
             {data.level}


### PR DESCRIPTION
Now the pods and scopes can only be dragged by the drag handle in the floating toolbar:

![Screenshot from 2023-04-29 10-46-39](https://user-images.githubusercontent.com/4576201/235316994-49dfde9e-3f76-435e-841c-52722365f9d7.png)

The headers of code and rich-text pods are removed. The scrollbar of Remirror is removed. The UI should be very clean now.

![Screenshot from 2023-04-29 10-51-34](https://user-images.githubusercontent.com/4576201/235317023-44918222-8bd4-440f-b7fa-93d73b783d68.png)
