### PR TITLE
fix: web-tree-sitter load wasm error

### DIFF
--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -12256,9 +12256,9 @@ wbuf@^1.1.0, wbuf@^1.7.3:
     minimalistic-assert "^1.0.0"
 
 web-tree-sitter@^0.20.7:
-  version "0.20.8"
-  resolved "https://registry.yarnpkg.com/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz#1e371cb577584789cadd75cb49c7ddfbc99d04c8"
-  integrity sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==
+  version "0.20.7"
+  resolved "https://registry.yarnpkg.com/web-tree-sitter/-/web-tree-sitter-0.20.7.tgz#b0ddb78e8244221a3100f432c7e162516cd9cd09"
+  integrity sha512-flC9JJmTII9uAeeYpWF8hxDJ7bfY+leldQryetll8Nv4WgI+MXc6h7TiyAZASWl9uC9TvmfdgOjZn1DAQecb3A==
 
 web-vitals@^2.1.0:
   version "2.1.4"


### PR DESCRIPTION
#260 updated `yarn.lock` and upgraded web-tree-sitter package from `0.20.7` to `0.20.8`, which broke the loading of tree-sitter wasm with the following error. This is weird; this PR revert the version.

```
Uncaught (in promise) RuntimeError: Aborted(LinkError: WebAssembly.instantiate(): 
Import #1 module="env" function="setTempRet0" error: function import requires a callable). 
Build with -sASSERTIONS for more info.
    at abort (tree-sitter.js:1:6824)
    at tree-sitter.js:1:8574
```

![Screenshot from 2023-05-03 12-20-09](https://user-images.githubusercontent.com/4576201/236022683-9846bdab-44cd-42af-b1c1-7f10b2d5cae4.png)
