### PR TITLE
add isGuest field and make guest userId the same format as registered users

### DIFF
--- a/api/prisma/migrations/20230501222052_add_isguset_field/migration.sql
+++ b/api/prisma/migrations/20230501222052_add_isguset_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isGuest" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -42,6 +42,7 @@ model User {
     lastname       String
     // A user might not have a password, if they login via OAuth.
     hashedPassword String?
+    isGuest        Boolean @default(false)
 
     createdAt    DateTime       @default(now())
     updatedAt    DateTime       @default(now()) @updatedAt

--- a/api/src/resolver_user.ts
+++ b/api/src/resolver_user.ts
@@ -50,10 +50,11 @@ async function signupGuest(_, {}) {
   const id = await nanoid();
   const user = await prisma.user.create({
     data: {
-      id: "guest_" + id,
-      email: "guest_" + id + "@example.com",
+      id: id,
+      email: id + "@example.com",
       firstname: "Guest",
       lastname: "Guest",
+      isGuest: true,
     },
   });
   return {
@@ -70,7 +71,9 @@ async function signupGuest(_, {}) {
 async function loginGuest(_, {id}) {
   const user = await prisma.user.findFirst({
     where: {
-      id,}
+      id,
+      isGuest: true,
+    }
   });
   if (!user) throw Error(`User does not exist`);
   return {


### PR DESCRIPTION
The guest user's ID was `guset_<nanoid>`. This creates potential consistency issues when handling the userId.

Now we remove the `guest_` prefix and add a `isGuest` field to the DB table instead.