### PR TITLE
auto-change textfield size of repo title

### DIFF
--- a/ui/src/pages/repo.tsx
+++ b/ui/src/pages/repo.tsx
@@ -93,7 +93,11 @@ const HeaderItem = memo<any>(({ id }) => {
             }),
       }}
       sx={{
-        maxWidth: "100%",
+        // Try to compute a correct width so that the textfield size changes
+        // according to content size.
+        width: `${((repoName?.length || 0) + 6) * 6}px`,
+        minWidth: "100px",
+        maxWidth: "500px",
         border: "none",
       }}
       disabled={!isOwner}


### PR DESCRIPTION
So that the longer titles will be shown gracefully.

Before:

![before](https://github.com/codepod-io/codepod/assets/4576201/f147e29e-08eb-404c-917e-1c6b93fa34f5)

After:

![after](https://github.com/codepod-io/codepod/assets/4576201/ba3b5761-43f0-4e54-8d6d-719385783a12)
