### PR TITLE
feat: persist execution results to DB

### DIFF
--- a/ui/src/lib/fetch.tsx
+++ b/ui/src/lib/fetch.tsx
@@ -182,6 +182,7 @@ export function normalize(pods) {
     if (pod.error) {
       pod.error = JSON.parse(pod.error);
     }
+    if (pod.stdout) pod.stdout = JSON.parse(pod.stdout);
     // DEBUG the deck's content seems to be a long string of escaped \
     if (pod.type === "SCOPE" && pod.content) {
       console.log(
@@ -220,14 +221,14 @@ function serializePodInput(pod) {
     type: nodetype2dbtype(type),
     column,
     lang,
-    // stdout,
     fold,
     thundar,
     utility,
     name,
     content: JSON.stringify(content),
-    // result: JSON.stringify(result),
-    // error: JSON.stringify(error),
+    stdout: JSON.stringify(stdout),
+    result: JSON.stringify(result),
+    error: JSON.stringify(error),
     x,
     y,
     width,

--- a/ui/src/lib/store/podSlice.tsx
+++ b/ui/src/lib/store/podSlice.tsx
@@ -144,6 +144,7 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
     set(
       produce((state) => {
         state.pods[id].stdout = stdout;
+        state.pods[id].dirty = true;
       })
     ),
   setPodResult: setPodResult(set, get),
@@ -157,6 +158,7 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
           image: content.data["image/png"],
           count: count,
         };
+        state.pods[id].dirty = true;
       })
     ),
   setPodExecuteReply: ({ id, result, count }) =>
@@ -192,6 +194,7 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
           evalue,
           stacktrace,
         };
+        state.pods[id].dirty = true;
       })
     ),
   setPodStream: ({ id, content }) =>
@@ -215,6 +218,7 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
           };
         }
         pod.stdout += content.text;
+        pod.dirty = true;
       })
     ),
   setPodExecuteResult: ({ id, result, name }) =>
@@ -364,6 +368,7 @@ function setPodResult(set, get) {
             // file,
             count,
           };
+          state.pods[id].dirty = true;
           // state.pods[id].running = false;
         } else {
           // most likely this id is "CODEPOD", which is for startup code and


### PR DESCRIPTION
The results are now saved to DB, which will be reloaded after refreshing or re-opening the project.