### PR TITLE
fix remirror toolbar position when panning on canvas

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -752,6 +752,8 @@ function CanvasImpl() {
     store,
     (state) => state.helperLineVertical
   );
+  const toggleMoved = useStore(store, (state) => state.toggleMoved);
+  const toggleClicked = useStore(store, (state) => state.toggleClicked);
 
   return (
     <Box
@@ -768,6 +770,12 @@ function CanvasImpl() {
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
+          onMove={() => {
+            toggleMoved();
+          }}
+          onPaneClick={() => {
+            toggleClicked();
+          }}
           onNodeDragStop={(event, node) => {
             removeDragHighlight();
             let mousePos = project({ x: event.clientX, y: event.clientY });

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -275,6 +275,13 @@ export interface CanvasSlice {
   setPaneFocus: () => void;
   setPaneBlur: () => void;
 
+  // onMove indicator
+  moved: boolean;
+  toggleMoved: () => void;
+  // clicked-on-canvas indicator
+  clicked: boolean;
+  toggleClicked: () => void;
+
   addNode: (
     type: "CODE" | "SCOPE" | "RICH",
     position: XYPosition,
@@ -941,6 +948,12 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
   },
   setPaneFocus: () => set({ isPaneFocused: true }),
   setPaneBlur: () => set({ isPaneFocused: false }),
+
+  moved: false,
+  toggleMoved: () => set({ moved: !get().moved }),
+  clicked: false,
+  toggleClicked: () => set({ clicked: !get().clicked }),
+
   /**
    * This node2children is maintained with the canvas reactflow states, not with
    * the pods. This mapping may be used by other components, e.g. the runtime.


### PR DESCRIPTION
New behaviors:
1. the remirror floating toolbar will follow the Rich-text pod when panning on canvas.
2. it will disappear when you click on the canvas

(minor) Also fixed an issue that prevented canvas-panning when mouse is over the remirror toolbar.



https://github.com/codepod-io/codepod/assets/4576201/5822151d-4f6e-4ffb-91a5-b0298cfa7af7

