### PR TITLE
fix: do not set pod as running when socket isn't connected

### DIFF
--- a/ui/src/lib/store/podSlice.tsx
+++ b/ui/src/lib/store/podSlice.tsx
@@ -49,6 +49,12 @@ export interface PodSlice {
     content: { data: { html: string; text: string; image: string } };
     count: number;
   }) => void;
+  setPodDisplayData: ({ id, content, count }) => void;
+  setPodExecuteReply: ({ id, result, count }) => void;
+  setPodStdout: ({ id, stdout }: { id: string; stdout: string }) => void;
+  setPodError: ({ id, ename, evalue, stacktrace }) => void;
+  setPodStream: ({ id, content }) => void;
+  setPodStatus: ({ id, status, lang }) => void;
   clonePod: (id: string) => any;
 }
 


### PR DESCRIPTION
Fix a bug that set the pod as running before checking the socket connection. This caused pod execution to be blocked.