### PR TITLE
add a left drag handle on the toolbar (deprecate the 4 handle idea)

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -308,6 +308,17 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
     <Box
       sx={{ display: "flex", alignItems: "center", justifyContent: "center" }}
     >
+      <Box
+        className="custom-drag-handle"
+        sx={{
+          cursor: "grab",
+          fontSize: "1.5rem",
+          padding: "8px",
+          display: "inline-flex",
+        }}
+      >
+        <DragIndicatorIcon fontSize="inherit" />
+      </Box>
       {!isGuest && (
         <Tooltip title="Run (shift-enter)">
           <IconButton
@@ -384,7 +395,15 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
           <ViewComfyIcon fontSize="inherit" />
         </IconButton>
       </Tooltip>
-      <Box className="custom-drag-handle" sx={{ cursor: "grab" }}>
+      <Box
+        className="custom-drag-handle"
+        sx={{
+          cursor: "grab",
+          fontSize: "1.5rem",
+          padding: "8px",
+          display: "inline-flex",
+        }}
+      >
         <DragIndicatorIcon fontSize="inherit" />
       </Box>
     </Box>

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -624,6 +624,17 @@ function MyFloatingToolbar({ id }: { id: string }) {
   const isGuest = useStore(store, (state) => state.role === "GUEST");
   return (
     <>
+      <Box
+        className="custom-drag-handle"
+        sx={{
+          cursor: "grab",
+          fontSize: "1.5rem",
+          padding: "8px",
+          display: "inline-flex",
+        }}
+      >
+        <DragIndicatorIcon fontSize="inherit" />
+      </Box>
       {!isGuest && (
         <Tooltip title="Delete">
           <IconButton
@@ -636,8 +647,16 @@ function MyFloatingToolbar({ id }: { id: string }) {
           </IconButton>
         </Tooltip>
       )}
-      <Box className="custom-drag-handle" sx={{ cursor: "grab" }}>
-        <DragIndicatorIcon fontSize="small" />
+      <Box
+        className="custom-drag-handle"
+        sx={{
+          cursor: "grab",
+          fontSize: "1.5rem",
+          padding: "8px",
+          display: "inline-flex",
+        }}
+      >
+        <DragIndicatorIcon fontSize="inherit" />
       </Box>
     </>
   );

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -94,6 +94,17 @@ function MyFloatingToolbar({ id }: { id: string }) {
         alignItems: "center",
       }}
     >
+      <Box
+        className="custom-drag-handle"
+        sx={{
+          cursor: "grab",
+          fontSize: "1.5rem",
+          padding: "8px",
+          display: "inline-flex",
+        }}
+      >
+        <DragIndicatorIcon fontSize="inherit" />
+      </Box>
       {!isGuest && (
         <Tooltip title="Run (shift-enter)">
           <IconButton
@@ -158,7 +169,15 @@ function MyFloatingToolbar({ id }: { id: string }) {
           </IconButton>
         </Tooltip>
       )}
-      <Box className="custom-drag-handle" sx={{ cursor: "grab" }}>
+      <Box
+        className="custom-drag-handle"
+        sx={{
+          cursor: "grab",
+          fontSize: "1.5rem",
+          padding: "8px",
+          display: "inline-flex",
+        }}
+      >
         <DragIndicatorIcon fontSize="inherit" />
       </Box>
     </Box>


### PR DESCRIPTION
The previous drag handle was on the top right corner. It is difficult to drag to the right without moving out of the parent scope.

In our early discussion, we would like to put the toolbar in all four corners. But this is not easy or clean to implement (e.g., needs to attach four elements to bind the onMouseEnter/Leave callbacks).

This PR is good enough for me to move a pod around.

Screenshot:

![Screenshot from 2023-05-08 05-42-50](https://user-images.githubusercontent.com/4576201/236828324-13f63b95-0e3a-48ce-825c-91c675a9f3c8.jpg)
