### PR TITLE
fix: compileLHS for subscript and attribute

### DIFF
--- a/ui/src/lib/parser.tsx
+++ b/ui/src/lib/parser.tsx
@@ -427,16 +427,20 @@ function compileLHS(node, st) {
     case "identifier":
       return new Set([node.text]);
     case "pattern_list":
+      // [a,b,c] = [1,2,3]
       return new Set(node.namedChildren.filter(notComment).map((n) => n.text));
     case "tuple_pattern":
+      // (a,b,c) = (1,2,3)
       return new Set(node.namedChildren.filter(notComment).map((n) => n.text));
     case "subscript":
+      // a[1] = 2
       let [l, r] = node.namedChildren.filter(notComment);
       compileExpression(r, st);
-      return compileLHS(l, st);
+      return compileExpression(l, st);
     case "attribute":
+      // a.b = 2
       let [obj, attr] = node.namedChildren.filter(notComment);
-      return compileLHS(obj, st);
+      return compileExpression(obj, st);
     default:
       global_errors.push({
         message: `unknown LHS type: ${node.type} in ${mysubstr(node.text)}`,

--- a/ui/src/tests/parser.test.tsx
+++ b/ui/src/tests/parser.test.tsx
@@ -46,4 +46,45 @@ describe("sum module", () => {
         expect(errors).toStrictEqual([]);
       });
   });
+
+  test("parse subscript LHS", async () => {
+    let { annotations, errors } = analyzeCode(`
+       x = [1,2,3]
+       x[0] = 1
+       `);
+    expect(annotations).toStrictEqual([
+      {
+        name: "x",
+        type: "vardef",
+        startIndex: 8,
+        endIndex: 9,
+        startPosition: { row: 1, column: 7 },
+        endPosition: { row: 1, column: 8 },
+      },
+      {
+        name: "x",
+        type: "varuse",
+        startIndex: 27,
+        endIndex: 28,
+        startPosition: { row: 2, column: 7 },
+        endPosition: { row: 2, column: 8 },
+      },
+    ]);
+  });
+
+  test("parse attribute LHS", async () => {
+    let { annotations } = analyzeCode(`
+    a.b = 3
+    `);
+    expect(annotations).toStrictEqual([
+      {
+        name: "a",
+        type: "varuse",
+        startIndex: 5,
+        endIndex: 6,
+        startPosition: { row: 1, column: 4 },
+        endPosition: { row: 1, column: 5 },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
When LHS is a subscript or an attribute, we should parse it as `varuse`, not `vardef`. The following two examples should now work:

![Screenshot from 2023-05-18 07-46-25](https://github.com/codepod-io/codepod/assets/4576201/cecb5f9b-85b3-4a96-8742-7210b415cbb5)


close #309 