### PR TITLE
fix: filter comment nodes when compile ForStmt

### DIFF
--- a/ui/src/lib/parser.tsx
+++ b/ui/src/lib/parser.tsx
@@ -284,7 +284,7 @@ function compileListComprehension(node: Parser.SyntaxNode, st: any) {
 }
 
 function compileForStatement(node: Parser.SyntaxNode, st: any) {
-  let [left, right, body] = node.namedChildren;
+  let [left, right, body] = node.namedChildren.filter(notComment);
   compileExpression(right, st);
   st = union(st, compileLHS(left, st));
   compileBlock(body, st);


### PR DESCRIPTION
Tree-sitter normally parses a for-statement into `[left,right,body]`, but if there're comments at the beginning of the body, it will be parsed into `[left,right,comment,comment,...,body]`. This causes our compiler to miss the real body. This PR fixes it.

Before, no unbound identifiers are marked:

![Screenshot from 2023-05-04 08-28-15](https://user-images.githubusercontent.com/4576201/236256520-3ec2f02c-369d-4ee7-b5b9-f4c6e9f17ded.png)

After, unbound identifiers are marked correctly:

![Screenshot from 2023-05-04 08-28-02](https://user-images.githubusercontent.com/4576201/236256553-52cb0d1d-d9b4-4aab-adf3-992f6b815cd5.png)
