### PR TITLE
[UI] Allow importing the Python script

### DIFF
--- a/ui/src/components/CanvasContextMenu.tsx
+++ b/ui/src/components/CanvasContextMenu.tsx
@@ -69,7 +69,7 @@ export function CanvasContextMenu(props) {
             <ListItemIcon sx={{ color: "inherit" }}>
               <FileUploadTwoToneIcon />
             </ListItemIcon>
-            <ListItemText>Import Jupyter Notebook</ListItemText>
+            <ListItemText>Import Code</ListItemText>
           </MenuItem>
         )}
       </MenuList>

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -294,9 +294,9 @@ export interface CanvasSlice {
     parent: string
   ) => void;
 
-  importIpynb: (
+  importLocalCode: (
     position: XYPosition,
-    repoName: string,
+    importScopeName: string,
     cellList: any[]
   ) => void;
 
@@ -478,8 +478,8 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     }
   },
 
-  importIpynb: (position, repoName, cellList) => {
-    console.log("Sync imported Jupyter notebook cells.");
+  importLocalCode: (position, importScopeName, cellList) => {
+    console.log("Sync imported Jupyter notebook or Python scripts");
     let nodesMap = get().ydoc.getMap<Node>("pods");
     let scopeNode = createNewNode("SCOPE", position);
     // parent could be "ROOT" or a SCOPE node
@@ -498,7 +498,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
       podParent = parent.id;
     }
 
-    scopeNode.data.name = repoName;
+    scopeNode.data.name = importScopeName;
     nodesMap.set(scopeNode.id, scopeNode);
 
     get().addPod({


### PR DESCRIPTION
## Summary 
- Allow importing a Python script to a pod.
- Change right-click context menu item
- The imported Python script is put into a scope rather than "ROOT". 

## Test

![importLocalCode](https://github.com/codepod-io/codepod/assets/10226241/ffec36ca-8bb7-42fc-aa97-aad0d4fcb1c0)
