### PR TITLE
feat: add authentication to yjs server

### DIFF
--- a/api/src/yjs-server.ts
+++ b/api/src/yjs-server.ts
@@ -3,7 +3,50 @@ import { WebSocketServer } from "ws";
 import express from "express";
 import http from "http";
 
+import jwt from "jsonwebtoken";
+
 import { setupWSConnection } from "./yjs-setupWS";
+
+import prisma from "./client";
+
+interface TokenInterface {
+  id: string;
+}
+
+/**
+ * Check if user has permission to access document.
+ * @param param0
+ * @returns
+ */
+async function checkPermission({
+  docName,
+  userId,
+}): Promise<"read" | "write" | "none"> {
+  // Docname is socket/he3og11sp3b73oh7k47o
+  // We need to get the actual ID of the pod
+  const repoId = docName.split("/")[1];
+  // Query the DB for the pod
+  const repo = await prisma.repo.findFirst({
+    where: {
+      id: repoId,
+    },
+    include: {
+      collaborators: true,
+      owner: true,
+    },
+  });
+  if (!repo) return "none";
+  if (
+    repo.owner.id === userId ||
+    repo.collaborators.find((collab) => collab.id === userId)
+  ) {
+    return "write";
+  }
+  if (repo.public) {
+    return "read";
+  }
+  return "none";
+}
 
 async function startServer() {
   const expapp = express();
@@ -13,16 +56,45 @@ async function startServer() {
 
   wss.on("connection", setupWSConnection);
 
-  http_server.on("upgrade", (request, socket, head) => {
+  http_server.on("upgrade", async (request, socket, head) => {
     // You may check auth of request here..
     // See https://github.com/websockets/ws#client-authentication
-    /**
-     * @param {any} ws
-     */
-    const handleAuth = (ws) => {
-      wss.emit("connection", ws, request);
-    };
-    wss.handleUpgrade(request, socket, head, handleAuth);
+    if (request.url) {
+      const url = new URL(`ws://${request.headers.host}${request.url}`);
+      const docName = request.url.slice(1).split("?")[0];
+      const token = url.searchParams.get("token");
+      if (token) {
+        const decoded = jwt.verify(
+          token,
+          process.env.JWT_SECRET as string
+        ) as TokenInterface;
+        const userId = decoded.id;
+        const permission = await checkPermission({ docName, userId });
+        switch (permission) {
+          case "read":
+            // TODO I should disable editing in the frontend as well.
+            wss.handleUpgrade(request, socket, head, function done(ws) {
+              wss.emit("connection", ws, request, { readOnly: true });
+            });
+            break;
+          case "write":
+            wss.handleUpgrade(request, socket, head, function done(ws) {
+              wss.emit("connection", ws, request, { readOnly: false });
+            });
+            break;
+          case "none":
+            // This should not happen. This should be blocked by frontend code.
+            socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+            socket.destroy();
+            return;
+        }
+        return;
+      }
+    }
+    // var token = url.parse(request.url, true).query.token;
+    socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+    socket.destroy();
+    return;
   });
 
   const port = process.env.PORT || 4233;
@@ -32,3 +104,10 @@ async function startServer() {
 }
 
 startServer();
+
+// ts-node-dev might fail to restart. Force the exiting and restarting. Ref:
+// https://github.com/wclr/ts-node-dev/issues/69#issuecomment-493675960
+process.on("SIGTERM", () => {
+  console.log("Received SIGTERM. Exiting...");
+  process.exit();
+});

--- a/api/src/yjs-server.ts
+++ b/api/src/yjs-server.ts
@@ -91,7 +91,6 @@ async function startServer() {
         return;
       }
     }
-    // var token = url.parse(request.url, true).query.token;
     socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
     socket.destroy();
     return;

--- a/ui/src/lib/store/repoStateSlice.tsx
+++ b/ui/src/lib/store/repoStateSlice.tsx
@@ -305,7 +305,12 @@ export const createRepoStateSlice: StateCreator<
         state.provider = new WebsocketProvider(
           serverURL,
           state.repoId,
-          state.ydoc
+          state.ydoc,
+          {
+            params: {
+              token: localStorage.getItem("token") || "",
+            },
+          }
         );
         // max retry time: 10s
         state.provider.connect();


### PR DESCRIPTION
1. Front-end sends the user token with the Yjs WebSocket request.
2. Yjs-server validates that the user has read or write access before connecting the WebSocket. This PR also handles read/write access differently at Yjs level.