### PR TITLE
run auto layout on result change

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -81,6 +81,10 @@ export const ResultBlock = memo<any>(function ResultBlock({ id }) {
   const error = useStore(store, (state) => state.pods[id].error);
   const stdout = useStore(store, (state) => state.pods[id].stdout);
   const running = useStore(store, (state) => state.pods[id].running);
+  const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
+  useEffect(() => {
+    autoLayoutROOT();
+  }, [running]);
   const lastExecutedAt = useStore(
     store,
     (state) => state.pods[id].lastExecutedAt


### PR DESCRIPTION
More specifically, on results **status** change (**start or end**), i.e., whenever the following circular progress indicator **show** or **disappear**. It won't run when the output is still expanding.

![image](https://github.com/codepod-io/codepod/assets/4576201/59922342-4f9d-4f0c-835d-6909a0288ebc)
