### PR TITLE
fix: dirty status on repo initial loading

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -80,11 +80,20 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
   const result = useStore(store, (state) => state.pods[id]?.result);
   const error = useStore(store, (state) => state.pods[id]?.error);
   const stdout = useStore(store, (state) => state.pods[id]?.stdout);
-  const running = useStore(store, (state) => state.pods[id]?.running);
+  const running = useStore(store, (state) => state.pods[id]?.running || false);
   const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
+  const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
+
+  const prevRunning = useRef(false);
   useEffect(() => {
-    autoLayoutROOT();
+    if (autoRunLayout) {
+      if (prevRunning.current != running) {
+        autoLayoutROOT();
+        prevRunning.current = running;
+      }
+    }
   }, [running]);
+
   const lastExecutedAt = useStore(
     store,
     (state) => state.pods[id]?.lastExecutedAt
@@ -474,9 +483,17 @@ export const CodeNode = memo<NodeProps>(function ({
 
   const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
   const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
+  const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
+
+  const prevLayout = useRef(layout);
   useEffect(() => {
-    // Run auto-layout when the output box layout changes.
-    autoLayoutROOT();
+    if (autoRunLayout) {
+      // Run auto-layout when the output box layout changes.
+      if (prevLayout.current != layout) {
+        autoLayoutROOT();
+        prevLayout.current = layout;
+      }
+    }
   }, [layout]);
 
   const onResizeStop = useCallback(
@@ -503,7 +520,9 @@ export const CodeNode = memo<NodeProps>(function ({
           true
         );
         updateView();
-        autoLayoutROOT();
+        if (autoRunLayout) {
+          autoLayoutROOT();
+        }
       }
     },
     [id, nodesMap, setPodGeo, updateView, autoLayoutROOT]

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -790,7 +790,17 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
             // be filed for CodeNode at the beginning or anytime the node height
             // is changed due to content height changes.
             const node = nextNodes.find((n) => n.id === change.id);
-            if (!node) throw new Error("Node not found");
+            const prevNode = nodes.find((n) => n.id === change.id);
+            if (!node || !prevNode) throw new Error("Node not found");
+            // At the beginning, a dimension change is fired for all pods for no
+            // good reason. This will cause all pods being marked dirty and get
+            // uploaded. Filter out that situation here.
+            if (
+              node.width === prevNode.width &&
+              node.height === prevNode.height
+            ) {
+              break;
+            }
 
             let geoData = {
               parent: node.parentNode ? node.parentNode : "ROOT",
@@ -867,7 +877,9 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
           get().deletePod(client, { id: change.id });
           get().buildNode2Children();
           // run auto-layout
-          get().autoLayoutROOT();
+          if (get().autoRunLayout) {
+            get().autoLayoutROOT();
+          }
           break;
         default:
           // should not reach here.
@@ -961,6 +973,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
   },
   autoLayoutROOT: () => {
     // get all scopes,
+    console.debug("autoLayoutROOT");
     let nodesMap = get().ydoc.getMap<Node>("pods");
     let nodes: Node[] = Array.from(nodesMap.values());
     nodes


### PR DESCRIPTION
On repo's initial loading or refreshing, there were "dirty" pods that gets uploaded.

![Screenshot 2023-06-08 at 18 20 04](https://github.com/codepod-io/codepod/assets/4576201/00433ea7-afe3-459d-900a-4d42d2a081df)


There are three causes, all fixed:

1. the auto-layout engine was run upon Code cell's `running` and `layout` states in `useEffect`, even if they are not changed. Now it is only triggered when the state is changed.
2. There were dimension change events from reactflow's `onNodeChange` without actual change. Now this is filtered out.
3. Rich text editor will fire a "change" event at the beginning. This is also filtered out.