### PR TITLE
fix: sx not an object warning

### DIFF
--- a/ui/src/pages/repos.tsx
+++ b/ui/src/pages/repos.tsx
@@ -84,11 +84,13 @@ function RepoLine({
           component={ReactLink}
           to={`/repo/${repo.id}`}
           sx={
-            deleting && {
-              color: theme.palette.action.disabled,
-              textDecorationColor: theme.palette.action.disabled,
-              pointerEvents: "none",
-            }
+            deleting
+              ? {
+                  color: theme.palette.action.disabled,
+                  textDecorationColor: theme.palette.action.disabled,
+                  pointerEvents: "none",
+                }
+              : {}
           }
         >
           <Box


### PR DESCRIPTION
Fix the following warning in dashboard page, introduced in #364 :

<img width="827" alt="Screenshot 2023-07-13 at 7 13 24 PM" src="https://github.com/codepod-io/codepod/assets/4576201/391367ab-114c-440d-90b4-352c7450f72c">
