### PR TITLE
use root YMap

### DIFF
--- a/api/src/yjs-plain.ts
+++ b/api/src/yjs-plain.ts
@@ -115,7 +115,9 @@ function setupNodesMapObserver(ydoc: Y.Doc, repoId: string) {
   // observe changes to the ydoc and write to the database
   // The nodes: {"nodeID": ReactFlowNode}
   // TODO Maybe embed the content into the nodes?
-  const nodesMap = ydoc.getMap<ReactflowNode<NodeData>>("nodesMap");
+  const nodesMap = ydoc.getMap("rootMap").get("nodesMap") as Y.Map<
+    ReactflowNode<NodeData>
+  >;
   // FIXME IMPORTANT do I need to unobserve?
   // FIXME will there be a destroy event?
   nodesMap.observe((YMapEvent, transaction) => {
@@ -172,7 +174,7 @@ async function handleUpdatePod({
 }
 
 function setupCodeMapObserver(ydoc: Y.Doc, repoId: string) {
-  const codeMap = ydoc.getMap<Y.Text | Y.XmlFragment>("codeMap");
+  const codeMap = ydoc.getMap("rootMap").get("codeMap") as Y.Map<Y.Text>;
   // const debouncedCallback = createDebouncedCallback();
   codeMap.observeDeep((events, transaction) => {
     if (transaction.local) {
@@ -201,7 +203,7 @@ function setupCodeMapObserver(ydoc: Y.Doc, repoId: string) {
 }
 
 function setupRichMapObserver(ydoc: Y.Doc, repoId: string) {
-  const richMap = ydoc.getMap<Y.XmlFragment>("richMap");
+  const richMap = ydoc.getMap("rootMap").get("richMap") as Y.Map<Y.XmlFragment>;
   richMap.observeDeep((events, transaction) => {
     if (transaction.local) {
       return;
@@ -277,7 +279,9 @@ async function handleDeleteEdge({
 }
 
 function setupEdgesMapObserver(ydoc: Y.Doc, repoId: string) {
-  const edgesMap = ydoc.getMap<ReactflowEdge>("edgesMap");
+  const edgesMap = ydoc
+    .getMap("rootMap")
+    .get("edgesMap") as Y.Map<ReactflowEdge>;
   edgesMap.observe((YMapEvent, transaction) => {
     if (transaction.local) {
       return;
@@ -352,10 +356,19 @@ async function loadFromDB(ydoc: Y.Doc, repoId: string) {
   }
   // TODO make sure the ydoc is empty.
   // 2. construct Y doc types
-  const nodesMap = ydoc.getMap<ReactflowNode<NodeData>>("nodesMap");
-  const edgesMap = ydoc.getMap<ReactflowEdge>("edgesMap");
-  const codeMap = ydoc.getMap("codeMap");
-  const richMap = ydoc.getMap("richMap");
+  const rootMap = ydoc.getMap("rootMap");
+  // const nodesMap = ydoc.getMap<ReactflowNode<NodeData>>("nodesMap");
+  // const edgesMap = ydoc.getMap<ReactflowEdge>("edgesMap");
+  // const codeMap = ydoc.getMap("codeMap");
+  // const richMap = ydoc.getMap("richMap");
+  const nodesMap = new Y.Map<ReactflowNode<NodeData>>();
+  const edgesMap = new Y.Map<ReactflowEdge>();
+  const codeMap = new Y.Map<Y.Text>();
+  const richMap = new Y.Map<Y.XmlFragment>();
+  rootMap.set("nodesMap", nodesMap);
+  rootMap.set("edgesMap", edgesMap);
+  rootMap.set("codeMap", codeMap);
+  rootMap.set("richMap", richMap);
   // Load pod content.
   repo.pods.forEach((pod) => {
     // let content : Y.Text | Y.XmlFragment;

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -170,9 +170,7 @@ function useJump() {
 
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
 
-  const nodesMap = useStore(store, (state) =>
-    state.ydoc.getMap<Node>("nodesMap")
-  );
+  const nodesMap = useStore(store, (state) => state.getNodesMap());
   const pods = useStore(store, (state) => state.pods);
 
   const reactflow = useReactFlow();
@@ -491,9 +489,6 @@ function CanvasImplWrap() {
   usePaste(reactFlowWrapper);
   useCut(reactFlowWrapper);
   useJump();
-
-  const { loading } = useInitNodes();
-  if (loading) return <div>Loading...</div>;
   return (
     <Box sx={{ height: "100%" }} ref={reactFlowWrapper}>
       <CanvasImpl />
@@ -863,6 +858,8 @@ function CanvasImpl() {
 }
 
 export function Canvas() {
+  const { loading } = useInitNodes();
+  if (loading) return <div>Loading...</div>;
   return (
     <ReactFlowProvider>
       <CanvasImplWrap />

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -440,11 +440,11 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   }
 
   const provider = useStore(store, (state) => state.provider);
-  const ydoc = useStore(store, (state) => state.ydoc);
-  const awareness = provider?.awareness;
+  const codeMap = useStore(store, (state) => state.getCodeMap());
 
   const resetSelection = useStore(store, (state) => state.resetSelection);
 
+  // FIXME useCallback?
   function onEditorDidMount(
     editor: monaco.editor.IStandaloneCodeEditor,
     monaco
@@ -511,12 +511,16 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
 
     // bind it to the ytext with pod id
     // if (monaco.languages.registerInlineCompletionsProvider)
-    const codeMap = ydoc.getMap<Y.Text>("codeMap");
     if (!codeMap.has(id)) {
       codeMap.set(id, new Y.Text());
     }
     const ytext = codeMap.get(id)!;
-    new MonacoBinding(ytext, editor.getModel()!, new Set([editor]), awareness);
+    new MonacoBinding(
+      ytext,
+      editor.getModel()!,
+      new Set([editor]),
+      provider?.awareness
+    );
 
     // FIXME: make sure the provider.wsconnected is true or it won't display any content.
   }

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -583,9 +583,7 @@ export const CodeNode = memo<NodeProps>(function ({
   );
   const isCutting = useStore(store, (state) => state.cuttingIds.has(id));
 
-  const nodesMap = useStore(store, (state) =>
-    state.ydoc.getMap<Node>("nodesMap")
-  );
+  const nodesMap = useStore(store, (state) => state.getNodesMap());
   const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
   const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
 
@@ -650,9 +648,10 @@ export const CodeNode = memo<NodeProps>(function ({
   );
 
   const node = nodesMap.get(id);
+  if (!node) return null;
 
   const fontSize = level2fontsize(
-    node?.data.level,
+    node.data.level,
     contextualZoomParams,
     contextualZoom
   );

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -299,7 +299,7 @@ const MyEditor = ({
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const resetSelection = useStore(store, (state) => state.resetSelection);
   const updateView = useStore(store, (state) => state.updateView);
-  const richMap = provider.doc.getMap<Y.XmlFragment>("richMap");
+  const richMap = useStore(store, (state) => state.getRichMap());
   if (!richMap.has(id)) {
     richMap.set(id, new Y.XmlFragment());
   }
@@ -550,9 +550,7 @@ export const RichNode = memo<Props>(function ({
   const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
   const devMode = useStore(store, (state) => state.devMode);
   const inputRef = useRef<HTMLInputElement>(null);
-  const nodesMap = useStore(store, (state) =>
-    state.ydoc.getMap<Node>("nodesMap")
-  );
+  const nodesMap = useStore(store, (state) => state.getNodesMap());
   const updateView = useStore(store, (state) => state.updateView);
   const reactFlowInstance = useReactFlow();
 
@@ -622,6 +620,7 @@ export const RichNode = memo<Props>(function ({
   }, [cursorNode]);
 
   const node = nodesMap.get(id);
+  if (!node) return null;
 
   const fontSize = level2fontsize(
     node?.data.level,

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -209,9 +209,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const setPodName = useStore(store, (state) => state.setPodName);
-  const nodesMap = useStore(store, (state) =>
-    state.ydoc.getMap<Node>("nodesMap")
-  );
+  const nodesMap = useStore(store, (state) => state.getNodesMap());
   const isGuest = useStore(store, (state) => state.role === "GUEST");
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -258,6 +256,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
   );
   const zoomLevel = useReactFlowStore((s) => s.transform[2]);
   const node = nodesMap.get(id);
+  if (!node) return null;
 
   const fontSize = level2fontsize(
     node?.data.level,

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -9,7 +9,7 @@ export function useYjsObserver() {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const ydoc = useStore(store, (state) => state.ydoc);
-  const nodesMap = ydoc.getMap<Node>("nodesMap");
+  const nodesMap = useStore(store, (state) => state.getNodesMap());
   const updateView = useStore(store, (state) => state.updateView);
   const resetSelection = useStore(store, (state) => state.resetSelection);
 

--- a/ui/src/lib/store/runtimeSlice.tsx
+++ b/ui/src/lib/store/runtimeSlice.tsx
@@ -22,7 +22,7 @@ function collectSymbolTables(
   let parentId = pod.parent;
   let allSymbolTables: Record<string, string>[] = [];
   // do this for all ancestor scopes.
-  const nodes = Array.from(get().ydoc.getMap<Node>("nodesMap"));
+  const nodes = Array.from(get().getNodesMap());
   while (parentId) {
     const siblings = nodes.filter((node) => node.parentNode === parentId);
     const tables = siblings.map((_id) => {
@@ -360,7 +360,8 @@ export const createRuntimeSlice: StateCreator<MyState, [], [], RuntimeSlice> = (
    * Add a pod to the chain and run it.
    */
   wsRun: async (id) => {
-    const nodes = Array.from(get().ydoc.getMap<Node>("nodesMap"));
+    const nodesMap = get().getNodesMap();
+    const nodes = Array.from(nodesMap);
     if (!get().socket) {
       get().addError({
         type: "error",
@@ -379,8 +380,6 @@ export const createRuntimeSlice: StateCreator<MyState, [], [], RuntimeSlice> = (
       // get the pods in the scope
       const children = nodes.filter((n) => n.parentNode === id);
       if (!children) return;
-      // The reactflow nodesMap stored in Yjs
-      let nodesMap = get().ydoc.getMap<Node>("nodesMap");
       // Sort by x and y positions, with the leftmost and topmost first.
       children.sort((a, b) => {
         let nodeA = nodesMap.get(a);
@@ -420,7 +419,7 @@ export const createRuntimeSlice: StateCreator<MyState, [], [], RuntimeSlice> = (
       return;
     }
     // Get the chain: get the edges, and then get the pods
-    const edgesMap = get().ydoc.getMap<Edge>("edgesMap");
+    const edgesMap = get().getEdgesMap();
     let edges = Array.from(edgesMap.values());
     // build a node2target map
     let node2target = {};


### PR DESCRIPTION
Instead of using four top-level YMaps (`nodesMap`, `edgesMap`, `codeMap`, `richMap`), this PR uses a root YMap `rootMap`, so that all fields are removable for possible future schema updates.

Before:

```ts
const nodesMap = ydoc.getMap<ReactflowNode<NodeData>>("nodesMap")
const edgesMap = ydoc.getMap<ReactflowEdge>("edgesMap")
const codeMap = ydoc.getMap<Y.Text>("codeMap")
const richMap = ydoc.getMap<Y.XmlFragment>("richMap")
```

After:

```ts
// rootMap
const rootMap = ydoc.getMap("rootMap");
// nested maps
const nodesMap = rootMap.get("nodesMap") as Y.Map<ReactflowNode<NodeData>>;
const edgesMap = rootMap.get("edgesMap") as Y.Map<ReactflowEdge>;
const codeMap = rootMap.get("codeMap") as Y.Map<Y.Text>;
const richMap = rootMap.get("richMap") as Y.Map<Y.XmlFragment>;
```

Also added four helper store.functions:

```ts
store.getNodesMap() {
  return get().ydoc.getMap("rootMap").get("nodesMap") as Y.Map<Node<NodeData>>;
},
store.getEdgesMap() {...}
store.getCodeMap() {...}
store.getRichMap() {...}
```

Ref from [Yjs document](https://docs.yjs.dev/api/faq):

> Consider using a single top-level YMap: Top-level shared types cannot be deleted, so you may want to structure all your data in a single top-level YMap, eg. yDoc.getMap('data').get('page-1').

