### PR TITLE
[UI] Drag-n-drop entire pod/scope

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -927,14 +927,14 @@ function CanvasImpl() {
             let scope = getScopeAtPos(mousePos, node.id);
             let toScope = scope ? scope.id : "ROOT";
             const parentScope = node.parentNode ? node.parentNode : "ROOT";
-            if (selectedPods.size > 0) {
+            if (selectedPods.size > 0 && parentScope !== toScope) {
               moveIntoScope(Array.from(selectedPods), toScope);
               // update view manually to remove the drag highlight.
               updateView();
-              // run auto layout on drag stop
-              if (autoRunLayout) {
-                autoLayoutROOT();
-              }
+            }
+            // run auto layout on drag stop
+            if (autoRunLayout) {
+              autoLayoutROOT();
             }
           }}
           onNodeDrag={(event, node) => {

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -420,7 +420,6 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
         readOnly: false,
       });
     } else {
-      // FIXME needs to hide the cursor in CMD node
       editor?.updateOptions({
         readOnly: true,
         //cursorWidth: 0,
@@ -504,17 +503,6 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
           setFocusedEditor(undefined);
         }
       },
-    });
-
-    // solution from https://github.com/microsoft/monaco-editor/issues/1742
-    const messageContribution = editor.getContribution(
-      "editor.contrib.messageController"
-    );
-    editor.onDidAttemptReadOnlyEdit(() => {
-      (messageContribution as any)?.showMessage(
-        "Please 'double click' first to edit the pod.",
-        editor.getPosition()
-      );
     });
 
     // editor.onDidChangeModelContent(async (e) => {

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -761,7 +761,7 @@ export const CodeNode = memo<NodeProps>(function ({
           cursor: "auto",
           fontSize,
         }}
-        className="custom-drag-handle"
+        className={focusedEditor === id ? "nodrag" : "custom-drag-handle"}
       >
         {Wrap(
           <Box

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -891,6 +891,19 @@ export const CodeNode = memo<NodeProps>(function ({
                 py: 1,
               }}
             >
+              <Box
+                sx={{
+                  // Put it 100% the width and height, above the following components.
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: "100%",
+                  zIndex: focusedEditor === id ? -1 : 10,
+                }}
+              >
+                {/* Overlay */}
+              </Box>
               <MyMonaco id={id} fontSize={fontSize} />
               <ResultBlock id={id} layout={layout} />
             </Box>

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -566,6 +566,8 @@ export const CodeNode = memo<NodeProps>(function ({
   const pod = getPod(id);
   const isGuest = useStore(store, (state) => state.role === "GUEST");
   const cursorNode = useStore(store, (state) => state.cursorNode);
+  const focusedEditor = useStore(store, (state) => state.focusedEditor);
+  const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
   const inputRef = useRef<HTMLInputElement>(null);
   const updateView = useStore(store, (state) => state.updateView);
@@ -748,10 +750,18 @@ export const CodeNode = memo<NodeProps>(function ({
         onMouseLeave={() => {
           setShowToolbar(false);
         }}
+        onClick={(e) => {
+          switch (e.detail) {
+            case 2:
+              setFocusedEditor(id);
+              break;
+          }
+        }}
         sx={{
           cursor: "auto",
           fontSize,
         }}
+        className="custom-drag-handle"
       >
         {Wrap(
           <Box
@@ -768,11 +778,9 @@ export const CodeNode = memo<NodeProps>(function ({
                 ? "red"
                 : pod.ispublic
                 ? "green"
-                : selected
-                ? "#003c8f"
-                : !isPodFocused
+                : focusedEditor !== id
                 ? "#d6dee6"
-                : "#5e92f3",
+                : "#003c8f",
             }}
           >
             <Box
@@ -882,7 +890,6 @@ export const CodeNode = memo<NodeProps>(function ({
               }}
             >
               <MyMonaco id={id} fontSize={fontSize} />
-
               <ResultBlock id={id} layout={layout} />
             </Box>
           </Box>

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -778,6 +778,8 @@ export const CodeNode = memo<NodeProps>(function ({
                 ? "red"
                 : pod.ispublic
                 ? "green"
+                : selected
+                ? "#003c8f"
                 : focusedEditor !== id
                 ? "#d6dee6"
                 : "#003c8f",

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -302,6 +302,7 @@ const MyEditor = ({
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const resetSelection = useStore(store, (state) => state.resetSelection);
   const updateView = useStore(store, (state) => state.updateView);
+  const editable = !isGuest && focusedEditor === id;
   const { manager, state, setState } = useRemirror({
     extensions: () => [
       new PlaceholderExtension({ placeholder }),
@@ -311,7 +312,10 @@ const MyEditor = ({
       new SupExtension(),
       new SubExtension(),
       new MarkdownExtension(),
-      new MyYjsExtension({ getProvider: () => provider, id }),
+      // YjsExtension seems to be incompatible with editable=false, throwing console errors.
+      ...(editable
+        ? [new MyYjsExtension({ getProvider: () => provider, id })]
+        : []),
       new MathInlineExtension(),
       new MathBlockExtension(),
       // new CalloutExtension({ defaultType: "warn" }),
@@ -425,7 +429,7 @@ const MyEditor = ({
             // - [1] https://remirror.io/docs/controlled-editor
             // - [2] demo that Chinese input method is not working:
             //   https://remirror.vercel.app/?path=/story/editors-controlled--editable
-            editable={!isGuest && focusedEditor === id}
+            editable={editable}
           >
             <HotkeyControl id={id} />
             {/* <WysiwygToolbar /> */}

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -715,6 +715,8 @@ export const RichNode = memo<Props>(function ({
               backgroundColor: "white",
               borderColor: pod.ispublic
                 ? "green"
+                : selected
+                ? "#003c8f"
                 : focusedEditor !== id
                 ? "#d6dee6"
                 : "#003c8f",

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -701,7 +701,7 @@ export const RichNode = memo<Props>(function ({
           cursor: "auto",
           fontSize,
         }}
-        className="custom-drag-handle"
+        className={focusedEditor === id ? "nodrag" : "custom-drag-handle"}
       >
         {" "}
         {Wrap(

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -693,7 +693,6 @@ export const RichNode = memo<Props>(function ({
         onClick={(e) => {
           switch (e.detail) {
             case 2:
-              console.log("Rich node double click");
               setFocusedEditor(id);
               break;
           }

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -291,6 +291,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
         width: "100%",
         height: "100%",
         border: isCutting ? "dashed 2px red" : "solid 1px #d6dee6",
+        borderColor: selected ? "#003c8f" : undefined,
         borderRadius: "4px",
         cursor: "auto",
         fontSize,

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -58,7 +58,6 @@ function MyFloatingToolbar({ id }: { id: string }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const reactFlowInstance = useReactFlow();
-  // const selected = useStore(store, (state) => state.pods[id]?.selected);
   const isGuest = useStore(store, (state) => state.role === "GUEST");
   const wsRunScope = useStore(store, (state) => state.wsRunScope);
   const clonePod = useStore(store, (state) => state.clonePod);
@@ -210,7 +209,6 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const setPodName = useStore(store, (state) => state.setPodName);
   const nodesMap = useStore(store, (state) => state.ydoc.getMap<Node>("pods"));
-  // const selected = useStore(store, (state) => state.pods[id]?.selected);
   const isGuest = useStore(store, (state) => state.role === "GUEST");
   const inputRef = useRef<HTMLInputElement>(null);
   const getPod = useStore(store, (state) => state.getPod);
@@ -303,6 +301,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
       onMouseLeave={() => {
         setShowToolbar(false);
       }}
+      className="custom-drag-handle"
     >
       {/* <NodeResizer color="#ff0071" minWidth={100} minHeight={30} /> */}
       <Box sx={{ opacity: showToolbar ? 1 : 0 }}>


### PR DESCRIPTION
## Summary
- Drag-n-drop the entire pod by dragging anywhere within the pod
- "Double click" to enter `Edit` mode.
- Bug: Monaco editor's cursor can't be hidden in `CMD` mode 

## Test
![move_pod_no_drag_handle](https://github.com/codepod-io/codepod/assets/10226241/00adeba0-967d-4afb-b07d-28ff5fd8ece0)
