### PR TITLE
allow up to 20MB graphql payload

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -41,6 +41,7 @@ async function startServer() {
     plugins: [ApolloServerPluginLandingPageLocalDefault({ embed: true })],
   });
   const expapp = express();
+  expapp.use(express.json({ limit: "20mb" }));
   const http_server = http.createServer(expapp);
   const wss = new WebSocketServer({ server: http_server });
   // graphql api will be available at /graphql


### PR DESCRIPTION
Fix the "Payload Too Large" error when saving output images and rich-text images. Reference: https://github.com/apollographql/apollo-server/issues/288