### PR TITLE
fix: cannot delete repos shared with others

### DIFF
--- a/api/src/resolver_repo.ts
+++ b/api/src/resolver_repo.ts
@@ -293,11 +293,7 @@ async function updateRepo(_, { id, name }, { userId }) {
 
 async function deleteRepo(_, { id }, { userId }) {
   if (!userId) throw Error("Unauthenticated");
-  const user = await prisma.user.findFirst({
-    where: {
-      id: userId,
-    },
-  });
+  // only a repo owner can delete a repo.
   const repo = await prisma.repo.findFirst({
     where: {
       id,
@@ -321,9 +317,6 @@ async function deleteRepo(_, { id }, { userId }) {
       repo: {
         id: repo.id,
       },
-      user: {
-        id: userId,
-      }
     },
   });
   // 3. delete the repo itself


### PR DESCRIPTION
The bug prevented deleting a repo that has been shared with others. The fix is to delete all UserRepoData associated with it.