### PR TITLE
feat: allow pod to access to names in all ancestor scopes

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -206,6 +206,10 @@ function useInitNodes() {
   const updateView = useStore(store, (state) => state.updateView);
   const updateEdgeView = useStore(store, (state) => state.updateEdgeView);
   const adjustLevel = useStore(store, (state) => state.adjustLevel);
+  const buildNode2Children = useStore(
+    store,
+    (state) => state.buildNode2Children
+  );
   useEffect(() => {
     const init = () => {
       let nodes = store2nodes("ROOT", { getId2children, getPod });
@@ -255,6 +259,7 @@ function useInitNodes() {
       }
       updateEdgeView();
       setLoading(false);
+      buildNode2Children();
     };
 
     if (!provider) return;

--- a/ui/src/components/MyKBar.tsx
+++ b/ui/src/components/MyKBar.tsx
@@ -39,7 +39,6 @@ function RenderResults() {
 export function MyKBar() {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const autoLayout = useStore(store, (state) => state.autoLayout);
   const autoForceGlobal = useStore(store, (state) => state.autoForceGlobal);
   const actions = [
     {
@@ -48,14 +47,6 @@ export function MyKBar() {
       keywords: "auto force",
       perform: () => {
         autoForceGlobal();
-      },
-    },
-    {
-      id: "auto-layout",
-      name: "Auto Layout",
-      keywords: "auto layout",
-      perform: () => {
-        autoLayout();
       },
     },
     // {

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -86,7 +86,6 @@ function MyFloatingToolbar({ id }: { id: string }) {
     },
     [onCopy, cutBegin, id]
   );
-  const autoLayout = useStore(store, (state) => state.autoLayout);
   const autoForce = useStore(store, (state) => state.autoForce);
   return (
     <Box
@@ -118,19 +117,6 @@ function MyFloatingToolbar({ id }: { id: string }) {
           </IconButton>
         </Tooltip>
       )}
-      {/* auto layout (auto shrink scopes) */}
-      {/* {!isGuest && (
-        <Tooltip title="auto shrink (global)">
-          <IconButton
-            size="small"
-            onClick={() => {
-              autoLayout();
-            }}
-          >
-            <CompressIcon fontSize="inherit" />
-          </IconButton>
-        </Tooltip>
-      )} */}
       {/* copy to clipbooard */}
       <CopyToClipboard
         text="dummy"

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -15,6 +15,10 @@ export function useYjsObserver() {
   const nodesMap = ydoc.getMap<Node>("pods");
   const updateView = useStore(store, (state) => state.updateView);
   const resetSelection = useStore(store, (state) => state.resetSelection);
+  const buildNode2Children = useStore(
+    store,
+    (state) => state.buildNode2Children
+  );
 
   useEffect(() => {
     const observer = (YMapEvent: YEvent<any>, transaction: Transaction) => {
@@ -56,6 +60,11 @@ export function useYjsObserver() {
               },
               false
             );
+            // FIXME debug this.
+            // if the pod parent changed, triggger buildNode2Children
+            if (node.parentNode !== change.oldValue.parentNode) {
+              buildNode2Children();
+            }
 
             break;
           default:


### PR DESCRIPTION
Now a pod can access all names defined in its ancestor scopes. The following canvas shows 4 examples:

1. **[new behavior]** function can be accessed in an inner scope
2. **[new behavior]** global variables can be accessed anywhere
3. exported name can be accessed in its parent scope
4. unexported name cannot be accessed in its parent scope

![Screenshot from 2023-05-06 17-27-45](https://user-images.githubusercontent.com/4576201/236651741-bd280097-3838-4c62-9b3b-688881b48cef.png)


Technical staff: this PR also supports ROOT in Node2Children map, and auto-build it.