### PR TITLE
contextual zoom initial font size reduction

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -603,7 +603,10 @@ export const CodeNode = memo<NodeProps>(function ({
     return (
       <Box
         sx={{
-          fontSize: fontSize * 2,
+          fontSize:
+            fontSize * zoomLevel > threshold / 1.5
+              ? fontSize * 1.25
+              : fontSize * 2,
           background: "#eee",
           borderRadius: "5px",
           border: "5px solid red",


### PR DESCRIPTION
When a pod is initially collapsed, the font size for the contextual zoom summary will be smaller. When the canvas is zoomed out past a certain point, the font size of the summary will increase to the previous set size. Fixes #316. 


https://github.com/codepod-io/codepod/assets/105993789/5120bd62-19d6-4384-a903-31a1b8944214

