### PR TITLE
fix: kebab-case sx property error

### DIFF
--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -346,13 +346,13 @@ const MyEditor = ({
         cursor: "auto",
         // Display different markers for different levels in nested ordered lists.
         ol: {
-          "list-style-type": "decimal",
+          listStylType: "decimal",
         },
         "ol li ol": {
-          "list-style-type": "lower-alpha",
+          listStyleType: "lower-alpha",
         },
         "ol li ol li ol": {
-          "list-style-type": "lower-roman",
+          listStyleType: "lower-roman",
         },
       }}
       ref={ref}


### PR DESCRIPTION
Fix the following error, introduced in #392 :

<img width="665" alt="Screenshot 2023-07-24 at 12 23 17 AM" src="https://github.com/codepod-io/codepod/assets/4576201/1f1143bf-cb01-4cc2-936f-6be8b37b3427">
