### PR TITLE
feat: use popup handles to create new nodes

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -57,7 +57,7 @@ import { useApolloClient } from "@apollo/client";
 import { NodeResizeControl, NodeResizer } from "reactflow";
 
 import "@reactflow/node-resizer/dist/style.css";
-import { NewPodButtons, ResizeIcon, level2fontsize } from "./utils";
+import { Handles, level2fontsize } from "./utils";
 import { timeDifference } from "../../lib/utils";
 import { ButtonGroup } from "@mui/material";
 
@@ -478,7 +478,6 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
 export const CodeNode = memo<NodeProps>(function ({
   data,
   id,
-  isConnectable,
   selected,
   // note that xPos and yPos are the absolute position of the node
   xPos,
@@ -701,33 +700,8 @@ export const CodeNode = memo<NodeProps>(function ({
                 opacity: showToolbar ? 1 : 0,
               }}
             >
-              <Handle
-                type="source"
-                position={Position.Top}
-                id="top"
-                isConnectable={isConnectable}
-              />
-              <Handle
-                type="source"
-                position={Position.Bottom}
-                id="bottom"
-                isConnectable={isConnectable}
-              />
-              <Handle
-                type="source"
-                position={Position.Left}
-                id="left"
-                isConnectable={isConnectable}
-              />
-              <Handle
-                type="source"
-                position={Position.Right}
-                id="right"
-                isConnectable={isConnectable}
-              />
+              <Handles pod={pod} xPos={xPos} yPos={yPos} />
             </Box>
-
-            <NewPodButtons pod={pod} xPos={xPos} yPos={yPos} />
 
             {/* The header of code pods. */}
             <Box>

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -138,7 +138,7 @@ import { SlashExtension } from "./extensions/slash";
 import { SlashSuggestor } from "./extensions/useSlash";
 import { BlockHandleExtension } from "./extensions/blockHandle";
 
-import { ConfirmDeleteButton, NewPodButtons, level2fontsize } from "./utils";
+import { ConfirmDeleteButton, Handles, level2fontsize } from "./utils";
 import { RepoContext } from "../../lib/store";
 
 import "./remirror-size.css";
@@ -703,32 +703,9 @@ export const RichNode = memo<Props>(function ({
                 opacity: showToolbar ? 1 : 0,
               }}
             >
-              <Handle
-                type="source"
-                position={Position.Top}
-                id="top"
-                isConnectable={isConnectable}
-              />
-              <Handle
-                type="source"
-                position={Position.Bottom}
-                id="bottom"
-                isConnectable={isConnectable}
-              />
-              <Handle
-                type="source"
-                position={Position.Left}
-                id="left"
-                isConnectable={isConnectable}
-              />
-              <Handle
-                type="source"
-                position={Position.Right}
-                id="right"
-                isConnectable={isConnectable}
-              />
+              <Handles pod={pod} xPos={xPos} yPos={yPos} />
             </Box>
-            <NewPodButtons pod={pod} xPos={xPos} yPos={yPos} />
+
             <Box>
               {devMode && (
                 <Box

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -46,7 +46,12 @@ import { RepoContext } from "../../lib/store";
 import { NodeResizer, NodeResizeControl } from "reactflow";
 import "@reactflow/node-resizer/dist/style.css";
 import { ResizableBox } from "react-resizable";
-import { ConfirmDeleteButton, ResizeIcon, level2fontsize } from "./utils";
+import {
+  ConfirmDeleteButton,
+  Handles,
+  ResizeIcon,
+  level2fontsize,
+} from "./utils";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 
 function MyFloatingToolbar({ id }: { id: string }) {
@@ -315,30 +320,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
           opacity: showToolbar ? 1 : 0,
         }}
       >
-        <Handle
-          type="source"
-          position={Position.Top}
-          id="top"
-          isConnectable={isConnectable}
-        />
-        <Handle
-          type="source"
-          position={Position.Bottom}
-          id="bottom"
-          isConnectable={isConnectable}
-        />
-        <Handle
-          type="source"
-          position={Position.Left}
-          id="left"
-          isConnectable={isConnectable}
-        />
-        <Handle
-          type="source"
-          position={Position.Right}
-          id="right"
-          isConnectable={isConnectable}
-        />
+        <Handles pod={pod} xPos={xPos} yPos={yPos} />
       </Box>
       {/* The header of scope nodes. */}
       <Box

--- a/ui/src/pages/profile.tsx
+++ b/ui/src/pages/profile.tsx
@@ -3,9 +3,16 @@ import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
 
 import Paper from "@mui/material/Paper";
-import { Container, Stack } from "@mui/material";
+import {
+  Button,
+  ClickAwayListener,
+  Container,
+  Popper,
+  Stack,
+} from "@mui/material";
 
 import useMe from "../lib/me";
+import React from "react";
 
 export default function Profile() {
   const { loading, me } = useMe();
@@ -35,6 +42,7 @@ export default function Profile() {
               </Box>
               <Box> Email: {me.email}</Box>
               <Box>CodePod version 0.4.6</Box>
+              <HandleButton />
             </Stack>
           </Paper>
           <Divider />
@@ -43,3 +51,48 @@ export default function Profile() {
     </Container>
   );
 }
+
+const HandleButton = ({}) => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(anchorEl ? null : event.currentTarget);
+  };
+  const open = Boolean(anchorEl);
+
+  const handler = React.useCallback((e) => {
+    console.log("keydown", e.key);
+    if (e.key === "Escape") {
+      setAnchorEl(null);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    document.addEventListener("keydown", handler);
+
+    return () => {
+      document.removeEventListener("keydown", handler);
+    };
+  }, []);
+  return (
+    <>
+      <Button onClick={handleClick}>Hello</Button>
+
+      <Popper open={open} anchorEl={anchorEl} placement={"right"}>
+        <ClickAwayListener
+          onClickAway={() => {
+            console.log("click away!");
+            setAnchorEl(null);
+          }}
+        >
+          <Stack
+            sx={{ border: 1, p: 1, bgcolor: "background.paper" }}
+            spacing={1}
+          >
+            <Button variant="contained">Code</Button>
+            <Button variant="contained">Rich</Button>
+          </Stack>
+        </ClickAwayListener>
+      </Popper>
+    </>
+  );
+};


### PR DESCRIPTION
The new-node buttons in #274 are too clumsy. This PR uses a pop-up menu instead. You can bring up the menus by clicking on the 4 edge handles.

![ezgif-5-71fa77df14](https://github.com/codepod-io/codepod/assets/4576201/d42f7162-e1ed-4d0f-8854-bf355a109703)
