### PR TITLE
feat: add contextual zoom

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -76,7 +76,7 @@
 }
 
 .react-flow__node-SCOPE.active {
-  box-shadow: 0px 0px 12px 0px rgba(100, 100, 100, 0.9);
+  box-shadow: 2px 2px 2px 2px rgba(208,2,27,1), 8px 8px 8px 8px rgba(218,102,123,1);
 }
 
 .react-flow__node-SCOPE.selected {
@@ -125,4 +125,11 @@
 
 .react-flow__edges {
   z-index: 9999 !important;
+}
+
+/* some scope nodes have z-index: 1000. This is set internally by reactflow, we
+have to force set the collapsed scope block (when contextual zoomed) to be above
+it, so that we can drag the block. */
+.react-flow__node:has(.scope-block) {
+  z-index: 1001 !important;
 }

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -23,6 +23,7 @@ import ReactFlow, {
   Node,
   ReactFlowProvider,
   Edge,
+  useViewport,
 } from "reactflow";
 import "reactflow/dist/style.css";
 
@@ -213,12 +214,6 @@ function useInitNodes() {
         console.warn(
           "The yjs server is not consistent with the database. Resetting the yjs server"
         );
-        // throw new Error("Inconsistent state");
-        //
-        // CAUTION should not use nodesMap.clear(), as it would delete all
-        // nodes! Both local and in database.
-        let nodesMap2 = new Map<string, Node>();
-        nodes.forEach((node) => nodesMap2.set(node.id, node));
         // Not only should we set nodes, but also delete.
         nodesMap.clear();
         // add the nodes, so that the nodesMap is consistent with the database.
@@ -467,6 +462,30 @@ function CanvasImplWrap() {
   return (
     <Box sx={{ height: "100%" }} ref={reactFlowWrapper}>
       <CanvasImpl />
+      <ViewportInfo />
+    </Box>
+  );
+}
+
+function ViewportInfo() {
+  const store = useContext(RepoContext);
+  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const { x, y, zoom } = useViewport();
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        bottom: 0,
+        right: 0,
+        backgroundColor: "rgba(0,0,0,0.5)",
+        color: "white",
+        padding: 1,
+        fontSize: 12,
+        borderRadius: 1,
+        zIndex: 100,
+      }}
+    >
+      {`x: ${x.toFixed(2)}, y: ${y.toFixed(2)}, zoom: ${zoom.toFixed(2)}`}
     </Box>
   );
 }

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -2,6 +2,7 @@ import { Position } from "monaco-editor";
 import { useState, useContext, memo, useCallback, useEffect } from "react";
 import MonacoEditor, { MonacoDiffEditor } from "react-monaco-editor";
 import { monaco } from "react-monaco-editor";
+import { Node } from "reactflow";
 import { useStore } from "zustand";
 import { RepoContext } from "../lib/store";
 import { MonacoBinding } from "y-monaco";
@@ -373,12 +374,12 @@ async function updateGitGutter(editor) {
 
 interface MyMonacoProps {
   id: string;
-  gitvalue: string;
+  fontSize: number;
 }
 
 export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   id = "0",
-  gitvalue = null,
+  fontSize = 14,
 }) {
   // there's no racket language support
   console.debug("[perf] rendering MyMonaco", id);
@@ -535,6 +536,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
           alwaysConsumeMouseWheel: false,
           vertical: "hidden",
         },
+        fontSize,
       }}
       onChange={onChange}
       editorDidMount={onEditorDidMount}

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -50,6 +50,8 @@ function SidebarSettings() {
   const setDevMode = useStore(store, (state) => state.setDevMode);
   const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
   const setAutoRunLayout = useStore(store, (state) => state.setAutoRunLayout);
+  const contextualZoom = useStore(store, (state) => state.contextualZoom);
+  const setContextualZoom = useStore(store, (state) => state.setContextualZoom);
   return (
     <Box>
       <Box>
@@ -90,6 +92,23 @@ function SidebarSettings() {
                 />
               }
               label="Auto Run Layout"
+            />
+          </FormGroup>
+        </Tooltip>
+        <Tooltip title={"Enable contextual zoom."} disableInteractive>
+          <FormGroup>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={contextualZoom}
+                  size="small"
+                  color="warning"
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setContextualZoom(event.target.checked);
+                  }}
+                />
+              }
+              label="Contextual Zoom"
             />
           </FormGroup>
         </Tooltip>

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -432,6 +432,10 @@ export const CodeNode = memo<NodeProps>(function ({
   const zoomLevel = useReactFlowStore((s) => s.transform[2]);
   const contextualZoom = useStore(store, (state) => state.contextualZoom);
   const level2fontsize = useStore(store, (state) => state.level2fontsize);
+  const threshold = useStore(
+    store,
+    (state) => state.contextualZoomParams.threshold
+  );
 
   // if (!pod) throw new Error(`Pod not found: ${id}`);
 
@@ -449,13 +453,13 @@ export const CodeNode = memo<NodeProps>(function ({
   if (
     contextualZoom &&
     node?.data.level > 0 &&
-    parentFontSize * zoomLevel < 8
+    parentFontSize * zoomLevel < threshold
   ) {
     // The parent scope is not shown, this node is not gonna be rendered at all.
     return <Box></Box>;
   }
 
-  if (contextualZoom && fontSize * zoomLevel < 8) {
+  if (contextualZoom && fontSize * zoomLevel < threshold) {
     // Return a collapsed block.
     let text = pod.content;
     if (text) {
@@ -468,7 +472,7 @@ export const CodeNode = memo<NodeProps>(function ({
     return (
       <Box
         sx={{
-          fontSize: fontSize * 4,
+          fontSize: fontSize * 2,
           background: "#eee",
           borderRadius: "5px",
           border: "5px solid red",

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -104,6 +104,7 @@ import { FloatingToolbar, useExtensionEvent } from "@remirror/react";
 import { TableExtension } from "@remirror/extension-react-tables";
 import { GenIcon, IconBase } from "@remirror/react-components";
 import "remirror/styles/all.css";
+import "./remirror-size.css";
 
 import { ProsemirrorPlugin, cx, htmlToProsemirrorNode } from "remirror";
 import { styled } from "@mui/material";
@@ -717,6 +718,10 @@ export const RichNode = memo<Props>(function ({
   const zoomLevel = useReactFlowStore((s) => s.transform[2]);
   const contextualZoom = useStore(store, (state) => state.contextualZoom);
   const level2fontsize = useStore(store, (state) => state.level2fontsize);
+  const threshold = useStore(
+    store,
+    (state) => state.contextualZoomParams.threshold
+  );
 
   if (!pod) return null;
 
@@ -728,13 +733,13 @@ export const RichNode = memo<Props>(function ({
   if (
     contextualZoom &&
     node?.data.level > 0 &&
-    parentFontSize * zoomLevel < 8
+    parentFontSize * zoomLevel < threshold
   ) {
     // The parent scope is not shown, this node is not gonna be rendered at all.
     return <Box></Box>;
   }
 
-  if (contextualZoom && fontSize * zoomLevel < 8) {
+  if (contextualZoom && fontSize * zoomLevel < threshold) {
     // Return a collapsed block.
     let text = "";
     if (pod.content) {
@@ -746,7 +751,7 @@ export const RichNode = memo<Props>(function ({
     return (
       <Box
         sx={{
-          fontSize: fontSize * 4,
+          fontSize: fontSize * 2,
           background: "#eee",
           borderRadius: "5px",
           border: "5px solid red",
@@ -814,6 +819,7 @@ export const RichNode = memo<Props>(function ({
         }}
         sx={{
           cursor: "auto",
+          fontSize,
         }}
       >
         {" "}

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -29,6 +29,7 @@ import ReactFlow, {
   ConnectionMode,
   MarkerType,
   Node,
+  useStore as useReactFlowStore,
 } from "reactflow";
 import "reactflow/dist/style.css";
 import Ansi from "ansi-to-react";
@@ -713,7 +714,62 @@ export const RichNode = memo<Props>(function ({
     }
   }, [data.name, setPodName, id]);
 
+  const zoomLevel = useReactFlowStore((s) => s.transform[2]);
+  const contextualZoom = useStore(store, (state) => state.contextualZoom);
+  const level2fontsize = useStore(store, (state) => state.level2fontsize);
+
   if (!pod) return null;
+
+  const node = nodesMap.get(id);
+
+  const fontSize = level2fontsize(node?.data.level);
+  const parentFontSize = level2fontsize(node?.data.level - 1);
+
+  if (
+    contextualZoom &&
+    node?.data.level > 0 &&
+    parentFontSize * zoomLevel < 8
+  ) {
+    // The parent scope is not shown, this node is not gonna be rendered at all.
+    return <Box></Box>;
+  }
+
+  if (contextualZoom && fontSize * zoomLevel < 8) {
+    // Return a collapsed block.
+    let text = "";
+    if (pod.content) {
+      // let json = JSON.parse(pod.content);
+      const plain = prosemirrorToPlainText(pod.content);
+      text = plain.split("\n")[0];
+    }
+    text = text || "Empty";
+    return (
+      <Box
+        sx={{
+          fontSize: fontSize * 4,
+          background: "#eee",
+          borderRadius: "5px",
+          border: "5px solid red",
+          textAlign: "center",
+          height: pod.height,
+          width: pod.width,
+          color: "darkorchid",
+        }}
+        className="custom-drag-handle"
+      >
+        <Box
+          sx={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+          }}
+        >
+          {text}
+        </Box>
+      </Box>
+    );
+  }
 
   // onsize is banned for a guest, FIXME: ugly code
   const Wrap = (child) =>
@@ -885,3 +941,52 @@ export const RichNode = memo<Props>(function ({
     </>
   );
 });
+
+function prosemirrorToPlainText(prosemirrorJson) {
+  let plainText = "";
+
+  // Iterate through each node in the prosemirror JSON object
+  prosemirrorJson.content.forEach((node) => {
+    // Handle each node type
+    switch (node.type) {
+      // Handle paragraph nodes
+      case "paragraph": {
+        // Iterate through each child of the paragraph
+        if (node.content) {
+          node.content.forEach((child) => {
+            // If the child is text, add its value to the plainText string
+            if (child.type === "text") {
+              plainText += child.text;
+            }
+          });
+          // Add a newline character after the paragraph
+          plainText += "\n";
+        }
+        break;
+      }
+      // Handle heading nodes
+      case "heading": {
+        // Add the heading text to the plainText string
+        node.content.forEach((child) => {
+          // If the child is text, add its value to the plainText string
+          if (child.type === "text") {
+            plainText += child.text;
+          }
+        });
+        // Add two newline characters after the heading
+        plainText += "\n\n";
+        break;
+      }
+      // Handle other node types
+      default: {
+        // If the node has content, recursively call the function on its content
+        if (node.content) {
+          plainText += prosemirrorToPlainText(node);
+        }
+        break;
+      }
+    }
+  });
+
+  return plainText;
+}

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -21,6 +21,7 @@ import ReactFlow, {
   MarkerType,
   Node,
   NodeProps,
+  useStore as useReactFlowStore,
 } from "reactflow";
 import "reactflow/dist/style.css";
 
@@ -97,7 +98,6 @@ function MyFloatingToolbar({ id }: { id: string }) {
       {!isGuest && (
         <Tooltip title="Run (shift-enter)">
           <IconButton
-            size="small"
             onClick={() => {
               wsRunScope(id);
             }}
@@ -110,7 +110,6 @@ function MyFloatingToolbar({ id }: { id: string }) {
       {!isGuest && (
         <Tooltip title="force layout">
           <IconButton
-            size="small"
             onClick={() => {
               autoForce(id);
             }}
@@ -138,7 +137,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
         options={{ debug: true, format: "text/plain", onCopy } as any}
       >
         <Tooltip title="Copy">
-          <IconButton size="small" className="copy-button">
+          <IconButton className="copy-button">
             <ContentCopyIcon fontSize="inherit" className="copy-button" />
           </IconButton>
         </Tooltip>
@@ -150,7 +149,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
           options={{ debug: true, format: "text/plain", onCopy: onCut } as any}
         >
           <Tooltip title="Cut">
-            <IconButton size="small">
+            <IconButton>
               <ContentCutIcon fontSize="inherit" />
             </IconButton>
           </Tooltip>
@@ -159,7 +158,6 @@ function MyFloatingToolbar({ id }: { id: string }) {
       {!isGuest && (
         <Tooltip title="Delete" className="nodrag">
           <IconButton
-            size="small"
             onClick={(e: any) => {
               // This does not work, will throw "Parent node
               // jqgdsz2ns6k57vich0bf not found" when deleting a scope.
@@ -175,7 +173,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
         </Tooltip>
       )}
       <Box className="custom-drag-handle" sx={{ cursor: "grab" }}>
-        <DragIndicatorIcon fontSize="small" />
+        <DragIndicatorIcon fontSize="inherit" />
       </Box>
     </Box>
   );
@@ -214,6 +212,53 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
 
   const [showToolbar, setShowToolbar] = useState(false);
 
+  const contextualZoom = useStore(store, (state) => state.contextualZoom);
+  const zoomLevel = useReactFlowStore((s) => s.transform[2]);
+  const node = nodesMap.get(id);
+  const level2fontsize = useStore(store, (state) => state.level2fontsize);
+  const fontSize = level2fontsize(node?.data.level);
+  const parentFontSize = level2fontsize(node?.data.level - 1);
+
+  if (
+    contextualZoom &&
+    node?.data.level > 0 &&
+    parentFontSize * zoomLevel < 8
+  ) {
+    // The parent scope is not shown, this node is not gonna be rendered at all.
+    return <Box></Box>;
+  }
+
+  if (contextualZoom && fontSize * zoomLevel < 8) {
+    // Return a collapsed blcok.
+    let text = node?.data.name ? `${node?.data.name}` : "A Scope";
+    return (
+      <Box
+        sx={{
+          fontSize: fontSize * 4,
+          background: "#eee",
+          borderRadius: "5px",
+          border: "5px solid red",
+          textAlign: "center",
+          height: pod.height,
+          width: pod.width,
+          color: "deeppink",
+        }}
+        className="custom-drag-handle scope-block"
+      >
+        <Box
+          sx={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+          }}
+        >
+          {text}
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <Box
       ref={ref}
@@ -223,6 +268,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
         border: isCutting ? "dashed 2px red" : "solid 1px #d6dee6",
         borderRadius: "4px",
         cursor: "auto",
+        fontSize,
       }}
       onMouseEnter={() => {
         setShowToolbar(true);
@@ -305,8 +351,8 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
               cursor: "auto",
             }}
           >
-            {id} at ({xPos}, {yPos}), w: {pod.width}, h: {pod.height} level:{" "}
-            {data.level}
+            {id} at ({xPos}, {yPos}), w: {pod.width}, h: {pod.height} parent:{" "}
+            {pod.parent} level: {data.level} fontSize: {fontSize}
           </Box>
         )}
         <Grid container spacing={2} sx={{ alignItems: "center" }}>
@@ -321,6 +367,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
                 display: "flex",
                 flexGrow: 1,
                 justifyContent: "center",
+                fontSize,
               }}
             >
               <InputBase
@@ -345,6 +392,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
                     padding: "0px",
                     textAlign: "center",
                     textOverflow: "ellipsis",
+                    fontSize,
                   },
                 }}
               ></InputBase>

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -213,6 +213,10 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
   const [showToolbar, setShowToolbar] = useState(false);
 
   const contextualZoom = useStore(store, (state) => state.contextualZoom);
+  const threshold = useStore(
+    store,
+    (state) => state.contextualZoomParams.threshold
+  );
   const zoomLevel = useReactFlowStore((s) => s.transform[2]);
   const node = nodesMap.get(id);
   const level2fontsize = useStore(store, (state) => state.level2fontsize);
@@ -222,19 +226,19 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
   if (
     contextualZoom &&
     node?.data.level > 0 &&
-    parentFontSize * zoomLevel < 8
+    parentFontSize * zoomLevel < threshold
   ) {
     // The parent scope is not shown, this node is not gonna be rendered at all.
     return <Box></Box>;
   }
 
-  if (contextualZoom && fontSize * zoomLevel < 8) {
+  if (contextualZoom && fontSize * zoomLevel < threshold) {
     // Return a collapsed blcok.
     let text = node?.data.name ? `${node?.data.name}` : "A Scope";
     return (
       <Box
         sx={{
-          fontSize: fontSize * 4,
+          fontSize: fontSize * 2,
           background: "#eee",
           borderRadius: "5px",
           border: "5px solid red",

--- a/ui/src/components/nodes/remirror-size.css
+++ b/ui/src/components/nodes/remirror-size.css
@@ -1,0 +1,95 @@
+
+.remirror-theme h1 {
+    font-size: 1.5em;
+    font-weight: 600;
+    margin: 0.5em 0;
+  }
+  
+  .remirror-theme h2 {
+    font-size: 1.25em;
+    font-weight: 600;
+    margin: 0.5em 0;
+  }
+  
+  .remirror-theme h3 {
+    font-size: 1.1em;
+    font-weight: 600;
+    margin: 0.5em 0;
+  }
+  
+  .remirror-theme h4 {
+    font-size: 1em;
+    font-weight: 600;
+    margin: 0.5em 0;
+  }
+  
+  
+  .remirror-theme h5 {
+    font-size: 0.9em;
+    font-weight: 600;
+    margin: 0.5em 0;
+  }
+  
+  
+  .remirror-theme h6 {
+    font-size: 0.8em;
+    font-weight: 600;
+    margin: 0.5em 0;
+  }
+  
+  .remirror-theme p {
+    margin: 0.5em 0;
+  }
+  
+  .remirror-theme ul {
+    margin: 0.5em 0;
+  }
+  
+  .remirror-theme ol {
+    margin: 0.5em 0;
+  }
+  
+  .remirror-theme li {
+    margin: 0.5em 0;
+  }
+  
+  .remirror-theme blockquote {
+    margin: 0.5em 0;
+  }
+  
+  .remirror-theme pre {
+    margin: 0.5em 0;
+  }
+  
+  
+  .remirror-theme code {
+    font-family: monospace;
+    font-size: 0.9em;
+    background: #f5f5f5;
+    padding: 0.1em 0.2em;
+    border-radius: 4px;
+  }
+  
+  
+  .remirror-theme hr {
+    border: none;
+    border-top: 1px solid #ddd;
+    margin: 0.5em 0;
+  }
+  
+  
+  .remirror-theme table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    margin: 0.5em 0;
+  }
+  
+  
+  .remirror-theme table td,
+  .remirror-theme table th {
+    border: 1px solid #ddd;
+    padding: 0.5em 1em;
+  }
+  
+  
+  

--- a/ui/src/lib/store/settingSlice.tsx
+++ b/ui/src/lib/store/settingSlice.tsx
@@ -10,6 +10,11 @@ export interface SettingSlice {
   setDevMode: (b: boolean) => void;
   autoRunLayout?: boolean;
   setAutoRunLayout: (b: boolean) => void;
+
+  fontSizeLevels: Record<any, number>;
+  contextualZoom: boolean;
+  setContextualZoom: (b: boolean) => void;
+  level2fontsize: (level: number) => number;
 }
 
 export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
@@ -50,5 +55,42 @@ export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
     set({ autoRunLayout: b });
     // also write to local storage
     localStorage.setItem("autoRunLayout", JSON.stringify(b));
+  },
+
+  contextualZoom: localStorage.getItem("contextualZoom")
+    ? JSON.parse(localStorage.getItem("contextualZoom")!)
+    : false,
+  setContextualZoom: (b: boolean) => {
+    set({ contextualZoom: b });
+    // also write to local storage
+    localStorage.setItem("contextualZoom", JSON.stringify(b));
+  },
+  // TODO Make it configurable.
+  fontSizeLevels: {
+    prev: 56,
+    0: 48,
+    1: 32,
+    2: 24,
+    3: 16,
+    next: 8,
+  },
+  level2fontsize: (level: number) => {
+    // default font size
+    if (!get().contextualZoom) return 16;
+    // when contextual zoom is on
+    switch (level) {
+      case -1:
+        return get().fontSizeLevels.prev;
+      case 0:
+        return get().fontSizeLevels[0];
+      case 1:
+        return get().fontSizeLevels[1];
+      case 2:
+        return get().fontSizeLevels[2];
+      case 3:
+        return get().fontSizeLevels[3];
+      default:
+        return get().fontSizeLevels.next;
+    }
   },
 });

--- a/ui/src/lib/store/settingSlice.tsx
+++ b/ui/src/lib/store/settingSlice.tsx
@@ -11,7 +11,7 @@ export interface SettingSlice {
   autoRunLayout?: boolean;
   setAutoRunLayout: (b: boolean) => void;
 
-  fontSizeLevels: Record<any, number>;
+  contextualZoomParams: Record<any, number>;
   contextualZoom: boolean;
   setContextualZoom: (b: boolean) => void;
   level2fontsize: (level: number) => number;
@@ -66,13 +66,14 @@ export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
     localStorage.setItem("contextualZoom", JSON.stringify(b));
   },
   // TODO Make it configurable.
-  fontSizeLevels: {
+  contextualZoomParams: {
     prev: 56,
     0: 48,
     1: 32,
     2: 24,
     3: 16,
     next: 8,
+    threshold: 16,
   },
   level2fontsize: (level: number) => {
     // default font size
@@ -80,17 +81,17 @@ export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
     // when contextual zoom is on
     switch (level) {
       case -1:
-        return get().fontSizeLevels.prev;
+        return get().contextualZoomParams.prev;
       case 0:
-        return get().fontSizeLevels[0];
+        return get().contextualZoomParams[0];
       case 1:
-        return get().fontSizeLevels[1];
+        return get().contextualZoomParams[1];
       case 2:
-        return get().fontSizeLevels[2];
+        return get().contextualZoomParams[2];
       case 3:
-        return get().fontSizeLevels[3];
+        return get().contextualZoomParams[3];
       default:
-        return get().fontSizeLevels.next;
+        return get().contextualZoomParams.next;
     }
   },
 });


### PR DESCRIPTION
# Introduction

This PR introduces a major feature called "contextual zoom". The idea is to see different level of details at different zoom levels, so that users can focus on a small subsets of content to work on. Think of it as Google maps where you zoom in & out to see different levels of details.

The feature contains roughly two significant behaviors:
1. different levels in the hierarchy have **different font sizes**
2. when zooming out, the pods and scopes that become too small to view will be **collapsed into a block, with large text summarizing its content**. These blocks can be dragged and moved easily (which is pretty easy to use).

This feature is experimental and disabled by default. There's a setting `contextual zoom` in the sidebar to enable it.

Future work
- [ ] expose font-size ladder configuration for different levels (currently 8, 16, 24, 32, 48, defined in `settingSlice.tsx`)
- [ ] display more meaningful summary information

## Fully expanded (zoomed in):

![Screenshot from 2023-05-06 06-38-14](https://user-images.githubusercontent.com/4576201/236627728-2b160e8c-dfbc-4221-a535-57563ed86122.png)

## Zoom out:

![Screenshot from 2023-05-06 06-38-21](https://user-images.githubusercontent.com/4576201/236627733-900ca4b4-9db4-4b77-8e2a-8e8327dcf814.png)

## Zoom out:

![Screenshot from 2023-05-06 06-38-25](https://user-images.githubusercontent.com/4576201/236627738-1a12fea2-5f22-4c54-bce8-76ecea9a535d.png)

## Zoom out:

![Screenshot from 2023-05-06 06-38-36](https://user-images.githubusercontent.com/4576201/236627741-5ef4d7d5-bd53-48b3-a34a-1869799c772d.png)
