### PR TITLE
disable portal to allow paning over handle menus

### DIFF
--- a/ui/src/components/nodes/utils.tsx
+++ b/ui/src/components/nodes/utils.tsx
@@ -366,7 +366,12 @@ const WrappedHandle = ({ position, children }) => {
         onClick={handleClick}
       />
 
-      <Popper open={open} anchorEl={anchorEl} placement={position}>
+      <Popper
+        open={open}
+        anchorEl={anchorEl}
+        placement={position}
+        disablePortal={true}
+      >
         <ClickAwayListener
           onClickAway={() => {
             setAnchorEl(null);


### PR DESCRIPTION
Make it pannable and zoomable when the pointer is over the popup menus (The handle popper in #421).