### PR TITLE
feat: consider output box in auto layout; better output box-sizing constraint

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -522,7 +522,7 @@ function CanvasImpl() {
     (state) => state.removeDragHighlight
   );
   const updateView = useStore(store, (state) => state.updateView);
-  const autoForceGlobal = useStore(store, (state) => state.autoForceGlobal);
+  const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
 
   const addNode = useStore(store, (state) => state.addNode);
   const reactFlowInstance = useReactFlow();
@@ -632,7 +632,7 @@ function CanvasImpl() {
             updateView();
             // run auto layout on drag stop
             if (autoRunLayout) {
-              autoForceGlobal();
+              autoLayoutROOT();
             }
           }}
           onNodeDrag={(event, node) => {

--- a/ui/src/components/MyKBar.tsx
+++ b/ui/src/components/MyKBar.tsx
@@ -39,14 +39,14 @@ function RenderResults() {
 export function MyKBar() {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const autoForceGlobal = useStore(store, (state) => state.autoForceGlobal);
+  const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
   const actions = [
     {
       id: "auto-force",
       name: "Auto Force",
       keywords: "auto force",
       perform: () => {
-        autoForceGlobal();
+        autoLayoutROOT();
       },
     },
     // {

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -396,6 +396,10 @@ export const CodeNode = memo<NodeProps>(function ({
   );
   const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
   const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
+  useEffect(() => {
+    // Run auto-layout when the output box layout changes.
+    autoLayoutROOT();
+  }, [layout]);
 
   const onResizeStop = useCallback(
     (e, data) => {

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -130,7 +130,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id }) {
         <Box
           sx={{ paddingBottom: "2px" }}
           overflow="auto"
-          maxHeight="140px"
+          maxHeight="1000px"
           border="1px"
         >
           {/* <Box bgcolor="lightgray">Error</Box> */}
@@ -395,7 +395,7 @@ export const CodeNode = memo<NodeProps>(function ({
       state.pods[id]?.stderr
   );
   const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
-  const autoForceGlobal = useStore(store, (state) => state.autoForceGlobal);
+  const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
 
   const onResizeStop = useCallback(
     (e, data) => {
@@ -417,10 +417,10 @@ export const CodeNode = memo<NodeProps>(function ({
           true
         );
         updateView();
-        autoForceGlobal();
+        autoLayoutROOT();
       }
     },
-    [id, nodesMap, setPodGeo, updateView, autoForceGlobal]
+    [id, nodesMap, setPodGeo, updateView, autoLayoutROOT]
   );
 
   const [showToolbar, setShowToolbar] = useState(false);
@@ -692,7 +692,13 @@ export const CodeNode = memo<NodeProps>(function ({
               <MyMonaco id={id} fontSize={fontSize} />
               {showResult && (
                 <Box
-                  className="nowheel"
+                  className={"nowheel"}
+                  // This ID is used for autolayout.
+                  //
+                  // TODO save result box position to DB.
+                  id={
+                    isRightLayout ? `result-${id}-right` : `result-${id}-bottom`
+                  }
                   // This also prevents the wheel event from bubbling up to the parent.
                   // onWheelCapture={(e) => {
                   //   e.stopPropagation();
@@ -703,9 +709,9 @@ export const CodeNode = memo<NodeProps>(function ({
                     position: "absolute",
                     top: isRightLayout ? 0 : "100%",
                     left: isRightLayout ? "100%" : 0,
-                    maxHeight: "160px",
-                    maxWidth: isRightLayout ? "300px" : "100%",
-                    minWidth: isRightLayout ? "150px" : "100%",
+                    ...(isRightLayout
+                      ? {}
+                      : { maxWidth: "100%", minWidth: "100%" }),
                     boxSizing: "border-box",
                     backgroundColor: "white",
                     zIndex: 100,

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -682,7 +682,7 @@ export const RichNode = memo<Props>(function ({
   const reactFlowInstance = useReactFlow();
 
   const [showToolbar, setShowToolbar] = useState(false);
-  const autoForceGlobal = useStore(store, (state) => state.autoForceGlobal);
+  const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
 
   const onResizeStop = useCallback(
     (e, data) => {
@@ -704,10 +704,10 @@ export const RichNode = memo<Props>(function ({
           true
         );
         updateView();
-        autoForceGlobal();
+        autoLayoutROOT();
       }
     },
-    [id, nodesMap, setPodGeo, updateView, autoForceGlobal]
+    [id, nodesMap, setPodGeo, updateView, autoLayoutROOT]
   );
 
   useEffect(() => {

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -86,7 +86,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
     },
     [onCopy, cutBegin, id]
   );
-  const autoForce = useStore(store, (state) => state.autoForce);
+  const autoLayout = useStore(store, (state) => state.autoLayout);
   return (
     <Box
       sx={{
@@ -110,7 +110,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
         <Tooltip title="force layout">
           <IconButton
             onClick={() => {
-              autoForce(id);
+              autoLayout(id);
             }}
           >
             <ViewTimelineOutlinedIcon fontSize="inherit" />


### PR DESCRIPTION
Now the output box will be considered in auto-layout.

Also changed the constraint of output box-sizing. The max height is adjusted to 1000px to show much content without scrolling. This should be enough to make good demos; don't print too much content.

TODOs:
- [ ] The output box position (bottom or right) is not saved to DB. So after refreshing, all output boxes will be on the bottom.
- [ ] The output box is not resizable yet.

Screenshot:


![Screenshot from 2023-05-08 04-58-18](https://user-images.githubusercontent.com/4576201/236818034-e8dbea30-17cf-4fcd-aeef-a9feb27bd4ec.png)


