### PR TITLE
fix: binary-op parsing

### DIFF
--- a/ui/src/lib/parser.tsx
+++ b/ui/src/lib/parser.tsx
@@ -723,7 +723,7 @@ function compileExpression(node: Parser.SyntaxNode, st) {
       return compileExpression(obj, st);
     case "binary_operator":
     case "boolean_operator": {
-      let [left, , right] = node.namedChildren.filter(notComment);
+      let [left, right] = node.namedChildren.filter(notComment);
       compileExpression(left, st);
       compileExpression(right, st);
       return new Set();


### PR DESCRIPTION
Introduced in #268, where the `node.children` is replaced with `node.namedChildren` but forgets to update the receiving variable list.

```diff
@@ -694,11 +694,11 @@ function compileExpression(node: Parser.SyntaxNode, st) {
     case "await":
       return compileExpression(node.firstNamedChild!, st);
     ...
     case "binary_operator":
     case "boolean_operator": {
-      let [left, , right] = node.namedChildren.filter(notComment);
+      let [left, , right] = node.children;
       compileExpression(left, st);
       compileExpression(right, st);
```

Now, both a() and b() can be recognized.

![Screenshot from 2023-05-05 12-02-36](https://user-images.githubusercontent.com/4576201/236547349-e7b25cff-4cbf-41cc-9de2-04909f593b7f.png)
