### PR TITLE
remove state.pods; fix runtime & results

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -56,31 +56,6 @@ const edgeTypes = {
   floating: FloatingEdge,
 };
 
-function useInitNodes() {
-  const store = useContext(RepoContext)!;
-  const provider = useStore(store, (state) => state.provider);
-  const [loading, setLoading] = useState(true);
-  const updateView = useStore(store, (state) => state.updateView);
-  const adjustLevel = useStore(store, (state) => state.adjustLevel);
-  useEffect(() => {
-    const init = () => {
-      // adjust level and update view
-      adjustLevel();
-      updateView();
-      setLoading(false);
-    };
-
-    if (!provider) return;
-    if (provider.synced) {
-      init();
-    } else {
-      provider.once("synced", init);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [provider]);
-  return { loading };
-}
-
 function getBestNode(
   nodes: Node[],
   from,
@@ -860,8 +835,6 @@ function CanvasImpl() {
 }
 
 export function Canvas() {
-  const { loading } = useInitNodes();
-  if (loading) return <div>Loading...</div>;
   return (
     <ReactFlowProvider>
       <CanvasImplWrap />

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -396,12 +396,13 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const clearResults = useStore(store, (s) => s.clearResults);
   const wsRun = useStore(store, (state) => state.wsRun);
-  const setPodFocus = useStore(store, (state) => state.setPodFocus);
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
-  const setPodBlur = useStore(store, (state) => state.setPodBlur);
   const setCursorNode = useStore(store, (state) => state.setCursorNode);
-  const annotations = useStore(store, (state) => state.pods[id]?.annotations);
+  const annotations = useStore(
+    store,
+    (state) => state.parseResult[id]?.annotations
+  );
   const showAnnotations = useStore(store, (state) => state.showAnnotations);
   const scopedVars = useStore(store, (state) => state.scopedVars);
   const updateView = useStore(store, (state) => state.updateView);
@@ -470,11 +471,9 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
       // onLayout(`${contentHeight}px`);
     };
     editor.onDidBlurEditorText(() => {
-      setPodBlur(id);
       setFocusedEditor(undefined);
     });
     editor.onDidFocusEditorText(() => {
-      setPodFocus(id);
       if (resetSelection()) updateView();
     });
     editor.onDidContentSizeChange(updateHeight);
@@ -497,7 +496,6 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
       run: () => {
         if (document.activeElement) {
           (document.activeElement as any).blur();
-          setPodBlur(id);
           setCursorNode(id);
           setFocusedEditor(undefined);
           selectPod(id, true);

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -85,11 +85,17 @@ function Timer({ lastExecutedAt }) {
 
 export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
   const store = useContext(RepoContext)!;
-  const results = useStore(store, (state) => state.pods[id]?.result);
-  const error = useStore(store, (state) => state.pods[id]?.error);
-  const stdout = useStore(store, (state) => state.pods[id]?.stdout);
-  const running = useStore(store, (state) => state.pods[id]?.running || false);
-  const exec_count = useStore(store, (state) => state.pods[id]?.exec_count);
+  const results = useStore(store, (state) => state.podResults[id]?.result);
+  const error = useStore(store, (state) => state.podResults[id]?.error);
+  const stdout = useStore(store, (state) => state.podResults[id]?.stdout);
+  const running = useStore(
+    store,
+    (state) => state.podResults[id]?.running || false
+  );
+  const exec_count = useStore(
+    store,
+    (state) => state.podResults[id]?.exec_count
+  );
   const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
   const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
 
@@ -105,17 +111,17 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
 
   const lastExecutedAt = useStore(
     store,
-    (state) => state.pods[id]?.lastExecutedAt
+    (state) => state.podResults[id]?.lastExecutedAt
   );
   const [showOutput, setShowOutput] = useState(true);
   const hasResult = useStore(
     store,
     (state) =>
-      state.pods[id]?.running ||
-      state.pods[id]?.result ||
-      state.pods[id]?.error ||
-      state.pods[id]?.stdout ||
-      state.pods[id]?.stderr
+      state.podResults[id]?.running ||
+      state.podResults[id]?.result ||
+      state.podResults[id]?.error ||
+      state.podResults[id]?.stdout ||
+      state.podResults[id]?.stderr
   );
   const [resultScroll, setResultScroll] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
@@ -574,12 +580,11 @@ export const CodeNode = memo<NodeProps>(function ({
   const cursorNode = useStore(store, (state) => state.cursorNode);
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
-  const isPodFocused = useStore(store, (state) => state.pods[id]?.focus);
   const inputRef = useRef<HTMLInputElement>(null);
   const updateView = useStore(store, (state) => state.updateView);
   const exec_count = useStore(
     store,
-    (state) => state.pods[id]?.exec_count || " "
+    (state) => state.podResults[id]?.exec_count || " "
   );
   const isCutting = useStore(store, (state) => state.cuttingIds.has(id));
 

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -257,13 +257,11 @@ function HotkeyControl({ id }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const setCursorNode = useStore(store, (state) => state.setCursorNode);
-  const setPodBlur = useStore(store, (state) => state.setPodBlur);
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const selectPod = useStore(store, (state) => state.selectPod);
 
   useKeymap("Escape", () => {
-    setPodBlur(id);
     setCursorNode(id);
     setFocusedEditor(undefined);
     selectPod(id, true);
@@ -292,11 +290,9 @@ const MyEditor = ({
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const isGuest = useStore(store, (state) => state.role === "GUEST");
-  const setPodFocus = useStore(store, (state) => state.setPodFocus);
   // the Yjs extension for Remirror
   const provider = useStore(store, (state) => state.provider)!;
 
-  const setPodBlur = useStore(store, (state) => state.setPodBlur);
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const resetSelection = useStore(store, (state) => state.resetSelection);
@@ -402,12 +398,10 @@ const MyEditor = ({
     <Box
       className="remirror-theme"
       onFocus={() => {
-        setPodFocus(id);
         setFocusedEditor(id);
         if (resetSelection()) updateView();
       }}
       onBlur={() => {
-        setPodBlur(id);
         setFocusedEditor(undefined);
       }}
       sx={{

--- a/ui/src/lib/nodes.tsx
+++ b/ui/src/lib/nodes.tsx
@@ -19,6 +19,8 @@ export function useYjsObserver() {
       updateView();
     };
 
+    // FIXME need to observe edgesMap as well
+    // FIXME need to observe resultMap as well
     nodesMap.observe(observer);
 
     return () => {

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -652,8 +652,8 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
 
     // clear the temporary nodes and the pasting/cutting state
     set(
-      produce((state) => {
-        state.pastingNode = undefined;
+      produce((state: MyState) => {
+        state.pastingNodes = undefined;
         state.headPastingNodes = new Set();
         state.pastingNodes = [];
         state.mousePos = undefined;
@@ -663,19 +663,6 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     );
 
     pastingNodes.forEach((node) => {
-      set(
-        produce((state) => {
-          let pod = state.pods[node!.id];
-          if (leadingNodes?.has(node.id)) {
-            pod.x = position.x;
-            pod.y = position.y;
-          }
-          pod.dirty = true;
-          // this flag triggers the addPods call when updating all dirty pods
-          pod.pending = true;
-        })
-      );
-
       // insert all nodes to the yjs map
       nodesMap.set(node.id, {
         ...(leadingNodes?.has(node.id) ? { ...node, position } : node),
@@ -703,15 +690,12 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
   cancelPaste: (cutting = false) => {
     const pastingNodes = get().pastingNodes || [];
     set(
-      produce((state) => {
+      produce((state: MyState) => {
         // Remove pastingNode from store.
         state.pastingNodes = [];
         state.headPastingNodes = new Set();
-        pastingNodes.forEach((node) => {
-          delete state.pods[node!.id];
-        });
         // Clear pasting data and update view.
-        state.pastingNode = undefined;
+        state.pastingNodes = undefined;
         state.mousePos = undefined;
         if (cutting) state.isCutting = false;
         else state.isPasting = false;

--- a/ui/src/lib/store/podSlice.tsx
+++ b/ui/src/lib/store/podSlice.tsx
@@ -1,13 +1,30 @@
 import { createStore, StateCreator, StoreApi } from "zustand";
 import produce from "immer";
 
-import { ApolloClient } from "@apollo/client";
+import * as Y from "yjs";
 
 import { Pod, MyState } from ".";
 
+type PodResult = {
+  exec_count?: number;
+  last_exec_end?: boolean;
+  result: {
+    type?: string;
+    html?: string;
+    text?: string;
+    image?: string;
+  }[];
+  running?: boolean;
+  lastExecutedAt?: Date;
+  stdout?: string;
+  stderr?: string;
+  error?: { ename: string; evalue: string; stacktrace: string[] } | null;
+};
+
 export interface PodSlice {
-  setPodFocus: (id: string) => void;
-  setPodBlur: (id: string) => void;
+  // local reactive variable for pod result
+  podResults: Record<string, PodResult>;
+  podNames: Record<string, string>;
   setPodName: ({ id, name }: { id: string; name: string }) => void;
   setPodResult: ({ id, type, content, count }) => void;
   setPodStdout: ({ id, stdout }: { id: string; stdout: string }) => void;
@@ -20,120 +37,109 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
   set,
   get
 ) => ({
-  setPodName: ({ id, name }) =>
+  podResults: {},
+  podNames: {},
+  setPodName: ({ id, name }) => {
     set(
       produce((state: MyState) => {
-        let pod = state.pods[id];
-        if (pod && pod.name !== name) {
-          pod.name = name;
-          pod.dirty = true;
-        }
-      }),
-      false,
-      // @ts-ignore
-      "setPodName"
-    ),
-  setPodStdout: ({ id, stdout }) =>
-    set(
-      produce((state) => {
-        state.pods[id].stdout = stdout;
-        state.pods[id].dirty = true;
+        state.podNames[id] = name;
       })
-    ),
-  setPodError: ({ id, ename, evalue, stacktrace }) =>
+    );
+  },
+  setPodStdout: ({ id, stdout }) => {
+    get().ensureResult(id);
+    set(
+      produce((state: MyState) => {
+        state.podResults[id].stdout = stdout;
+      })
+    );
+  },
+  setPodError: ({ id, ename, evalue, stacktrace }) => {
+    get().ensureResult(id);
     set(
       produce((state: MyState) => {
         if (id === "CODEPOD") return;
-        state.pods[id].error = {
+        state.podResults[id].error = {
           ename,
           evalue,
           stacktrace,
         };
-        state.pods[id].dirty = true;
       })
-    ),
+    );
+  },
   setPodStatus: ({ id, status, lang }) =>
     set(
       produce((state: MyState) => {
         // console.log("WS_STATUS", { lang, status });
         state.kernels[lang].status = status;
         // this is for racket kernel, which does not have a execute_reply
-        if (lang === "racket" && status === "idle" && state.pods[id]) {
-          state.pods[id].running = false;
-        }
-      })
-    ),
-  setPodFocus: (id: string) =>
-    set(
-      produce((state: MyState) => {
-        if (state.pods[id]) {
-          state.pods[id].focus = true;
-        }
-      })
-    ),
-  setPodBlur: (id: string) =>
-    set(
-      produce((state: MyState) => {
-        if (state.pods[id]) {
-          state.pods[id].focus = false;
-        }
+        // if (lang === "racket" && status === "idle" && state.pods[id]) {
+        //   state.pods[id].running = false;
+        // }
       })
     ),
   clonePod: (id: string) => {
-    const pod = get().pods[id];
+    const nodesMap = get().getNodesMap();
+    const node = nodesMap.get(id);
+    const nodes = Array.from(nodesMap.values());
+    const children = nodes.filter((n) => n.parentNode === id);
     return {
-      ...pod,
-      children: pod.children.map((child) => get().clonePod(child.id)),
+      ...node,
+      children: children.map((child) => get().clonePod(child.id)),
     };
   },
   setPodResult({ id, type, content, count }) {
-    if (get().pods[id]) {
-      set(
-        produce((state) => {
-          if (state.pods[id].last_exec_end) {
-            state.pods[id].result = [];
-            state.pods[id].last_exec_end = false;
-          }
-          switch (type) {
-            case "display_data":
-              // console.log("WS_DISPLAY_DATA", content);
-              state.pods[id].result.push({
-                type,
-                text: content.data["text/plain"],
-                image: content.data["image/png"],
-              });
-              break;
-            case "execute_result":
-              // console.log("WS_EXECUTE_RESULT", content);
-              state.pods[id].result.push({
-                type,
-                text: content.data["text/plain"],
-              });
-              break;
-            case "stream":
-              // console.log("WS_STREAM", content);
-              state.pods[id].result.push({
-                // content.name : "stdout" or "stderr"
-                type: `${type}_${content.name}`,
-                text: content.text,
-              });
-              break;
-            case "execute_reply":
-              state.pods[id].running = false;
-              state.pods[id].lastExecutedAt = Date.now();
-              state.pods[id].result.push({
-                type,
-                text: content,
-              });
-              state.pods[id].exec_count = count;
-              state.pods[id].last_exec_end = true;
-              break;
-            default:
-              break;
-          }
-          state.pods[id].dirty = true;
-        })
-      );
+    const nodesMap = get().getNodesMap();
+    const node = nodesMap.get(id);
+    if (!node) {
+      console.log("setPodResult: node not found", id);
+      return;
     }
+    get().ensureResult(id);
+    set(
+      produce((state: MyState) => {
+        if (state.podResults[id].last_exec_end) {
+          state.podResults[id].result = [];
+          state.podResults[id].last_exec_end = false;
+        }
+        switch (type) {
+          case "display_data":
+            // console.log("WS_DISPLAY_DATA", content);
+            state.podResults[id].result.push({
+              type,
+              text: content.data["text/plain"],
+              image: content.data["image/png"],
+            });
+            break;
+          case "execute_result":
+            // console.log("WS_EXECUTE_RESULT", content);
+            state.podResults[id].result.push({
+              type,
+              text: content.data["text/plain"],
+            });
+            break;
+          case "stream":
+            // console.log("WS_STREAM", content);
+            state.podResults[id].result.push({
+              // content.name : "stdout" or "stderr"
+              type: `${type}_${content.name}`,
+              text: content.text,
+            });
+            break;
+          case "execute_reply":
+            state.podResults[id].running = false;
+            state.podResults[id].lastExecutedAt = new Date();
+            state.podResults[id].result.push({
+              type,
+              text: content,
+            });
+            state.podResults[id].exec_count = count;
+            state.podResults[id].last_exec_end = true;
+            break;
+          default:
+            break;
+        }
+      })
+    );
   },
 });

--- a/ui/src/lib/store/repoStateSlice.tsx
+++ b/ui/src/lib/store/repoStateSlice.tsx
@@ -56,7 +56,6 @@ export async function registerUser(
 }
 
 export interface RepoStateSlice {
-  pods: Record<string, Pod>;
   // From source pod id to target pod id.
   setSessionId: (sessionId: string) => void;
   setRepoData: (repo: {
@@ -113,7 +112,6 @@ export const createRepoStateSlice: StateCreator<
   [],
   RepoStateSlice
 > = (set, get) => ({
-  pods: {},
   error: null,
   repoLoaded: false,
   user: {},
@@ -269,7 +267,7 @@ export const createRepoStateSlice: StateCreator<
   disconnectYjs: () =>
     set(
       // clean up the connected provider after exiting the page
-      produce((state) => {
+      produce((state: MyState) => {
         console.log("disconnecting yjs socket ..");
         if (state.provider) {
           state.provider.destroy();


### PR DESCRIPTION
This is follow-up PR for #331 to fix broken things.

What's changed:

- state.pods are removed and fixed all compile errors
- Runtime and results are fixed.

Remaining TODOs regarding this centered-Yjs transition:

- [ ] fix copy-n-paste
- [ ] fix jupyter import/export
- [ ] save results to Yjs and sync with peers
- [ ] sync titles: doc title, scope title, pod title