### PR TITLE
feat: add slash command to insert remirror table

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -95,3 +95,30 @@
 .remirror-editor.ProseMirror {
   overflow-y: hidden !important;
 }
+
+
+.mention {
+  background: #7963d266;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.remirror-theme {
+  /* Provide sufficient space to see the popup */
+  --rmr-space-6: 400px;
+}
+.suggestions {
+  border: 1px solid darkgray;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+}
+.suggestion {
+  padding: 2px 8px;
+}
+.highlighted {
+  background: #7963d233;
+}
+.hovered {
+  background: #7963d222;
+}

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -105,7 +105,7 @@ import { TableExtension } from "@remirror/extension-react-tables";
 import { GenIcon, IconBase } from "@remirror/react-components";
 import "remirror/styles/all.css";
 
-import { ProsemirrorPlugin, htmlToProsemirrorNode } from "remirror";
+import { ProsemirrorPlugin, cx, htmlToProsemirrorNode } from "remirror";
 import { styled } from "@mui/material";
 
 import { MyYjsExtension } from "./YjsRemirror";


### PR DESCRIPTION
To insert a table into the rich-text editor, type `/table` then press `<enter>`. Note:
1. must type in full `/table`; selecting from the drop-down table won't work.
2. the `/table` text will be inserted. Ideally we'd remove it after a table is inserted.

These are the limitations of using the `MentionExtension` to implement slash commands.

![Screenshot from 2023-05-03 04-51-57](https://user-images.githubusercontent.com/4576201/235908344-5ad43587-c90d-4078-bdc6-a7f311e0f9de.png)
