### PR TITLE
fix edge zindex to make edges selectible above scope background

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -122,3 +122,7 @@
 .hovered {
   background: #7963d222;
 }
+
+.react-flow__edges {
+  z-index: 9999 !important;
+}


### PR DESCRIPTION
We have to set `.react-flow__edges`'s `z-index` property. Reference: https://github.com/wbkd/react-flow/issues/3020#issuecomment-1527349777.

You can select an edge by clicking on it, which will turn red. Press `<backspace>` to delete the edge.

Before:
<img width=600 src="https://user-images.githubusercontent.com/4576201/236586121-8b01e7ab-6dbb-4229-b888-053492aec9bd.png"/>


After:
<img width=600 src="https://user-images.githubusercontent.com/4576201/236586116-aac2956f-ff21-4f29-be85-11b467b1bc4e.png"/>


