### PR TITLE
feat: add export to svg

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -26,6 +26,7 @@
     "d3-quadtree": "^3.0.1",
     "formik": "^2.2.9",
     "graphql": "^16.6.0",
+    "html-to-image": "^1.11.11",
     "jwt-decode": "^3.1.2",
     "kbar": "^0.1.0-beta.40",
     "monaco-editor": "^0.34.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7541,6 +7541,11 @@ html-minifier-terser@^6.0.2:
     relateurl "^0.2.7"
     terser "^5.10.0"
 
+html-to-image@^1.11.11:
+  version "1.11.11"
+  resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.11.11.tgz#c0f8a34dc9e4b97b93ff7ea286eb8562642ebbea"
+  integrity sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==
+
 html-webpack-plugin@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz#c3911936f57681c1f9f4d8b68c158cd9dfe52f50"


### PR DESCRIPTION
There's a "download image" button in the sidebar. Once clicked, a high-quality SVG file will be generated (for the **current viewport** of the canvas). The file name is `<reponame>-<repoId>-<ISOdate>.svg` so that it is easy to backup your work with version info.

The SVG file can be big, e.g., 5MB. You can then convert it into pdf, which makes it 150KB.

The UI screenshot:

![Screenshot from 2023-05-06 15-39-55](https://user-images.githubusercontent.com/4576201/236649321-893f68f6-1cc2-4772-a192-ace79f2c1778.jpg)

Generated .svg file:

![test-download-9f02svi2nk1bpetqeohs-2023-05-06T22_38_17 848Z](https://user-images.githubusercontent.com/4576201/236649328-d9058066-be0c-4bb9-9f4e-4b59163f04b3.svg)
