### PR TITLE
fix: drag on toolbar handle into a scope

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -75,15 +75,15 @@
   text-decoration: wavy underline red;
 }
 
-.react-flow__node-scope.active {
+.react-flow__node-SCOPE.active {
   box-shadow: 0px 0px 12px 0px rgba(100, 100, 100, 0.9);
 }
 
-.react-flow__node-scope.selected {
+.react-flow__node-SCOPE.selected {
   box-shadow: 0px 0px 8px 0px rgba(100, 100, 100, 0.5);
 }
 
-.react-flow__node-scope.selected {
+.react-flow__node-SCOPE.selected {
   border-width: 2px;
 }
 

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -588,17 +588,6 @@ function CanvasImpl() {
           onNodeDragStop={(event, node) => {
             removeDragHighlight();
             let mousePos = project({ x: event.clientX, y: event.clientY });
-            // check if the mouse is still inside this node. If not, the user
-            // has beenn trying to move a pod out.
-            if (
-              mousePos.x < node.positionAbsolute!.x ||
-              mousePos.y < node.positionAbsolute!.y ||
-              mousePos.x > node.positionAbsolute!.x + node.width! ||
-              mousePos.y > node.positionAbsolute!.y + node.height!
-            ) {
-              console.log("Cannot drop outside parent scope");
-              return;
-            }
             let scope = getScopeAtPos(mousePos, node.id);
             if (scope && scope.id !== node.parentNode) {
               moveIntoScope(node.id, scope.id);


### PR DESCRIPTION
Dragging on the toolbar handle into the scope might not work.

This is because the new darg handler in the toolbar (#248) is outside of the node, and there was a check that will prevent moving into a scope. The check was used to restrict a node not to be moved outside its parent scope. This restriction was removed in #236 to support auto-shrink/enlarge, so we no longer need to check the positions. Removing that check fix the regression.

The scope should have a shadow when a node is dragging over it. The dragging shadow was not working due to a CSS class name change in #241, this PR fixes that as well.