### PR TITLE
[BE] remove cut-n-paste support

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -35,7 +35,6 @@ import Button from "@mui/material/Button";
 import CircleIcon from "@mui/icons-material/Circle";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import ContentCutIcon from "@mui/icons-material/ContentCut";
 import Grid from "@mui/material/Grid";
 import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
 import KeyboardDoubleArrowRightIcon from "@mui/icons-material/KeyboardDoubleArrowRight";
@@ -372,16 +371,6 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
     [clonePod, id]
   );
 
-  const cutBegin = useStore(store, (state) => state.cutBegin);
-
-  const onCut = useCallback(
-    (clipboardData: any) => {
-      onCopy(clipboardData);
-      cutBegin(id);
-    },
-    [onCopy, cutBegin, id]
-  );
-
   return (
     <Box
       sx={{ display: "flex", alignItems: "center", justifyContent: "center" }}
@@ -429,18 +418,6 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
           </IconButton>
         </Tooltip>
       </CopyToClipboard>
-      {!isGuest && (
-        <CopyToClipboard
-          text="dummy"
-          options={{ debug: true, format: "text/plain", onCopy: onCut } as any}
-        >
-          <Tooltip title="Cut">
-            <IconButton>
-              <ContentCutIcon fontSize="inherit" />
-            </IconButton>
-          </Tooltip>
-        </CopyToClipboard>
-      )}
       {!isGuest && (
         <Tooltip title="Delete">
           <IconButton
@@ -501,13 +478,13 @@ export const CodeNode = memo<NodeProps>(function ({
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
   const inputRef = useRef<HTMLInputElement>(null);
   const updateView = useStore(store, (state) => state.updateView);
-  const isCutting = useStore(store, (state) => state.cuttingIds.has(id));
 
   const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
   const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
   const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
 
   const prevLayout = useRef(layout);
+
   useEffect(() => {
     if (autoRunLayout) {
       // Run auto-layout when the output box layout changes.
@@ -679,13 +656,11 @@ export const CodeNode = memo<NodeProps>(function ({
               border: "1px #d6dee6",
               borderWidth: pod.ispublic ? "4px" : "2px",
               borderRadius: "4px",
-              borderStyle: isCutting ? "dashed" : "solid",
+              borderStyle: "solid",
               width: "100%",
               height: "100%",
               backgroundColor: "rgb(244, 246, 248)",
-              borderColor: isCutting
-                ? "red"
-                : pod.ispublic
+              borderColor: pod.ispublic
                 ? "green"
                 : selected
                 ? "#003c8f"

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -31,7 +31,6 @@ import Tooltip from "@mui/material/Tooltip";
 import IconButton from "@mui/material/IconButton";
 import Grid from "@mui/material/Grid";
 import DeleteIcon from "@mui/icons-material/Delete";
-import ContentCutIcon from "@mui/icons-material/ContentCut";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
 import ViewTimelineOutlinedIcon from "@mui/icons-material/ViewTimelineOutlined";
@@ -76,15 +75,6 @@ function MyFloatingToolbar({ id }: { id: string }) {
     [clonePod, id]
   );
 
-  const cutBegin = useStore(store, (state) => state.cutBegin);
-
-  const onCut = useCallback(
-    (clipboardData: any) => {
-      onCopy(clipboardData);
-      cutBegin(id);
-    },
-    [onCopy, cutBegin, id]
-  );
   const autoLayout = useStore(store, (state) => state.autoLayout);
   return (
     <Box
@@ -138,19 +128,6 @@ function MyFloatingToolbar({ id }: { id: string }) {
           </IconButton>
         </Tooltip>
       </CopyToClipboard>
-
-      {!isGuest && (
-        <CopyToClipboard
-          text="dummy"
-          options={{ debug: true, format: "text/plain", onCopy: onCut } as any}
-        >
-          <Tooltip title="Cut">
-            <IconButton>
-              <ContentCutIcon fontSize="inherit" />
-            </IconButton>
-          </Tooltip>
-        </CopyToClipboard>
-      )}
       {!isGuest && (
         <Tooltip title="Delete" className="nodrag">
           <IconButton
@@ -204,7 +181,6 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
   const pod = getPod(id);
 
   const devMode = useStore(store, (state) => state.devMode);
-  const isCutting = useStore(store, (state) => state.cuttingIds.has(id));
 
   useEffect(() => {
     if (!data.name) return;
@@ -271,7 +247,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
       sx={{
         width: "100%",
         height: "100%",
-        border: isCutting ? "dashed 2px red" : "solid 1px #d6dee6",
+        border: "solid 1px #d6dee6",
         borderRadius: "4px",
         cursor: "auto",
         fontSize,


### PR DESCRIPTION
## Summary
The cut-n-paste was introduced in PR #165 , as the moveIntoScope #280 function was implemented, cut-n-paste seems unnecessary, this is a Better Engineering effort to reduce the tech debt. 

- The cut button is removed from the toolbar in Code/Scope pod.
