### PR TITLE
[UI] Support exporting pod stdout and result

### DIFF
--- a/api/src/resolver_export.ts
+++ b/api/src/resolver_export.ts
@@ -60,16 +60,9 @@ async function exportJSON(_, { repoId }, { userId }) {
       },
     },
   });
-  // now export repo to a file
   if (!repo) throw Error("Repo not exists.");
-  const filename = `${
-    repo.name || "Untitled"
-  }-${new Date().toISOString()}.json`;
-  const aws_url = await uploadToS3WithExpiration(
-    filename,
-    JSON.stringify({ name: repo.name, version: "v0.0.1", pods: repo.pods })
-  );
-  return aws_url;
+  // return the JSON string
+  return JSON.stringify({ name: repo.name, format: "codepod", version: "v0.0.1", pods: repo.pods });
 }
 
 interface Pod {

--- a/runtime/src/zmq-utils.ts
+++ b/runtime/src/zmq-utils.ts
@@ -133,7 +133,7 @@ export function constructExecuteRequest({ code, msg_id, cp = {} }) {
       cp,
       // FIXME if this is true, no result is returned!
       silent: false,
-      store_history: false,
+      store_history: true,
       // XXX this does not seem to be used
       user_expressions: {
         x: "3+4",

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -794,6 +794,8 @@ function CanvasImpl() {
           cellList = JSON.parse(String(fileContent)).cells.map((cell) => ({
             cellType: cell.cell_type,
             cellSource: cell.source.join(""),
+            cellOutputs: cell.outputs || [],
+            execution_count: cell.execution_count || 0,
           }));
           importScopeName = fileName.substring(0, fileName.length - 6);
           break;

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -868,7 +868,10 @@ function ExportJSON() {
         "href",
         "data:text/plain;charset=utf-8," + encodeURIComponent(data.exportJSON)
       );
-      element.setAttribute("download", `${repoName || ""}.json`);
+      const filename = `${
+        repoName || "Untitled"
+      }-${new Date().toISOString()}.json`;
+      element.setAttribute("download", filename);
 
       element.style.display = "none";
       document.body.appendChild(element);


### PR DESCRIPTION
## Summary
- When exporting, the pod's stdout and result are written to a Jupyter notebook
- "Raw JSON" export functionality is moved to the frontend
- The Jupyter notebook result is imported in addition to the entire notebook
- Bug fix: "execution_count" is returned from runtime server now

## Test

![export_pod_result](https://github.com/codepod-io/codepod/assets/10226241/20f0868e-1bdf-4da8-921d-85f643c8f0d3)

![import_ipynb_result](https://github.com/codepod-io/codepod/assets/10226241/ca597daf-c4f7-4b67-90b8-ee2d9569af6f)

