### PR TITLE
feat: add recursive @export

### DIFF
--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -282,6 +282,8 @@ function highlightAnnotations(
                 return "myDecoration-varuse";
               case "varuse":
                 return "myDecoration-varuse";
+              case "bridge":
+                return "myDecoration-bridge-unused";
               default:
                 throw new Error("unknown type: " + type);
             }

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -855,6 +855,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
           nodesMap.delete(change.id);
           // remove from store
           get().deletePod(client, { id: change.id });
+          get().buildNode2Children();
           // run auto-layout
           get().autoForceGlobal();
           break;

--- a/ui/src/lib/store/index.tsx
+++ b/ui/src/lib/store/index.tsx
@@ -35,6 +35,7 @@ export type Pod = {
   symbolTable?: { [key: string]: string };
   annotations?: Annotation[];
   ispublic?: boolean;
+  isbridge?: boolean;
   x: number;
   y: number;
   width?: number;


### PR DESCRIPTION
An exported function or variable can now be further exported to ancestor scopes. To use this, create a new pod in the parent scope with:

```
@export foo
@export x
```

Note that `@export` must be the **first character** of the line.

## Screenshot
Before, no recursive export, the outer scope cannot see the definitions:

<img width=600 src="https://user-images.githubusercontent.com/4576201/236795547-031d4a50-0f39-47e9-a8c9-950cbc2e3e05.png"/>

After, with the recursive @export bridging pod:

<img width=600 src="https://user-images.githubusercontent.com/4576201/236795558-86ad2a97-4ad8-47c2-8955-1cadfb387325.png"/>

