### PR TITLE
[UI] Jupyter notebook export patch

### DIFF
--- a/ui/src/lib/store/index.tsx
+++ b/ui/src/lib/store/index.tsx
@@ -31,7 +31,7 @@ export type Pod = {
   status?: string;
   stdout?: string;
   stderr?: string;
-  error?: { evalue: string; stacktrace: string[] } | null;
+  error?: { ename: string; evalue: string; stacktrace: string[] } | null;
   lastExecutedAt?: Date;
   lang: string;
   column?: number;


### PR DESCRIPTION
## Summary
- For Jupyter notebook export
   - Better align the pod result with Jupyter cell output format, issue #411 
      - Add error output
      - separate `execute_result` and `display_data`
- For Jupyter notebook import 
   - Support `error` imports
- Improve exported .ipynb readability
- Add repo_id into the top-level `metadata`