### PR TITLE
make newpod buttons non-overlap with editor

### DIFF
--- a/ui/src/components/nodes/utils.tsx
+++ b/ui/src/components/nodes/utils.tsx
@@ -288,6 +288,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const addNode = useStore(store, (state) => state.addNode);
+  const defaultOpacity = 0;
   return (
     <>
       {/* Bottom 1 */}
@@ -299,11 +300,10 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           position: "absolute",
           bottom: "0px",
           left: "25%",
-          transform: "translate(-50%, 50%)",
+          transform: "translate(-50%, 100%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          // opacity: showToolbar ? 0.5 : 0,
-          opacity: 0,
+          opacity: defaultOpacity,
           "&:hover": {
             opacity: 1,
           },
@@ -323,11 +323,10 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           position: "absolute",
           bottom: "0px",
           left: "75%",
-          transform: "translate(-50%, 50%)",
+          transform: "translate(-50%, 100%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          // opacity: showToolbar ? 0.5 : 0,
-          opacity: 0,
+          opacity: defaultOpacity,
           "&:hover": {
             opacity: 1,
           },
@@ -347,11 +346,10 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           position: "absolute",
           top: "25%",
           left: "0px",
-          transform: "translate(-50%, -50%)",
+          transform: "translate(-100%, -50%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          // opacity: showToolbar ? 0.5 : 0,
-          opacity: 0,
+          opacity: defaultOpacity,
           "&:hover": {
             opacity: 1,
           },
@@ -372,11 +370,10 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           position: "absolute",
           top: "75%",
           left: "0px",
-          transform: "translate(-50%, -50%)",
+          transform: "translate(-100%, -50%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          // opacity: showToolbar ? 0.5 : 0,
-          opacity: 0,
+          opacity: defaultOpacity,
           "&:hover": {
             opacity: 1,
           },
@@ -397,11 +394,10 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           position: "absolute",
           top: "25%",
           right: "0px",
-          transform: "translate(50%, -50%)",
+          transform: "translate(100%, -50%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          // opacity: showToolbar ? 0.5 : 0,
-          opacity: 0,
+          opacity: defaultOpacity,
           "&:hover": {
             opacity: 1,
           },
@@ -422,11 +418,10 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           position: "absolute",
           top: "75%",
           right: "0px",
-          transform: "translate(50%, -50%)",
+          transform: "translate(100%, -50%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          // opacity: showToolbar ? 0.5 : 0,
-          opacity: 0,
+          opacity: defaultOpacity,
           "&:hover": {
             opacity: 1,
           },
@@ -441,7 +436,11 @@ export function NewPodButtons({ pod, xPos, yPos }) {
   );
 }
 
-export function level2fontsize(level: number, contextualZoomParams: Record<any, number>, contextualZoom: boolean) {
+export function level2fontsize(
+  level: number,
+  contextualZoomParams: Record<any, number>,
+  contextualZoom: boolean
+) {
   // default font size
   if (!contextualZoom) return 16;
   // when contextual zoom is on

--- a/ui/src/components/nodes/utils.tsx
+++ b/ui/src/components/nodes/utils.tsx
@@ -9,6 +9,8 @@ import {
 import { useContext } from "react";
 
 import Button from "@mui/material/Button";
+import CodeIcon from "@mui/icons-material/Code";
+import NoteIcon from "@mui/icons-material/Note";
 
 import { useStore } from "zustand";
 
@@ -311,7 +313,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           addNode("CODE", { x: xPos, y: yPos + pod!.height! + 50 }, pod.parent);
         }}
       >
-        + Code
+        + <CodeIcon fontSize="small" />
       </Button>
 
       {/* Bottom 2 */}
@@ -334,7 +336,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           addNode("RICH", { x: xPos, y: yPos + pod!.height! + 50 }, pod.parent);
         }}
       >
-        + Note
+        + <NoteIcon fontSize="small" />
       </Button>
       {/* Left 1 */}
       <Button
@@ -357,7 +359,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           addNode("CODE", { x: xPos - pod!.width! - 50, y: yPos }, pod.parent);
         }}
       >
-        + Code
+        + <CodeIcon fontSize="small" />
       </Button>
 
       {/* Left 2 */}
@@ -381,7 +383,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           addNode("RICH", { x: xPos - pod!.width! - 50, y: yPos }, pod.parent);
         }}
       >
-        + Note
+        + <NoteIcon fontSize="small" />
       </Button>
 
       {/* Right 1 */}
@@ -405,7 +407,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           addNode("CODE", { x: xPos + pod!.width! + 50, y: yPos }, pod.parent);
         }}
       >
-        + Code
+        + <CodeIcon fontSize="small" />
       </Button>
 
       {/* Right 2 */}
@@ -429,7 +431,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           addNode("RICH", { x: xPos + pod!.width! + 50, y: yPos }, pod.parent);
         }}
       >
-        + Note
+        + <NoteIcon fontSize="small" />
       </Button>
     </>
   );

--- a/ui/src/components/nodes/utils.tsx
+++ b/ui/src/components/nodes/utils.tsx
@@ -288,7 +288,6 @@ export function NewPodButtons({ pod, xPos, yPos }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const addNode = useStore(store, (state) => state.addNode);
-  const defaultOpacity = 0;
   return (
     <>
       {/* Bottom 1 */}
@@ -303,7 +302,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           transform: "translate(-50%, 100%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          opacity: defaultOpacity,
+          opacity: 0,
           "&:hover": {
             opacity: 1,
           },
@@ -326,7 +325,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           transform: "translate(-50%, 100%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          opacity: defaultOpacity,
+          opacity: 0,
           "&:hover": {
             opacity: 1,
           },
@@ -349,7 +348,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           transform: "translate(-100%, -50%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          opacity: defaultOpacity,
+          opacity: 0,
           "&:hover": {
             opacity: 1,
           },
@@ -373,7 +372,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           transform: "translate(-100%, -50%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          opacity: defaultOpacity,
+          opacity: 0,
           "&:hover": {
             opacity: 1,
           },
@@ -397,7 +396,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           transform: "translate(100%, -50%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          opacity: defaultOpacity,
+          opacity: 0,
           "&:hover": {
             opacity: 1,
           },
@@ -421,7 +420,7 @@ export function NewPodButtons({ pod, xPos, yPos }) {
           transform: "translate(100%, -50%)",
           zIndex: 100,
           whiteSpace: "nowrap",
-          opacity: defaultOpacity,
+          opacity: 0,
           "&:hover": {
             opacity: 1,
           },


### PR DESCRIPTION
The previous "new pod" buttons on the side are prone to accidental clicks.

From

<img width="426" alt="Screenshot 2023-07-22 at 3 16 41 PM" src="https://github.com/codepod-io/codepod/assets/4576201/d904806d-397c-4e47-854e-00d71f7c910d">

To

<img width="476" alt="Screenshot 2023-07-22 at 3 25 15 PM" src="https://github.com/codepod-io/codepod/assets/4576201/539f7848-12dc-4348-b067-285497ea5e62">

