### PR TITLE
trigger auto-layout when auto-layout setting is toggled on

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -90,7 +90,6 @@ function SidebarSettings() {
                   color="warning"
                   onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                     setAutoRunLayout(event.target.checked);
-                    // if event.target.checked then run autoLayoutRoot??
                     if (event.target.checked) {
                       autoLayoutROOT();
                     }

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -53,6 +53,7 @@ function SidebarSettings() {
   const setAutoRunLayout = useStore(store, (state) => state.setAutoRunLayout);
   const contextualZoom = useStore(store, (state) => state.contextualZoom);
   const setContextualZoom = useStore(store, (state) => state.setContextualZoom);
+  const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
   return (
     <Box>
       <Box>
@@ -89,6 +90,10 @@ function SidebarSettings() {
                   color="warning"
                   onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                     setAutoRunLayout(event.target.checked);
+                    // if event.target.checked then run autoLayoutRoot??
+                    if (event.target.checked) {
+                      autoLayoutROOT();
+                    }
                   }}
                 />
               }


### PR DESCRIPTION
Toggling on the auto-layout setting in the sidebar should now trigger auto-layout for any overlapping pods or scopes. 