### PR TITLE
fix content loss caused by `dirty` status override

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -320,7 +320,11 @@ function SyncStatus() {
     let res: string[] = [];
     if (state.repoLoaded) {
       for (const id in state.pods) {
-        if (state.pods[id].dirty || state.pods[id].isSyncing) {
+        if (
+          state.pods[id].dirty ||
+          state.pods[id].dirtyPending ||
+          state.pods[id].isSyncing
+        ) {
           res.push(id);
         }
       }
@@ -339,7 +343,7 @@ function SyncStatus() {
   useEffect(() => {
     let id = setInterval(() => {
       remoteUpdateAllPods(client);
-    }, 1000);
+    }, 3000);
     return () => {
       clearInterval(id);
     };

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -343,7 +343,7 @@ function SyncStatus() {
   useEffect(() => {
     let id = setInterval(() => {
       remoteUpdateAllPods(client);
-    }, 3000);
+    }, 1000);
     return () => {
       clearInterval(id);
     };

--- a/ui/src/lib/store/index.tsx
+++ b/ui/src/lib/store/index.tsx
@@ -20,6 +20,9 @@ export type Pod = {
   type: "CODE" | "SCOPE" | "RICH";
   content?: string;
   dirty?: boolean;
+  // A temporary dirty status used during remote API syncing, so that new dirty
+  // status is not cleared by API returns.
+  dirtyPending?: boolean;
   isSyncing?: boolean;
   children: { id: string; type: string }[];
   parent: string;


### PR DESCRIPTION
One `dirty` status isn't enough. If a new change happens after a previous remote API sync but before the API response, the new dirty status will be cleared, causing the new change not written to remote.

This PR fixes it, by adding a temporary dirty status used specific during/for remote API syncing.