### PR TITLE
fix: two console errors from #328

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -188,7 +188,7 @@ function SidebarSettings() {
             <FormControlLabel
               control={
                 <Switch
-                  checked={(apiKey && autoCompletion) as boolean}
+                  checked={!!(apiKey && autoCompletion)}
                   size="small"
                   color="warning"
                   onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
@@ -208,16 +208,18 @@ function SidebarSettings() {
                     disableInteractive
                     sx={{ display: "inline" }}
                   >
-                    <IconButton
-                      size="small"
-                      sx={{ display: "inline" }}
-                      onClick={() => setSettingOpen(true)}
-                      disabled={isGuest}
-                    >
-                      <HelpOutlineOutlinedIcon
-                        sx={{ fontSize: 14 }}
-                      ></HelpOutlineOutlinedIcon>
-                    </IconButton>
+                    <Box>
+                      <IconButton
+                        size="small"
+                        sx={{ display: "inline" }}
+                        onClick={() => setSettingOpen(true)}
+                        disabled={isGuest}
+                      >
+                        <HelpOutlineOutlinedIcon
+                          sx={{ fontSize: 14 }}
+                        ></HelpOutlineOutlinedIcon>
+                      </IconButton>
+                    </Box>
                   </Tooltip>
                 </>
               }


### PR DESCRIPTION
Fix two errors in the browser developer console:

<img width="660" alt="Screenshot 2023-07-07 at 12 55 00 PM" src="https://github.com/codepod-io/codepod/assets/4576201/5a4b38ee-fb0b-414c-a5a9-caa400566a03">

<img width="706" alt="Screenshot 2023-07-07 at 1 35 40 PM" src="https://github.com/codepod-io/codepod/assets/4576201/18163444-fcb1-4948-9b93-fac49c3d58b4">
