### PR TITLE
add more auto-layout ticks

### DIFF
--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -1053,7 +1053,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
       // .force("charge", d3.forceManyBody())
       // .force("center", forceCenter(0, 0))
       .stop();
-    simulation.tick(1);
+    simulation.tick(10);
     tmpNodes.forEach((node) => {
       node.x -= node.width! / 2;
       node.y -= node.height! / 2;


### PR DESCRIPTION
The d3-force-layout applies the physical force to the nodes in iterations. We used 1 iteration, but it may not fully push nodes apart. Now we use 10.

Before:
<img width=400 src="https://user-images.githubusercontent.com/4576201/236549900-ba744a9d-4b67-4d15-82ca-5083440279e7.png"/>

After:
<img width=400 src="https://user-images.githubusercontent.com/4576201/236549915-2695ebe8-462f-4b49-8d66-317893cd78e0.png"/>
