### PR TITLE
fix: node height changing bug caused by border

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -604,6 +604,8 @@ export const CodeNode = memo<NodeProps>(function ({
           background: "#eee",
           borderRadius: "5px",
           border: "5px solid red",
+          // Offset the border to prevent the node height from changing.
+          margin: "-5px",
           textAlign: "center",
           height: pod.height,
           width: pod.width,

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -815,6 +815,8 @@ export const RichNode = memo<Props>(function ({
           background: "#eee",
           borderRadius: "5px",
           border: "5px solid red",
+          // Offset the border to prevent the node height from changing.
+          margin: "-5px",
           textAlign: "center",
           height: pod.height,
           width: pod.width,


### PR DESCRIPTION
The height of a collapsed Code or Rich node is changing due to the border size of 5px. This PR offsets that wth a -5px margin.