### PR TITLE
Apply "Show Line Numbers" as toggle switch in sidebar

### DIFF
--- a/ui/src/components/CanvasContextMenu.tsx
+++ b/ui/src/components/CanvasContextMenu.tsx
@@ -68,14 +68,6 @@ export function CanvasContextMenu(props) {
             <ListItemText>New Scope</ListItemText>
           </MenuItem>
         )}
-        <MenuItem onClick={flipShowLineNumbers} sx={ItemStyle}>
-          <ListItemIcon sx={{ color: "inherit" }}>
-            <FormatListNumberedIcon />
-          </ListItemIcon>
-          <ListItemText>
-            {showLineNumbers ? "Hide " : "Show "} Line Numbers
-          </ListItemText>
-        </MenuItem>
       </MenuList>
     </Box>
   );

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -486,7 +486,7 @@ function ExportFile() {
           // call export graphQL api to get the AWS S3 url
           exportJSON({ variables: { repoId } });
         }}
-        disabled={false}
+        disabled={true}
       >
         Python File
       </Button>
@@ -521,7 +521,7 @@ function ExportJSON() {
           // call export graphQL api to get the AWS S3 url
           exportJSON({ variables: { repoId } });
         }}
-        disabled={false}
+        disabled={true}
       >
         Raw JSON
       </Button>

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -49,6 +49,11 @@ function SidebarSettings() {
   );
   const devMode = useStore(store, (state) => state.devMode);
   const setDevMode = useStore(store, (state) => state.setDevMode);
+  const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
+  const setShowLineNumbers = useStore(
+    store,
+    (state) => state.setShowLineNumbers
+  );
   const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
   const setAutoRunLayout = useStore(store, (state) => state.setAutoRunLayout);
   const contextualZoom = useStore(store, (state) => state.contextualZoom);
@@ -57,6 +62,23 @@ function SidebarSettings() {
   return (
     <Box>
       <Box>
+        <Tooltip title={"Show Line Numbers"} disableInteractive>
+          <FormGroup>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={showLineNumbers}
+                  size="small"
+                  color="warning"
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setShowLineNumbers(event.target.checked);
+                  }}
+                />
+              }
+              label="Show Line Numbers"
+            />
+          </FormGroup>
+        </Tooltip>
         <Tooltip
           title={"Enable Debug Mode, e.g., show pod IDs"}
           disableInteractive
@@ -464,7 +486,7 @@ function ExportFile() {
           // call export graphQL api to get the AWS S3 url
           exportJSON({ variables: { repoId } });
         }}
-        disabled={true}
+        disabled={false}
       >
         Python File
       </Button>
@@ -499,7 +521,7 @@ function ExportJSON() {
           // call export graphQL api to get the AWS S3 url
           exportJSON({ variables: { repoId } });
         }}
-        disabled={true}
+        disabled={false}
       >
         Raw JSON
       </Button>

--- a/ui/src/lib/store/settingSlice.tsx
+++ b/ui/src/lib/store/settingSlice.tsx
@@ -10,11 +10,12 @@ export interface SettingSlice {
   setDevMode: (b: boolean) => void;
   autoRunLayout?: boolean;
   setAutoRunLayout: (b: boolean) => void;
-
   contextualZoomParams: Record<any, number>;
   contextualZoom: boolean;
   setContextualZoom: (b: boolean) => void;
   level2fontsize: (level: number) => number;
+  showLineNumbers?: boolean;
+  setShowLineNumbers: (b: boolean) => void;
 }
 
 export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
@@ -64,6 +65,15 @@ export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
     set({ contextualZoom: b });
     // also write to local storage
     localStorage.setItem("contextualZoom", JSON.stringify(b));
+  },
+  showLineNumbers: localStorage.getItem("showLineNumbers")
+    ? JSON.parse(localStorage.getItem("showLineNumbers")!)
+    : false,
+  setShowLineNumbers: (b: boolean) => {
+    // set it
+    set({ showLineNumbers: b });
+    // also write to local storage
+    localStorage.setItem("showLineNumbers", JSON.stringify(b));
   },
   // TODO Make it configurable.
   contextualZoomParams: {


### PR DESCRIPTION
- Add the toggle switch in sidebar
- remove the menu item from Right Click menu.
- 
![showLineNumbers](https://github.com/codepod-io/codepod/assets/10226241/36799204-441c-4f37-9fda-ab3ddec36bef)
