### PR TITLE
[Backend] Refactor ipynb kernel messages serialization

### DIFF
--- a/runtime/src/kernel.ts
+++ b/runtime/src/kernel.ts
@@ -19,9 +19,6 @@ let wire: ZmqWire;
 
 let socket;
 
-// FIXME Assuming setSocket() called per kernel session
-let session_exec_count = 0;
-
 function ensureZmqConnected() {
   if (!wire) {
     // estabilish a ZMQ connection
@@ -58,7 +55,6 @@ function setSocket(_socket) {
         handleIOPub_execute_result({
           msgs,
           socket,
-          exec_count: session_exec_count + 1,
         });
         break;
       case "stdout":
@@ -71,14 +67,12 @@ function setSocket(_socket) {
         handleIOPub_stream({
           msgs,
           socket,
-          exec_count: session_exec_count + 1,
         });
         break;
       case "display_data":
         handleIOPub_display_data({
           msgs,
           socket,
-          exec_count: session_exec_count + 1,
         });
         break;
       default:
@@ -101,7 +95,6 @@ function setSocket(_socket) {
       case "execute_reply":
         {
           let [podId, name] = msgs.parent_header.msg_id.split("#");
-          session_exec_count = msgs.content.execution_count;
           let payload = {
             podId,
             name,

--- a/runtime/src/kernel.ts
+++ b/runtime/src/kernel.ts
@@ -19,7 +19,7 @@ let wire: ZmqWire;
 
 let socket;
 
-// FIXME Aussming setSocket() called per kernel session
+// FIXME Assuming setSocket() called per kernel session
 let session_exec_count = 0;
 
 function ensureZmqConnected() {

--- a/runtime/src/zmq-utils.ts
+++ b/runtime/src/zmq-utils.ts
@@ -281,7 +281,7 @@ export function handleIOPub_status({ msgs, socket, lang }) {
   );
 }
 
-export function handleIOPub_display_data({ msgs, socket, exec_count }) {
+export function handleIOPub_display_data({ msgs, socket }) {
   console.log("emitting display data ..");
   let [podId, name] = msgs.parent_header.msg_id.split("#");
   let payload = {
@@ -294,13 +294,11 @@ export function handleIOPub_display_data({ msgs, socket, exec_count }) {
     //   transient: ...
     // }
     content: msgs.content,
-    // There's no exec_count in display_data, thus we pass in the session exec_count
-    count: exec_count,
   };
   socket.send(JSON.stringify({ type: "display_data", payload }));
 }
 
-export function handleIOPub_execute_result({ msgs, socket, exec_count }) {
+export function handleIOPub_execute_result({ msgs, socket }) {
   console.log("emitting execute_result ..");
   let [podId, name] = msgs.parent_header.msg_id.split("#");
   let payload = {
@@ -309,7 +307,7 @@ export function handleIOPub_execute_result({ msgs, socket, exec_count }) {
     // result: msgs.content.data["text/plain"],
     // This might contain text/plain, or text/html that contains image
     content: msgs.content,
-    count: exec_count,
+    count: msgs.content.execution_count,
   };
   if (name) {
     console.log("emitting IO result");
@@ -356,7 +354,7 @@ export function handleIOPub_error({ msgs, socket }) {
   }
 }
 
-export function handleIOPub_stream({ msgs, socket, exec_count }) {
+export function handleIOPub_stream({ msgs, socket }) {
   if (!msgs.parent_header.msg_id) {
     console.log("No msg_id, skipped");
     console.log(msgs.parent_header);
@@ -376,7 +374,6 @@ export function handleIOPub_stream({ msgs, socket, exec_count }) {
           // name: stdout or stderr
           // text:
           content: msgs.content,
-          count: exec_count,
         },
       })
     );
@@ -389,7 +386,6 @@ export function handleIOPub_stream({ msgs, socket, exec_count }) {
           payload: {
             podId,
             content: msgs.content,
-            count: exec_count,
           },
         })
       );
@@ -402,7 +398,6 @@ export function handleIOPub_stream({ msgs, socket, exec_count }) {
           payload: {
             podId,
             content: msgs.content,
-            count: exec_count,
           },
         })
       );

--- a/runtime/src/zmq-utils.ts
+++ b/runtime/src/zmq-utils.ts
@@ -281,12 +281,12 @@ export function handleIOPub_status({ msgs, socket, lang }) {
   );
 }
 
-export function handleIOPub_display_data({ msgs, socket }) {
+export function handleIOPub_display_data({ msgs, socket, exec_count }) {
   console.log("emitting display data ..");
   let [podId, name] = msgs.parent_header.msg_id.split("#");
   let payload = {
     podId,
-    name,
+    //name,
     // content is a dict of
     // {
     //   data: {'text/plain': ..., 'image/png': ...},
@@ -294,24 +294,22 @@ export function handleIOPub_display_data({ msgs, socket }) {
     //   transient: ...
     // }
     content: msgs.content,
-    // There's no exe_count in display_data
-    // FIXME I should use execute_reply for count
-    //
-    // count: msgs.content.execution_count,
+    // There's no exec_count in display_data, thus we pass in the session exec_count
+    count: exec_count,
   };
   socket.send(JSON.stringify({ type: "display_data", payload }));
 }
 
-export function handleIOPub_execute_result({ msgs, socket }) {
+export function handleIOPub_execute_result({ msgs, socket, exec_count }) {
   console.log("emitting execute_result ..");
   let [podId, name] = msgs.parent_header.msg_id.split("#");
   let payload = {
     podId,
     name,
     // result: msgs.content.data["text/plain"],
-    // This might contina text/plain, or text/html that contains image
+    // This might contain text/plain, or text/html that contains image
     content: msgs.content,
-    count: msgs.content.execution_count,
+    count: exec_count,
   };
   if (name) {
     console.log("emitting IO result");
@@ -358,7 +356,7 @@ export function handleIOPub_error({ msgs, socket }) {
   }
 }
 
-export function handleIOPub_stream({ msgs, socket }) {
+export function handleIOPub_stream({ msgs, socket, exec_count }) {
   if (!msgs.parent_header.msg_id) {
     console.log("No msg_id, skipped");
     console.log(msgs.parent_header);
@@ -378,6 +376,7 @@ export function handleIOPub_stream({ msgs, socket }) {
           // name: stdout or stderr
           // text:
           content: msgs.content,
+          count: exec_count,
         },
       })
     );
@@ -390,6 +389,7 @@ export function handleIOPub_stream({ msgs, socket }) {
           payload: {
             podId,
             content: msgs.content,
+            count: exec_count,
           },
         })
       );
@@ -402,6 +402,7 @@ export function handleIOPub_stream({ msgs, socket }) {
           payload: {
             podId,
             content: msgs.content,
+            count: exec_count,
           },
         })
       );

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -969,7 +969,7 @@ function ExportJupyterNB() {
                       .split(/\r?\n/)
                       .map((line) => line + "\n") || [""],
                   },
-                  execution_count: result.count,
+                  execution_count: pod.exec_count,
                 });
                 break;
               case "display_data":

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -959,39 +959,51 @@ function ExportJupyterNB() {
           q.push([pod, geoScore.substring(0, 2) + "0" + geoScore.substring(2)]);
         } else if (pod.type == "CODE") {
           let podOutput: any[] = [];
-          // FIXME, the pod result needs to support an array of execution result as well as the execution order
-          if (pod.stdout) {
-            podOutput.push({
-              output_type: "stream",
-              name: "stdout",
-              text: pod.stdout.split(/\r?\n/).map((line) => line + "\n"),
-            });
-          }
-          if (pod.result?.image) {
-            podOutput.push({
-              output_type: "display_data",
-              data: {
-                "text/plain": (pod.result.text || "")
-                  .split(/\r?\n/)
-                  .map((line) => line + "\n") || [""],
-                "image/png": pod.result.image,
-              },
-            });
-          }
-          if (
-            pod.result?.text &&
-            !pod.result?.text.startsWith("ok") &&
-            !pod.result?.text.startsWith("error")
-          ) {
-            podOutput.push({
-              output_type: "execute_result",
-              data: {
-                "text/plain": (pod.result.text || "")
-                  .split(/\r?\n/)
-                  .map((line) => line + "\n") || [""],
-              },
-              execution_count: pod.result?.count,
-            });
+          for (const result of pod.result!) {
+            switch (result.type) {
+              case "execute_result":
+                podOutput.push({
+                  output_type: result.type,
+                  data: {
+                    "text/plain": (result.text || "")
+                      .split(/\r?\n/)
+                      .map((line) => line + "\n") || [""],
+                  },
+                  execution_count: result.count,
+                });
+                break;
+              case "display_data":
+                podOutput.push({
+                  output_type: result.type,
+                  data: {
+                    "text/plain": (result.text || "")
+                      .split(/\r?\n/)
+                      .map((line) => line + "\n") || [""],
+                    "image/png": result.image,
+                  },
+                });
+                break;
+              case "stream_stdout":
+                podOutput.push({
+                  output_type: "stream",
+                  name: "stdout",
+                  text: (result.text || "")
+                    .split(/\r?\n/)
+                    .map((line) => line + "\n"),
+                });
+                break;
+              case "stream_stderr":
+                podOutput.push({
+                  output_type: "stream",
+                  name: "stderr",
+                  text: (result.text || "")
+                    .split(/\r?\n/)
+                    .map((line) => line + "\n"),
+                });
+                break;
+              default:
+                break;
+            }
           }
           if (pod.error) {
             podOutput.push({
@@ -1003,7 +1015,7 @@ function ExportJupyterNB() {
           }
           jupyterCellList.push({
             cell_type: "code",
-            execution_count: pod.result?.count || 0,
+            execution_count: pod.exec_count,
             // TODO: expand other Codepod related-metadata fields, or run a real-time search in database when importing.
             metadata: { id: pod.id, geoScore: Number(geoScore) },
             source: [pod.content || ""],

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -294,7 +294,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                         component="pre"
                         whiteSpace="pre-wrap"
                         key={combinedKey}
-                        sx={{ fontSize: "0.8em" }}
+                        sx={{ fontSize: "0.8em", margin: 0, padding: 0 }}
                       >
                         <Ansi>{res.text}</Ansi>
                       </Box>
@@ -305,7 +305,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                         component="pre"
                         whiteSpace="pre-wrap"
                         key={combinedKey}
-                        sx={{ fontSize: "0.8em" }}
+                        sx={{ fontSize: "0.8em", margin: 0, padding: 0 }}
                       >
                         <Ansi>{res.text}</Ansi>
                       </Box>
@@ -350,11 +350,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                           {res.text}
                         </Box>
                       );
-                    } else {
-                      return <></>;
                     }
-                  default:
-                    return <></>;
                 }
               })}
             </Box>

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -332,6 +332,8 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                         key={combinedKey}
                         sx={{
                           fontSize: "0.8em",
+                          margin: 0,
+                          padding: 0,
                           borderTop: "1px solid rgb(214, 222, 230)",
                         }}
                       >
@@ -345,7 +347,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                           component="pre"
                           whiteSpace="pre-wrap"
                           key={combinedKey}
-                          sx={{ fontSize: "0.8em" }}
+                          sx={{ fontSize: "0.8em", margin: 0, padding: 0 }}
                         >
                           {res.text}
                         </Box>

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -84,10 +84,11 @@ function Timer({ lastExecutedAt }) {
 
 export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
   const store = useContext(RepoContext)!;
-  const result = useStore(store, (state) => state.pods[id]?.result);
+  const results = useStore(store, (state) => state.pods[id]?.result);
   const error = useStore(store, (state) => state.pods[id]?.error);
   const stdout = useStore(store, (state) => state.pods[id]?.stdout);
   const running = useStore(store, (state) => state.pods[id]?.running || false);
+  const exec_count = useStore(store, (state) => state.pods[id]?.exec_count);
   const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
   const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
 
@@ -118,6 +119,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
   const [resultScroll, setResultScroll] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
   const clearResults = useStore(store, (state) => state.clearResults);
+  const result = results ? results[0] : undefined;
   if (!hasResult) return <></>;
   return (
     <Box
@@ -197,9 +199,6 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
               )}
             </>
           )}
-          {result.image && (
-            <img src={`data:image/png;base64,${result.image}`} alt="output" />
-          )}
         </Box>
       )}
 
@@ -211,64 +210,62 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
           maxHeight="1000px"
           border="1px"
         >
-          {/* FIXME result?.count is not correct, always 0 or 1. */}
-          {(stdout || (result?.text && result?.count > 0) || error) &&
-            showMenu && (
-              <ButtonGroup
+          {(stdout || exec_count || error) && showMenu && (
+            <ButtonGroup
+              sx={{
+                // border: '1px solid #757ce8',
+                fontSize: "0.8em",
+                backgroundColor: "white",
+                zIndex: 201,
+                position: "absolute",
+                top: "10px",
+                right: "25px",
+                // "& .MuiButton-root": {
+                //   fontSize: ".9em",
+                //   paddingTop: 0,
+                //   paddingBottom: 0,
+                // },
+              }}
+              variant="contained"
+              size="small"
+              aria-label="outlined primary button group"
+              // orientation="vertical"
+            >
+              <Box
                 sx={{
-                  // border: '1px solid #757ce8',
-                  fontSize: "0.8em",
-                  backgroundColor: "white",
-                  zIndex: 201,
-                  position: "absolute",
-                  top: "10px",
-                  right: "25px",
-                  // "& .MuiButton-root": {
-                  //   fontSize: ".9em",
-                  //   paddingTop: 0,
-                  //   paddingBottom: 0,
-                  // },
+                  color: "primary.main",
+                  fontWeight: "bold",
+                  display: "flex",
+                  padding: "5px 5px",
+                  alignItems: "center",
+                  justifyContent: "center",
                 }}
-                variant="contained"
-                size="small"
-                aria-label="outlined primary button group"
-                // orientation="vertical"
               >
-                <Box
-                  sx={{
-                    color: "primary.main",
-                    fontWeight: "bold",
-                    display: "flex",
-                    padding: "5px 5px",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  Output options:
-                </Box>
-                <Button
-                  onClick={() => {
-                    setResultScroll(!resultScroll);
-                  }}
-                >
-                  {resultScroll ? "Unfocus" : "Focus"}
-                </Button>
-                <Button
-                  onClick={() => {
-                    setShowOutput(!showOutput);
-                  }}
-                >
-                  Hide
-                </Button>
-                <Button
-                  onClick={() => {
-                    clearResults(id);
-                  }}
-                >
-                  Clear
-                </Button>
-              </ButtonGroup>
-            )}
+                Output options:
+              </Box>
+              <Button
+                onClick={() => {
+                  setResultScroll(!resultScroll);
+                }}
+              >
+                {resultScroll ? "Unfocus" : "Focus"}
+              </Button>
+              <Button
+                onClick={() => {
+                  setShowOutput(!showOutput);
+                }}
+              >
+                Hide
+              </Button>
+              <Button
+                onClick={() => {
+                  clearResults(id);
+                }}
+              >
+                Clear
+              </Button>
+            </ButtonGroup>
+          )}
 
           {stdout && (
             <Box
@@ -278,19 +275,69 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
               <Ansi>{stdout}</Ansi>
             </Box>
           )}
-          {result?.text && result?.count > 0 && (
+          {results && results.length > 0 && (
             <Box
               sx={{
                 display: "flex",
                 fontSize: "0.8em",
-                flexDirection: "row",
-                alignItems: "center",
+                flexDirection: "column",
+                alignItems: "left",
                 borderTop: "1px solid rgb(214, 222, 230)",
               }}
             >
-              <Box component="pre" whiteSpace="pre-wrap">
-                {result.text}
-              </Box>
+              {results.map((res, i) => {
+                switch (res.type) {
+                  case "stream_stdout":
+                    return (
+                      <Box
+                        component="pre"
+                        whiteSpace="pre-wrap"
+                        key={i + 1}
+                        sx={{ fontSize: "0.8em" }}
+                      >
+                        <Ansi>{res.text}</Ansi>
+                      </Box>
+                    );
+                  case "display_data":
+                    return (
+                      <Box component="pre" whiteSpace="pre-wrap" key={i + 1}>
+                        {res.text}
+                        <img
+                          src={`data:image/png;base64,${res.image}`}
+                          alt="output"
+                        />
+                      </Box>
+                    );
+                  case "execute_result":
+                    return (
+                      <Box
+                        component="pre"
+                        whiteSpace="pre-wrap"
+                        key={i + 1}
+                        sx={{ fontSize: "0.8em" }}
+                      >
+                        {res.text}
+                      </Box>
+                    );
+                  case "execute_reply":
+                    if (i == 0) {
+                      return (
+                        <Box
+                          component="pre"
+                          whiteSpace="pre-wrap"
+                          key={i + 1}
+                          sx={{ fontSize: "0.8em" }}
+                        >
+                          {res.text}
+                        </Box>
+                      );
+                    } else {
+                      return <></>;
+                    }
+                  default:
+                    return <></>;
+                }
+              })}
             </Box>
           )}
           {error && <Box color="red">{error?.evalue}</Box>}
@@ -507,7 +554,7 @@ export const CodeNode = memo<NodeProps>(function ({
   const updateView = useStore(store, (state) => state.updateView);
   const exec_count = useStore(
     store,
-    (state) => state.pods[id]?.result?.count || " "
+    (state) => state.pods[id]?.exec_count || " "
   );
   const isCutting = useStore(store, (state) => state.cuttingIds.has(id));
 

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -286,13 +286,25 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
               }}
             >
               {results.map((res, i) => {
+                const combinedKey = `${res.type}-${i}`;
                 switch (res.type) {
                   case "stream_stdout":
                     return (
                       <Box
                         component="pre"
                         whiteSpace="pre-wrap"
-                        key={i + 1}
+                        key={combinedKey}
+                        sx={{ fontSize: "0.8em" }}
+                      >
+                        <Ansi>{res.text}</Ansi>
+                      </Box>
+                    );
+                  case "stream_stderr":
+                    return (
+                      <Box
+                        component="pre"
+                        whiteSpace="pre-wrap"
+                        key={combinedKey}
                         sx={{ fontSize: "0.8em" }}
                       >
                         <Ansi>{res.text}</Ansi>
@@ -300,7 +312,11 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                     );
                   case "display_data":
                     return (
-                      <Box component="pre" whiteSpace="pre-wrap" key={i + 1}>
+                      <Box
+                        component="pre"
+                        whiteSpace="pre-wrap"
+                        key={combinedKey}
+                      >
                         {res.text}
                         <img
                           src={`data:image/png;base64,${res.image}`}
@@ -313,8 +329,11 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                       <Box
                         component="pre"
                         whiteSpace="pre-wrap"
-                        key={i + 1}
-                        sx={{ fontSize: "0.8em" }}
+                        key={combinedKey}
+                        sx={{
+                          fontSize: "0.8em",
+                          borderTop: "1px solid rgb(214, 222, 230)",
+                        }}
                       >
                         {res.text}
                       </Box>
@@ -325,7 +344,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                         <Box
                           component="pre"
                           whiteSpace="pre-wrap"
-                          key={i + 1}
+                          key={combinedKey}
                           sx={{ fontSize: "0.8em" }}
                         >
                           {res.text}

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -601,7 +601,6 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
               break;
           }
         }
-        console.log(podResults);
         // move the created node to scope and configure the necessary node attributes
         const posInsideScope = getNodePositionInsideScope(
           node,

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -558,12 +558,11 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
         );
 
         let podRichContent = cell.cellType == "markdown" ? cell.cellSource : "";
-        let execution_count = cell.execution_count || 0;
+        let execution_count = cell.execution_count || null;
         let podResults: {
           type?: string;
           html?: string;
           text?: string;
-          count: number;
           image?: string;
         }[] = [];
         let podError = { ename: "", evalue: "", stacktrace: [] };
@@ -573,21 +572,18 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
               podResults.push({
                 // "stream_stdout" or "stream_stderr"
                 type: `${cellOutput["output_type"]}_${cellOutput["name"]}`,
-                count: execution_count,
                 text: cellOutput["text"].join(""),
               });
               break;
             case "execute_result":
               podResults.push({
                 type: cellOutput["output_type"],
-                count: execution_count,
                 text: cellOutput["data"]["text/plain"].join(""),
               });
               break;
             case "display_data":
               podResults.push({
                 type: cellOutput["output_type"],
-                count: execution_count,
                 text: cellOutput["data"]["text/plain"].join(""),
                 image: cellOutput["data"]["image/png"],
               });

--- a/ui/src/lib/store/index.tsx
+++ b/ui/src/lib/store/index.tsx
@@ -27,7 +27,14 @@ export type Pod = {
   isSyncing?: boolean;
   children: { id: string; type: string }[];
   parent: string;
-  result?: { html?: string; text?: string; count: number; image?: string };
+  result?: {
+    type?: string;
+    html?: string;
+    text?: string;
+    count: number;
+    image?: string;
+  }[];
+  exec_count?: number;
   status?: string;
   stdout?: string;
   stderr?: string;

--- a/ui/src/lib/store/index.tsx
+++ b/ui/src/lib/store/index.tsx
@@ -31,10 +31,10 @@ export type Pod = {
     type?: string;
     html?: string;
     text?: string;
-    count: number;
     image?: string;
   }[];
   exec_count?: number;
+  last_exec_end?: boolean;
   status?: string;
   stdout?: string;
   stderr?: string;

--- a/ui/src/lib/store/podSlice.tsx
+++ b/ui/src/lib/store/podSlice.tsx
@@ -240,7 +240,6 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
               state.pods[id].result.push({
                 type,
                 text: content.data["text/plain"],
-                count: count,
               });
               break;
             case "stream":
@@ -257,7 +256,6 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
               state.pods[id].result.push({
                 type,
                 text: content,
-                count: count,
               });
               state.pods[id].exec_count = count;
               state.pods[id].last_exec_end = true;

--- a/ui/src/lib/store/podSlice.tsx
+++ b/ui/src/lib/store/podSlice.tsx
@@ -222,9 +222,9 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
     if (get().pods[id]) {
       set(
         produce((state) => {
-          if (state.pods[id].exec_count != count) {
+          if (state.pods[id].last_exec_end) {
             state.pods[id].result = [];
-            state.pods[id].exec_count = count;
+            state.pods[id].last_exec_end = false;
           }
           switch (type) {
             case "display_data":
@@ -233,7 +233,6 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
                 type,
                 text: content.data["text/plain"],
                 image: content.data["image/png"],
-                count: count,
               });
               break;
             case "execute_result":
@@ -250,7 +249,6 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
                 // content.name : "stdout" or "stderr"
                 type: `${type}_${content.name}`,
                 text: content.text,
-                count: count,
               });
               break;
             case "execute_reply":
@@ -262,6 +260,7 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
                 count: count,
               });
               state.pods[id].exec_count = count;
+              state.pods[id].last_exec_end = true;
               break;
             default:
               break;

--- a/ui/src/lib/store/podSlice.tsx
+++ b/ui/src/lib/store/podSlice.tsx
@@ -52,20 +52,9 @@ export interface PodSlice {
     client: ApolloClient<object> | null,
     { id }: { id: string }
   ) => Promise<void>;
-  setPodResult: ({
-    id,
-    content,
-    count,
-  }: {
-    id: string;
-    content: { data: { html: string; text: string; image: string } };
-    count: number;
-  }) => void;
-  setPodDisplayData: ({ id, content, count }) => void;
-  setPodExecuteReply: ({ id, result, count }) => void;
+  setPodResult: ({ id, type, content, count }) => void;
   setPodStdout: ({ id, stdout }: { id: string; stdout: string }) => void;
   setPodError: ({ id, ename, evalue, stacktrace }) => void;
-  setPodStream: ({ id, content }) => void;
   setPodStatus: ({ id, status, lang }) => void;
   clonePod: (id: string) => any;
 }
@@ -183,45 +172,6 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
         state.pods[id].dirty = true;
       })
     ),
-  setPodResult: setPodResult(set, get),
-  setPodDisplayData: ({ id, content, count }) =>
-    set(
-      produce((state) => {
-        // console.log("WS_DISPLAY_DATA", content);
-        state.pods[id].result = {
-          text: content.data["text/plain"],
-          // FIXME hard coded MIME
-          image: content.data["image/png"],
-          count: count,
-        };
-        state.pods[id].dirty = true;
-      })
-    ),
-  setPodExecuteReply: ({ id, result, count }) =>
-    set(
-      produce((state) => {
-        // console.log("WS_EXECUTE_REPLY", action.payload);
-        if (id in state.pods) {
-          // state.pods[id].execute_reply = {
-          //   text: result,
-          //   count: count,
-          // };
-          // console.log("WS_EXECUTE_REPLY", result);
-          state.pods[id].running = false;
-          state.pods[id].lastExecutedAt = Date.now();
-          if (!state.pods[id].result) {
-            state.pods[id].result = {
-              text: result,
-              count: count,
-            };
-          }
-        } else {
-          // most likely this id is "CODEPOD", which is for startup code and
-          // should not be send to the browser
-          console.log("WARNING id not recognized", id);
-        }
-      })
-    ),
   setPodError: ({ id, ename, evalue, stacktrace }) =>
     set(
       produce((state) => {
@@ -232,49 +182,6 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
           stacktrace,
         };
         state.pods[id].dirty = true;
-      })
-    ),
-  setPodStream: ({ id, content }) =>
-    set(
-      produce((state) => {
-        if (!(id in state.pods)) {
-          console.warn("id is not found:", id);
-          return;
-        }
-        // append
-        let pod = state.pods[id];
-        if (content.name === "stderr" && pod.lang === "racket") {
-          // if (!pod.result) {
-          //   pod.result = {};
-          // }
-          // pod.result.stderr = true;
-          pod.error = {
-            ename: "stderr",
-            evalue: "stderr",
-            stacktrace: "",
-          };
-        }
-        pod.stdout += content.text;
-        pod.dirty = true;
-      })
-    ),
-  setPodExecuteResult: ({ id, result, name }) =>
-    set(
-      produce((state) => {
-        state.pods[id].io[name] = { result };
-      })
-    ),
-  setIOResult: ({ id, name, ename, evalue, stacktrace }) =>
-    set(
-      produce((state) => {
-        console.log("IOERROR", { id, name, ename, evalue, stacktrace });
-        state.pods[id].io[name] = {
-          error: {
-            ename,
-            evalue,
-            stacktrace,
-          },
-        };
       })
     ),
   setPodStatus: ({ id, status, lang }) =>
@@ -310,6 +217,59 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
       ...pod,
       children: pod.children.map((child) => get().clonePod(child.id)),
     };
+  },
+  setPodResult({ id, type, content, count }) {
+    if (get().pods[id]) {
+      set(
+        produce((state) => {
+          if (state.pods[id].exec_count != count) {
+            state.pods[id].result = [];
+            state.pods[id].exec_count = count;
+          }
+          switch (type) {
+            case "display_data":
+              // console.log("WS_DISPLAY_DATA", content);
+              state.pods[id].result.push({
+                type,
+                text: content.data["text/plain"],
+                image: content.data["image/png"],
+                count: count,
+              });
+              break;
+            case "execute_result":
+              // console.log("WS_EXECUTE_RESULT", content);
+              state.pods[id].result.push({
+                type,
+                text: content.data["text/plain"],
+                count: count,
+              });
+              break;
+            case "stream":
+              // console.log("WS_STREAM", content);
+              state.pods[id].result.push({
+                // content.name : "stdout" or "stderr"
+                type: `${type}_${content.name}`,
+                text: content.text,
+                count: count,
+              });
+              break;
+            case "execute_reply":
+              state.pods[id].running = false;
+              state.pods[id].lastExecutedAt = Date.now();
+              state.pods[id].result.push({
+                type,
+                text: content,
+                count: count,
+              });
+              state.pods[id].exec_count = count;
+              break;
+            default:
+              break;
+          }
+          state.pods[id].dirty = true;
+        })
+      );
+    }
   },
 });
 
@@ -376,42 +336,4 @@ function deletePod(set, get) {
       await doRemoteDeletePod(client, ids);
     }
   };
-}
-
-function setPodResult(set, get) {
-  return ({ id, content, count }) =>
-    set(
-      produce((state: MyState) => {
-        if (id in state.pods) {
-          let text = content.data["text/plain"];
-          let html = content.data["text/html"];
-          let file;
-          if (text) {
-            let match = text.match(/CODEPOD-link\s+(.*)"/);
-            if (match) {
-              let fname = match[1].substring(match[1].lastIndexOf("/") + 1);
-              let url = `${window.location.protocol}//api.${window.location.host}/static/${match[1]}`;
-              console.log("url", url);
-              html = `<a target="_blank" style="color:blue" href="${url}" download>${fname}</a>`;
-              file = url;
-            }
-            // http:://api.codepod.test:3000/static/30eea3b1-e767-4fa8-8e3f-a23774eef6c6/ccc.txt
-            // http:://api.codepod.test:3000/static/30eea3b1-e767-4fa8-8e3f-a23774eef6c6/ccc.txt
-          }
-          state.pods[id].result = {
-            text,
-            html,
-            // TODO a link to the file
-            // file,
-            count,
-          };
-          state.pods[id].dirty = true;
-          // state.pods[id].running = false;
-        } else {
-          // most likely this id is "CODEPOD", which is for startup code and
-          // should not be send to the browser
-          console.log("WARNING id not recognized", id);
-        }
-      })
-    );
 }

--- a/ui/src/lib/store/runtimeSlice.tsx
+++ b/ui/src/lib/store/runtimeSlice.tsx
@@ -477,7 +477,7 @@ export const createRuntimeSlice: StateCreator<MyState, [], [], RuntimeSlice> = (
   clearResults: (id) => {
     set(
       produce((state) => {
-        state.pods[id].result = null;
+        state.pods[id].result = [];
         state.pods[id].stdout = "";
         state.pods[id].error = null;
         state.pods[id].dirty = true;
@@ -488,7 +488,7 @@ export const createRuntimeSlice: StateCreator<MyState, [], [], RuntimeSlice> = (
     set(
       produce((state) => {
         Object.keys(state.pods).forEach((id) => {
-          state.pods[id].result = null;
+          state.pods[id].result = [];
           state.pods[id].stdout = "";
           state.pods[id].error = null;
           state.pods[id].dirty = true;
@@ -617,22 +617,48 @@ function onMessage(set, get: () => MyState) {
           get().setPodStdout({ id: podId, stdout });
         }
         break;
+      case "stream":
+        {
+          let { podId, content, count } = payload;
+          get().setPodResult({
+            id: podId,
+            type,
+            content,
+            count,
+          });
+        }
+        break;
       case "execute_result":
         {
           let { podId, content, count } = payload;
-          get().setPodResult({ id: podId, content, count });
+          get().setPodResult({
+            id: podId,
+            type,
+            content,
+            count,
+          });
         }
         break;
       case "display_data":
         {
           let { podId, content, count } = payload;
-          get().setPodDisplayData({ id: podId, content, count });
+          get().setPodResult({
+            id: podId,
+            type,
+            content,
+            count,
+          });
         }
         break;
       case "execute_reply":
         {
           let { podId, result, count } = payload;
-          get().setPodExecuteReply({ id: podId, result, count });
+          get().setPodResult({
+            id: podId,
+            type,
+            content: result,
+            count,
+          });
           set({ runningId: null });
           // Continue to run the chain if there is any.
           get().wsRunNext();
@@ -644,18 +670,11 @@ function onMessage(set, get: () => MyState) {
           get().setPodError({ id: podId, ename, evalue, stacktrace });
         }
         break;
-      case "stream":
-        {
-          let { podId, content } = payload;
-          get().setPodStream({ id: podId, content });
-        }
-        break;
       case "status":
         {
           const { lang, status, id } = payload;
           get().setPodStatus({ id, lang, status });
         }
-
         break;
       case "interrupt_reply":
         // console.log("got interrupt_reply", payload);

--- a/ui/src/lib/store/runtimeSlice.tsx
+++ b/ui/src/lib/store/runtimeSlice.tsx
@@ -619,12 +619,12 @@ function onMessage(set, get: () => MyState) {
         break;
       case "stream":
         {
-          let { podId, content, count } = payload;
+          let { podId, content } = payload;
           get().setPodResult({
             id: podId,
             type,
             content,
-            count,
+            count: null,
           });
         }
         break;
@@ -641,12 +641,12 @@ function onMessage(set, get: () => MyState) {
         break;
       case "display_data":
         {
-          let { podId, content, count } = payload;
+          let { podId, content } = payload;
           get().setPodResult({
             id: podId,
             type,
             content,
-            count,
+            count: null,
           });
         }
         break;


### PR DESCRIPTION
## Summary
Currently, the kernel messages are concatenated and stored in a single object, i.e., `pod.result`. This concatenation behavior creates a few discrepancy with Colab regarding the output results, e.g., it can't produce multiple plots in a single pod, the order of line execution might confuse users (see screenshots in Test section)

## Test
### Before
- <img width="512" alt="Screenshot 2023-08-04 at 10 41 48 PM" src="https://github.com/codepod-io/codepod/assets/10226241/280e9312-228b-4152-a6e5-b5f1ba9ce4f1">
- <img width="635" alt="Screenshot 2023-08-04 at 10 40 19 PM" src="https://github.com/codepod-io/codepod/assets/10226241/42c2c45e-d66e-420d-8da2-9b03684b5c23">

### After
<img width="591" alt="Screenshot 2023-08-04 at 10 41 10 PM" src="https://github.com/codepod-io/codepod/assets/10226241/49f53a5e-dd3a-4649-b811-bb4b33856bff">

- Export/Import also verified

## Follow-up
- The `ResultBlock` in `Code.tsx` needs more tuning
- We might need to support more message types, [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html)


