### PR TITLE
[UI] Move multi-pod into a scope

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -750,6 +750,9 @@ function CanvasImpl() {
 
   const addNode = useStore(store, (state) => state.addNode);
   const importLocalCode = useStore(store, (state) => state.importLocalCode);
+
+  const selectedPods = useStore(store, (state) => state.selectedPods);
+
   const reactFlowInstance = useReactFlow();
 
   const project = useCallback(
@@ -924,8 +927,8 @@ function CanvasImpl() {
             let scope = getScopeAtPos(mousePos, node.id);
             let toScope = scope ? scope.id : "ROOT";
             const parentScope = node.parentNode ? node.parentNode : "ROOT";
-            if (toScope !== parentScope) {
-              moveIntoScope(node.id, toScope);
+            if (selectedPods.size > 0) {
+              moveIntoScope(Array.from(selectedPods), toScope);
             }
             // update view manually to remove the drag highlight.
             updateView();

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -929,12 +929,12 @@ function CanvasImpl() {
             const parentScope = node.parentNode ? node.parentNode : "ROOT";
             if (selectedPods.size > 0) {
               moveIntoScope(Array.from(selectedPods), toScope);
-            }
-            // update view manually to remove the drag highlight.
-            updateView();
-            // run auto layout on drag stop
-            if (autoRunLayout) {
-              autoLayoutROOT();
+              // update view manually to remove the drag highlight.
+              updateView();
+              // run auto layout on drag stop
+              if (autoRunLayout) {
+                autoLayoutROOT();
+              }
             }
           }}
           onNodeDrag={(event, node) => {


### PR DESCRIPTION
## Summary
For Issue #419 
- Update `moveIntoScope((nodeId: string, scopeId: string))` to `(nodeIds: string[], scopeId: string)`
## Test

 
![move_multi_pod_to_scope](https://github.com/codepod-io/codepod/assets/10226241/3866803c-0596-4402-bbaa-d29db8025748)

