### PR TITLE
fix: unexpected jumpback after resizing

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -459,7 +459,11 @@ export const CodeNode = memo<NodeProps>(function ({
       const node = nodesMap.get(id);
       if (node) {
         // new width
-        nodesMap.set(id, { ...node, width: size.width });
+        nodesMap.set(id, {
+          ...node,
+          width: size.width,
+          style: { ...node.style, width: size.width },
+        });
         setPodGeo(
           id,
           {

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -709,7 +709,11 @@ export const RichNode = memo<Props>(function ({
       const node = nodesMap.get(id);
       if (node) {
         // new width
-        nodesMap.set(id, { ...node, width: size.width });
+        nodesMap.set(id, {
+          ...node,
+          width: size.width,
+          style: { ...node.style, width: size.width },
+        });
         setPodGeo(
           id,
           {


### PR DESCRIPTION
The pod size might jump back after resizing. The bug was introduced in #285 , the reason is we set `nodeMap.set({width:}`, but missed `nodeMap.set({width, style: {width})`