### PR TITLE
fix: Chinese input method in Remirror editor

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -23,7 +23,6 @@ import ReactFlow, {
   NodeProps,
   useStore as useReactFlowStore,
 } from "reactflow";
-import "reactflow/dist/style.css";
 
 import Box from "@mui/material/Box";
 import InputBase from "@mui/material/InputBase";

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -23,7 +23,6 @@ import ReactFlow, {
   NodeProps,
   useStore as useReactFlowStore,
 } from "reactflow";
-import "reactflow/dist/style.css";
 
 import Box from "@mui/material/Box";
 import InputBase from "@mui/material/InputBase";

--- a/ui/src/components/nodes/extensions/codepodSync.ts
+++ b/ui/src/components/nodes/extensions/codepodSync.ts
@@ -19,6 +19,9 @@ interface CodePodSyncOptions {
   handlerKeys: [],
   customHandlerKeys: [],
 })
+/**
+ * This extension is used to sync the content of the editor with the pod.
+ */
 export class CodePodSyncExtension extends PlainExtension<CodePodSyncOptions> {
   firstUpdate = true;
   turndownService = new TurndownService();
@@ -32,8 +35,9 @@ export class CodePodSyncExtension extends PlainExtension<CodePodSyncOptions> {
           id: this.options.id,
           content: state.doc.toJSON(),
         },
+        // The first onChange event is triggered wehn the content is the same.
+        // Skip it.
         this.firstUpdate
-        // true
       );
       this.firstUpdate = false;
     }

--- a/ui/src/components/nodes/extensions/codepodSync.ts
+++ b/ui/src/components/nodes/extensions/codepodSync.ts
@@ -1,0 +1,49 @@
+import TurndownService from "turndown";
+
+import { PlainExtension, StateUpdateLifecycleProps, extension } from "remirror";
+
+interface CodePodSyncOptions {
+  // Options are `Dynamic` by default.
+  id: string;
+  setPodContent: any;
+  setPodRichContent: any;
+}
+
+@extension<CodePodSyncOptions>({
+  defaultOptions: {
+    id: "defaultId",
+    setPodContent: () => {},
+    setPodRichContent: () => {},
+  },
+  staticKeys: [],
+  handlerKeys: [],
+  customHandlerKeys: [],
+})
+export class CodePodSyncExtension extends PlainExtension<CodePodSyncOptions> {
+  firstUpdate = true;
+  turndownService = new TurndownService();
+  get name(): string {
+    return "codepod-sync";
+  }
+  onStateUpdate({ state, tr }: StateUpdateLifecycleProps) {
+    if (tr?.docChanged) {
+      this.options.setPodContent(
+        {
+          id: this.options.id,
+          content: state.doc.toJSON(),
+        },
+        this.firstUpdate
+        // true
+      );
+      this.firstUpdate = false;
+    }
+
+    var markdown = this.turndownService.turndown(
+      this.store.helpers.getHTML(state)
+    );
+    this.options.setPodRichContent({
+      id: this.options.id,
+      richContent: markdown,
+    });
+  }
+}

--- a/ui/src/lib/store/podSlice.tsx
+++ b/ui/src/lib/store/podSlice.tsx
@@ -33,7 +33,12 @@ export interface PodSlice {
     dirty?: boolean
   ) => void;
   setPodName: ({ id, name }: { id: string; name: string }) => void;
-  setPodContent: ({ id, content }: { id: string; content: string }) => void;
+  setPodContent: (
+    { id, content }: { id: string; content: string },
+    // Whether to perform additional verification of whether content ==
+    // pod.content before setting the dirty flag..
+    verify?: boolean
+  ) => void;
   setPodRichContent: ({
     id,
     richContent,
@@ -87,10 +92,15 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
       // @ts-ignore
       "setPodName"
     ),
-  setPodContent: ({ id, content }) =>
+  setPodContent: ({ id, content }, verify = false) =>
     set(
       produce((state) => {
         let pod = state.pods[id];
+        if (verify) {
+          if (JSON.stringify(pod.content) === JSON.stringify(content)) {
+            return;
+          }
+        }
         pod.content = content;
         pod.dirty = true;
       }),


### PR DESCRIPTION

The [controlled Remirror editor](https://remirror.io/docs/controlled-editor) will prevent Chinese (or CJK) input methods from working.


Remirror's official demo:
- **Un-controlled** Remirror editor, Chinese input working: https://remirror.vercel.app/?path=/story/editors-markdown--basic
- **Controlled** Remirror editor, Chinese input NOT working: https://remirror.vercel.app/?path=/story/editors-controlled--editable

This PR changes **Controlled** Remirror editor to **Un-controlled**.