### PR TITLE
allow pod to be moved into ROOT scope

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -599,8 +599,9 @@ function CanvasImpl() {
             removeDragHighlight();
             let mousePos = project({ x: event.clientX, y: event.clientY });
             let scope = getScopeAtPos(mousePos, node.id);
-            if (scope && scope.id !== node.parentNode) {
-              moveIntoScope(node.id, scope.id);
+            let toScope = scope ? scope.id : "ROOT";
+            if (toScope !== node.parentNode) {
+              moveIntoScope(node.id, toScope);
             }
             // update view manually to remove the drag highlight.
             updateView();


### PR DESCRIPTION
Now when moving a pod, it can be moved into any scope, including ROOT scope.

At this point, the drag-n-drop behavior is very straightforward: just drag it anywhere and it will be moved there. The cut-n-paste function is now deprecated.