### PR TITLE
use remirror image extension

### DIFF
--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -54,6 +54,8 @@ import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import {
   BoldExtension,
   CalloutExtension,
+  DropCursorExtension,
+  ImageExtension,
   ItalicExtension,
   LinkExtension,
   PlaceholderExtension,
@@ -409,6 +411,8 @@ const MyEditor = ({
       new SupExtension(),
       new SubExtension(),
       new LinkExtension({ autoLink: true }),
+      new ImageExtension({ enableResizing: true }),
+      new DropCursorExtension(),
       // new CalloutExtension({ defaultType: "warn" }),
       ...wysiwygPreset(),
     ],


### PR DESCRIPTION
Now you can drag and drop a picture onto the rich-text editor. It supports resizing the image.

![Screenshot from 2023-05-03 01-45-28](https://user-images.githubusercontent.com/4576201/235870438-781dff8c-047a-4097-9e28-bb06be9794ca.png)
