### PR TITLE
show `cursor: grab` only on drag handle

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -352,7 +352,7 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
           <ViewComfyIcon fontSize="inherit" />
         </IconButton>
       </Tooltip>
-      <Box className="custom-drag-handle">
+      <Box className="custom-drag-handle" sx={{ cursor: "grab" }}>
         <DragIndicatorIcon fontSize="small" />
       </Box>
     </Box>
@@ -478,6 +478,9 @@ export const CodeNode = memo<NodeProps>(function ({
         }}
         onMouseLeave={() => {
           setShowToolbar(false);
+        }}
+        sx={{
+          cursor: "auto",
         }}
       >
         {Wrap(

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -287,7 +287,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
           </IconButton>
         </Tooltip>
       )}
-      <Box className="custom-drag-handle">
+      <Box className="custom-drag-handle" sx={{ cursor: "grab" }}>
         <DragIndicatorIcon fontSize="small" />
       </Box>
     </>
@@ -408,6 +408,9 @@ export const RichNode = memo<Props>(function ({
         }}
         onMouseLeave={() => {
           setShowToolbar(false);
+        }}
+        sx={{
+          cursor: "auto",
         }}
       >
         {" "}

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -174,7 +174,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
           </IconButton>
         </Tooltip>
       )}
-      <Box className="custom-drag-handle">
+      <Box className="custom-drag-handle" sx={{ cursor: "grab" }}>
         <DragIndicatorIcon fontSize="small" />
       </Box>
     </Box>
@@ -222,6 +222,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
         height: "100%",
         border: isCutting ? "dashed 2px red" : "solid 1px #d6dee6",
         borderRadius: "4px",
+        cursor: "auto",
       }}
       onMouseEnter={() => {
         setShowToolbar(true);


### PR DESCRIPTION
The cursor will only be shown as "grab" when it is over the handle, so that it is more clear to users as to where to drag. 