### PR TITLE
set autorun-layout setting default to false

### DIFF
--- a/ui/src/lib/store/settingSlice.tsx
+++ b/ui/src/lib/store/settingSlice.tsx
@@ -45,7 +45,7 @@ export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
   },
   autoRunLayout: localStorage.getItem("autoRunLayout")
     ? JSON.parse(localStorage.getItem("autoRunLayout")!)
-    : true,
+    : false,
   setAutoRunLayout: (b: boolean) => {
     set({ autoRunLayout: b });
     // also write to local storage


### PR DESCRIPTION
The auto-layout algorithm now detects only circle collision, which is not ideal.

The auto-run was enabled by default in #246 . Now disable this by default in setting.