### PR TITLE
stylize output box options

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -73,13 +73,14 @@ function Timer({ lastExecutedAt }) {
     return () => clearInterval(interval);
   }, [counter]);
   return (
-    <Box 
+    <Box
       sx={{
         padding: "5px",
       }}
-      >
+    >
       Last run: {timeDifference(new Date(), lastExecutedAt)}
-    </Box>);
+    </Box>
+  );
 }
 
 export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
@@ -188,7 +189,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                     }}
                   >
                     <CheckCircleIcon
-                      style={{ marginTop: "5px"}}
+                      style={{ marginTop: "5px" }}
                       fontSize="inherit"
                     />{" "}
                     <Timer lastExecutedAt={lastExecutedAt} />
@@ -216,9 +217,9 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
             showMenu && (
               <ButtonGroup
                 sx={{
-                  // border: '1px solid #757ce8', 
+                  // border: '1px solid #757ce8',
                   fontSize: "0.8em",
-                  backgroundColor: 'white', 
+                  backgroundColor: "white",
                   zIndex: 201,
                   position: "absolute",
                   top: "10px",
@@ -234,22 +235,23 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                 aria-label="outlined primary button group"
                 // orientation="vertical"
               >
-              <Box 
-                sx={{
-                  color: 'primary.main',
-                  fontWeight: 'bold', 
-                  display: 'flex',
-                  padding: '5px 5px',
-                  alignItems: 'center',
-                  justifyContent: 'center'
-                }}
-              >
-                Output options:
-              </Box>
+                <Box
+                  sx={{
+                    color: "primary.main",
+                    fontWeight: "bold",
+                    display: "flex",
+                    padding: "5px 5px",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  Output options:
+                </Box>
                 <Button
                   onClick={() => {
                     setResultScroll(!resultScroll);
-                  }}                >
+                  }}
+                >
                   {resultScroll ? "Unfocus" : "Focus"}
                 </Button>
                 <Button
@@ -305,10 +307,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
       ) : (
         <Box
           sx={{
-            paddingTop: "5px",
-            paddingBottom: "5px",
-            paddingLeft: "5px",
-            paddingRight: "5px",
+            padding: "10px",
             display: "flex",
             justifyContent: "center",
             alignItems: "bottom",
@@ -330,15 +329,13 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
             }}
             sx={{
               fontSize: "0.8em",
-              paddingTop: "0px",
-              paddingBottom: "0px",
               // lineHeight: "8px",
-              // zIndex: 201,
+              zIndex: 201,
             }}
             size="small"
             variant="contained"
           >
-            Reveal it
+            Reveal
           </Button>
         </Box>
       )}

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -72,7 +72,14 @@ function Timer({ lastExecutedAt }) {
     }, 1000);
     return () => clearInterval(interval);
   }, [counter]);
-  return <Box>Last executed: {timeDifference(new Date(), lastExecutedAt)}</Box>;
+  return (
+    <Box 
+      sx={{
+        padding: "5px",
+      }}
+      >
+      Last run: {timeDifference(new Date(), lastExecutedAt)}
+    </Box>);
 }
 
 export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
@@ -173,14 +180,17 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                       borderImage: "initial",
                       borderTopLeftRadius: "20px",
                       borderTopRightRadius: "20px",
+                      // FIXME: Why not a complete oval?
+                      // borderBottomLeftRadius: "20px",
+                      // borderBottomRightRadius: "20px",
                       display: "flex",
                       fontSize: "0.8em",
                     }}
                   >
                     <CheckCircleIcon
-                      style={{ marginTop: "5px" }}
+                      style={{ marginTop: "5px"}}
                       fontSize="inherit"
-                    />
+                    />{" "}
                     <Timer lastExecutedAt={lastExecutedAt} />
                   </Box>
                 </Box>
@@ -205,42 +215,47 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
           {(stdout || (result?.text && result?.count > 0) || error) &&
             showMenu && (
               <ButtonGroup
-                sx={[
-                  {
-                    fontSize: "0.8em",
-                    paddingTop: "3px",
-                    paddingBottom: "2px",
-                    lineHeight: "10px",
-                    zIndex: 201,
-                    position: "absolute",
-                    top: "-64.5px",
-                    right: "15px",
-                    "& .MuiButton-root": {
-                      fontSize: ".9em",
-                      paddingTop: 0,
-                      paddingBottom: 0,
-                    },
-                  },
-                ]}
-                variant="outlined"
+                sx={{
+                  // border: '1px solid #757ce8', 
+                  fontSize: "0.8em",
+                  backgroundColor: 'white', 
+                  zIndex: 201,
+                  position: "absolute",
+                  top: "10px",
+                  right: "25px",
+                  // "& .MuiButton-root": {
+                  //   fontSize: ".9em",
+                  //   paddingTop: 0,
+                  //   paddingBottom: 0,
+                  // },
+                }}
+                variant="contained"
+                size="small"
                 aria-label="outlined primary button group"
-                orientation="vertical"
+                // orientation="vertical"
               >
+              <Box 
+                sx={{
+                  color: 'primary.main',
+                  fontWeight: 'bold', 
+                  display: 'flex',
+                  padding: '5px 5px',
+                  alignItems: 'center',
+                  justifyContent: 'center'
+                }}
+              >
+                Output options:
+              </Box>
                 <Button
                   onClick={() => {
                     setResultScroll(!resultScroll);
-                  }}
-                  variant="text"
-                  size="small"
-                >
+                  }}                >
                   {resultScroll ? "Unfocus" : "Focus"}
                 </Button>
                 <Button
                   onClick={() => {
                     setShowOutput(!showOutput);
                   }}
-                  variant="text"
-                  size="small"
                 >
                   Hide
                 </Button>
@@ -248,8 +263,6 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                   onClick={() => {
                     clearResults(id);
                   }}
-                  variant="text"
-                  size="small"
                 >
                   Clear
                 </Button>
@@ -292,10 +305,13 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
       ) : (
         <Box
           sx={{
+            paddingTop: "5px",
             paddingBottom: "5px",
+            paddingLeft: "5px",
+            paddingRight: "5px",
             display: "flex",
             justifyContent: "center",
-            alignItems: "center",
+            alignItems: "bottom",
           }}
         >
           <Box
@@ -306,7 +322,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
               paddingTop: "2px",
             }}
           >
-            This output has been hidden.{" "}
+            Output hidden.{" "}
           </Box>
           <Button
             onClick={() => {
@@ -314,15 +330,15 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
             }}
             sx={{
               fontSize: "0.8em",
-              paddingTop: "3px",
-              paddingBottom: "2px",
-              lineHeight: "10px",
-              zIndex: 201,
+              paddingTop: "0px",
+              paddingBottom: "0px",
+              // lineHeight: "8px",
+              // zIndex: 201,
             }}
             size="small"
-            variant="text"
+            variant="contained"
           >
-            Show it
+            Reveal it
           </Button>
         </Box>
       )}


### PR DESCRIPTION
Adjust how output box options are displayed: 

![image](https://github.com/codepod-io/codepod/assets/438579/3ac6f2bd-6879-44ea-bebe-7128769a2d98)

![image](https://github.com/codepod-io/codepod/assets/438579/0b573fc8-97aa-457b-89f8-f95c3934aebb)

Ref: https://github.com/codepod-io/codepod/issues/321