### PR TITLE
[UI] Edit cmd mode patch

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -50,7 +50,6 @@ import FloatingEdge from "./nodes/FloatingEdge";
 import CustomConnectionLine from "./nodes/CustomConnectionLine";
 import HelperLines from "./HelperLines";
 import { getAbsPos, newNodeShapeConfig } from "../lib/store/canvasSlice";
-import { htmlToProsemirrorNode } from "remirror";
 
 const nodeTypes = { SCOPE: ScopeNode, CODE: CodeNode, RICH: RichNode };
 const edgeTypes = {

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -401,8 +401,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const setPodBlur = useStore(store, (state) => state.setPodBlur);
-  const selectPod = useStore(store, (state) => state.selectPod);
-  const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
+  const setCursorNode = useStore(store, (state) => state.setCursorNode);
   const annotations = useStore(store, (state) => state.pods[id]?.annotations);
   const showAnnotations = useStore(store, (state) => state.showAnnotations);
   const scopedVars = useStore(store, (state) => state.scopedVars);
@@ -491,7 +490,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
         if (document.activeElement) {
           (document.activeElement as any).blur();
           setPodBlur(id);
-          selectPod(id, true);
+          setCursorNode(id);
           setFocusedEditor(undefined);
         }
       },

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -495,6 +495,7 @@ export const CodeNode = memo<NodeProps>(function ({
 
   const pod = getPod(id);
   const isGuest = useStore(store, (state) => state.role === "GUEST");
+  const cursorNode = useStore(store, (state) => state.cursorNode);
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
   const inputRef = useRef<HTMLInputElement>(null);
   const updateView = useStore(store, (state) => state.updateView);
@@ -509,6 +510,8 @@ export const CodeNode = memo<NodeProps>(function ({
   const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
 
   const prevLayout = useRef(layout);
+  const [showToolbar, setShowToolbar] = useState(false);
+
   useEffect(() => {
     if (autoRunLayout) {
       // Run auto-layout when the output box layout changes.
@@ -518,6 +521,14 @@ export const CodeNode = memo<NodeProps>(function ({
       }
     }
   }, [layout]);
+
+  useEffect(() => {
+    if (cursorNode === id) {
+      setShowToolbar(true);
+    } else {
+      setShowToolbar(false);
+    }
+  }, [cursorNode]);
 
   const onResizeStop = useCallback(
     (e, data) => {
@@ -551,7 +562,6 @@ export const CodeNode = memo<NodeProps>(function ({
     [id, nodesMap, setPodGeo, updateView, autoLayoutROOT]
   );
 
-  const [showToolbar, setShowToolbar] = useState(false);
   useEffect(() => {
     if (!data.name) return;
     setPodName({ id, name: data.name });

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -253,7 +253,7 @@ const MyStyledWrapper = styled("div")(
 function HotkeyControl({ id }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const selectPod = useStore(store, (state) => state.selectPod);
+  const setCursorNode = useStore(store, (state) => state.setCursorNode);
   const setPodBlur = useStore(store, (state) => state.setPodBlur);
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
@@ -262,7 +262,7 @@ function HotkeyControl({ id }) {
     if (document.activeElement) {
       (document.activeElement as any).blur();
       setPodBlur(id);
-      selectPod(id, true);
+      setCursorNode(id);
       setFocusedEditor(undefined);
     }
     return true;
@@ -446,7 +446,6 @@ function MyFloatingToolbar({ id }: { id: string }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const reactFlowInstance = useReactFlow();
-  // const selected = useStore(store, (state) => state.pods[id]?.selected);
   const isGuest = useStore(store, (state) => state.role === "GUEST");
   return (
     <>
@@ -517,6 +516,7 @@ export const RichNode = memo<Props>(function ({
   const pod = getPod(id);
   const isGuest = useStore(store, (state) => state.role === "GUEST");
   const width = useStore(store, (state) => state.pods[id]?.width);
+  const cursorNode = useStore(store, (state) => state.cursorNode);
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
   const devMode = useStore(store, (state) => state.devMode);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -578,6 +578,14 @@ export const RichNode = memo<Props>(function ({
     store,
     (state) => state.contextualZoomParams.threshold
   );
+
+  useEffect(() => {
+    if (cursorNode === id) {
+      setShowToolbar(true);
+    } else {
+      setShowToolbar(false);
+    }
+  }, [cursorNode]);
 
   if (!pod) return null;
 

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -207,6 +207,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
 
   const devMode = useStore(store, (state) => state.devMode);
   const isCutting = useStore(store, (state) => state.cuttingIds.has(id));
+  const cursorNode = useStore(store, (state) => state.cursorNode);
 
   useEffect(() => {
     if (!data.name) return;
@@ -218,6 +219,13 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
 
   const [showToolbar, setShowToolbar] = useState(false);
 
+  useEffect(() => {
+    if (cursorNode === id) {
+      setShowToolbar(true);
+    } else {
+      setShowToolbar(false);
+    }
+  }, [cursorNode]);
   const contextualZoom = useStore(store, (state) => state.contextualZoom);
   const contextualZoomParams = useStore(
     store,

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -277,6 +277,9 @@ export interface CanvasSlice {
   focusedEditor: string | undefined;
   setFocusedEditor: (id?: string) => void;
 
+  cursorNode: string | undefined;
+  setCursorNode: (id?: string) => void;
+
   updateView: () => void;
   updateEdgeView: () => void;
 
@@ -405,6 +408,14 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     set(
       produce((state: MyState) => {
         state.focusedEditor = id;
+      })
+    ),
+
+  cursorNode: undefined,
+  setCursorNode: (id?: string) =>
+    set(
+      produce((state: MyState) => {
+        state.cursorNode = id;
       })
     ),
   /**
@@ -975,6 +986,9 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
           throw new Error("Add node should not be handled here");
         case "select":
           get().selectPod(change.id, change.selected);
+          if (change.selected) {
+            get().setCursorNode(change.id);
+          }
           break;
         case "dimensions":
           {


### PR DESCRIPTION
## Summary
PR #398 introduced CMD mode, and issue #418 and #420 reveal some improvement and bugs.
- For #418,
    - To go into a scope, the key combination is adjusted to `SHIFT` + `ArrowDown`
    - To go to a parent scope, the key combination is adjusted to `SHIFT` + `ArrowUp`
- For #420, the reason is that `useJump()` uses `selectedPods` to choose the `from` node, while in a multi-selection scenario, `selectedPods` contains more than 1 node. As a workaround, a new state variable `cursorNode` is added for a single node selection.
   - The toolbar pops-up while jumping to a node
- Misc
    - On a code pod, pressing `SHIFT`+`Enter` will run the pod
    - On a scope, pressing `SHIFT`+`Enter` will run the scope

## Test

![CMD_mode_patch](https://github.com/codepod-io/codepod/assets/10226241/4c4c8ccb-3eb0-4761-af4a-34beebfc0f1b)
