### PR TITLE
use :8080 port by default

### DIFF
--- a/compose/dev/compose.yml
+++ b/compose/dev/compose.yml
@@ -76,7 +76,7 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - 80:80
+      - 8080:8080
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
   

--- a/compose/dev/nginx.conf
+++ b/compose/dev/nginx.conf
@@ -1,7 +1,7 @@
 server {
 
-        listen 80;
-        listen [::]:80;
+        listen 8080;
+        listen [::]:8080;
 
         server_name localhost;
 
@@ -34,8 +34,8 @@ server {
 }
 
 server {
-        listen 80;
-        listen [::]:80;
+        listen 8080;
+        listen [::]:8080;
         server_name prisma.127.0.0.1.sslip.io;
         location / {
                 # rewrite ^/prisma(.*)$ /prisma break;


### PR DESCRIPTION
Use `:8080` instead of `:80` for development.
* `:80` port isn't intuitive for development, and
* many systems need sudo privilege to open `:80` port. 
