### PR TITLE
use Monaco's addAction instead of addCommand

### DIFF
--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -394,7 +394,6 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const readOnly = useStore(store, (state) => state.role === "GUEST");
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const getPod = useStore(store, (state) => state.getPod);
-  const setCurrentEditor = useStore(store, (state) => state.setCurrentEditor);
   const setPodContent = useStore(store, (state) => state.setPodContent);
   const initPodContent = useStore(store, (state) => state.initPodContent);
   const clearResults = useStore(store, (s) => s.clearResults);
@@ -412,14 +411,6 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const onChange = (value) => setPodContent({ id, content: value });
   let [editor, setEditor] =
     useState<monaco.editor.IStandaloneCodeEditor | null>(null);
-  const onRun = useCallback(() => {
-    // it's MonacoEditor's bug microsoft/monaco-editor#2947, it always triggered the last created instance
-    const activeId = store.getState().currentEditor;
-    if (activeId) {
-      clearResults(activeId);
-      wsRun(activeId);
-    }
-  }, [clearResults, store, wsRun]);
 
   useEffect(() => {
     if (!editor) return;
@@ -470,12 +461,19 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
     editor.onDidFocusEditorText(() => {
       setPodFocus(id);
       if (resetSelection()) updateView();
-      setCurrentEditor(id);
     });
     editor.onDidContentSizeChange(updateHeight);
-    // FIXME clean up?
-    editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, function () {
-      onRun();
+    // Note: must use addAction instead of addCommand. The addCommand is not
+    // working because it is bound to only the latest Monaco instance. This is a
+    // known bug: https://github.com/microsoft/monaco-editor/issues/2947
+    editor.addAction({
+      id: "Run",
+      label: "Run",
+      keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.Enter],
+      run: () => {
+        clearResults(id);
+        wsRun(id);
+      },
     });
     // editor.onDidChangeModelContent(async (e) => {
     //   // content is value?

--- a/ui/src/lib/store/repoStateSlice.tsx
+++ b/ui/src/lib/store/repoStateSlice.tsx
@@ -102,8 +102,6 @@ export interface RepoStateSlice {
     apiKey: string
   ) => Promise<boolean>;
   loadVisibility: (client: ApolloClient<object>, repoId: string) => void;
-  currentEditor: string | null;
-  setCurrentEditor: (id: string | null) => void;
   setUser: (user: any) => void;
   addClient: (clientId: any, name, color) => void;
   deleteClient: (clientId: any) => void;
@@ -135,8 +133,6 @@ export const createRepoStateSlice: StateCreator<
   ydoc: new Doc(),
   provider: null,
   // keep different seletced info on each user themselves
-  // to fixed maco editor command bug
-  currentEditor: null,
   //TODO: all presence information are now saved in clients map for future usage. create a modern UI to show those information from clients (e.g., online users)
   clients: new Map(),
   loadError: null,
@@ -150,7 +146,6 @@ export const createRepoStateSlice: StateCreator<
   setSessionId: (id) => set({ sessionId: id }),
   addError: (error) => set({ error }),
   clearError: () => set({ error: null }),
-  setCurrentEditor: (id) => set({ currentEditor: id }),
 
   loadRepo: loadRepo(set, get),
   remoteUpdateAllPods: async (client) => {


### PR DESCRIPTION
Adopting a [better workaround](https://github.com/microsoft/monaco-editor/issues/2947#issuecomment-1639608153) (replacing the fix in #70) to handle Monaco's multiple instances bug.