### PR TITLE
use one global instance of Prisma client

### DIFF
--- a/api/src/client.ts
+++ b/api/src/client.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from "@prisma/client";
+
+let prisma = new PrismaClient();
+
+export default prisma;

--- a/api/src/resolver_export.ts
+++ b/api/src/resolver_export.ts
@@ -1,7 +1,6 @@
-import Prisma from "@prisma/client";
-
 import AWS from "aws-sdk";
 import { writeFile, readFile, unlink } from "fs/promises";
+import prisma from './client'
 
 console.log("REGION", process.env.EXPORT_AWS_S3_REGION);
 
@@ -36,10 +35,6 @@ async function uploadToS3WithExpiration(filename, content) {
     console.log("Error uploading file:", error);
   }
 }
-
-const { PrismaClient } = Prisma;
-
-const prisma = new PrismaClient();
 
 /**
  * Export to a JSON file for the pods' raw data.

--- a/api/src/resolver_repo.ts
+++ b/api/src/resolver_repo.ts
@@ -1,12 +1,9 @@
-import Prisma from "@prisma/client";
 // nanoid v4 does not work with nodejs. https://github.com/ai/nanoid/issues/365
 import { customAlphabet } from "nanoid/async";
 import { lowercase, numbers } from "nanoid-dictionary";
+import prisma from './client'
 
 const nanoid = customAlphabet(lowercase + numbers, 20);
-const { PrismaClient } = Prisma;
-
-const prisma = new PrismaClient();
 
 async function ensureRepoEditAccess({ repoId, userId }) {
   let repo = await prisma.repo.findFirst({

--- a/api/src/resolver_runtime.ts
+++ b/api/src/resolver_runtime.ts
@@ -16,12 +16,6 @@ import {
   initRoutes as initRoutes_k8s,
 } from "./spawner-k8s";
 
-import Prisma from "@prisma/client";
-
-const { PrismaClient } = Prisma;
-
-const prisma = new PrismaClient();
-
 const apollo_client = new ApolloClient({
   cache: new InMemoryCache({}),
   uri: process.env.PROXY_API_URL,

--- a/api/src/resolver_user.ts
+++ b/api/src/resolver_user.ts
@@ -1,4 +1,3 @@
-import Prisma from "@prisma/client";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { OAuth2Client } from "google-auth-library";
@@ -7,11 +6,9 @@ import { OAuth2Client } from "google-auth-library";
 import { customAlphabet } from "nanoid/async";
 import { lowercase, numbers } from "nanoid-dictionary";
 
+import prisma from './client'
+
 const nanoid = customAlphabet(lowercase + numbers, 20);
-
-const { PrismaClient } = Prisma;
-
-const prisma = new PrismaClient();
 
 async function me(_, __, { userId }) {
   if (!userId) throw Error("Unauthenticated");


### PR DESCRIPTION
This PR follows [Prisma's official best practice](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#prismaclient-in-long-running-applications). Hopefully this would reduce the number of active connections and fix the following error:

```
Error querying the database: db error:
  FATAL: remaining connection slots are reserved for non-replication superuser connections
```