### PR TITLE
fix: disconnect parentnode in DB; fix ROOT scopeId compare

### DIFF
--- a/api/src/resolver_repo.ts
+++ b/api/src/resolver_repo.ts
@@ -406,14 +406,15 @@ async function updatePod(_, { id, repoId, input }, { userId }) {
     },
     data: {
       ...input,
-      parent:
-        input.parent && input.parent !== "ROOT"
-          ? {
+      parent: input.parent
+        ? input.parent === "ROOT"
+          ? { disconnect: true }
+          : {
               connect: {
                 id: input.parent,
               },
             }
-          : undefined,
+        : undefined,
       children: {
         connect: input.children?.map((id) => ({ id })),
       },

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -600,7 +600,8 @@ function CanvasImpl() {
             let mousePos = project({ x: event.clientX, y: event.clientY });
             let scope = getScopeAtPos(mousePos, node.id);
             let toScope = scope ? scope.id : "ROOT";
-            if (toScope !== node.parentNode) {
+            const parentScope = node.parentNode ? node.parentNode : "ROOT";
+            if (toScope !== parentScope) {
               moveIntoScope(node.id, toScope);
             }
             // update view manually to remove the drag highlight.


### PR DESCRIPTION
Fixed two bugs related to #280:
1. when updating the parent node to ROOT in DB, we need to disconnect the previous parent pod, because Prisma treats `undefined` as `do nothing` instead of `disconnect`.
2. correctly compare the ROOT scopeID to avoid duplicate moveIntoScope calls