### PR TITLE
simplify copy-n-paste

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -422,10 +422,11 @@ function CanvasImpl() {
   const [parentNode, setParentNode] = useState(undefined);
 
   const moved = useStore(store, (state) => state.moved);
-  const clicked = useStore(store, (state) => state.clicked);
+  const paneClicked = useStore(store, (state) => state.paneClicked);
+  const nodeClicked = useStore(store, (state) => state.nodeClicked);
   useEffect(() => {
     setShowContextMenu(false);
-  }, [moved, clicked]);
+  }, [moved, paneClicked, nodeClicked]);
   const escapePressed = useKeyPress("Escape");
   useEffect(() => {
     if (escapePressed) {
@@ -465,7 +466,8 @@ function CanvasImpl() {
     (state) => state.helperLineVertical
   );
   const toggleMoved = useStore(store, (state) => state.toggleMoved);
-  const toggleClicked = useStore(store, (state) => state.toggleClicked);
+  const togglePaneClicked = useStore(store, (state) => state.togglePaneClicked);
+  const toggleNodeClicked = useStore(store, (state) => state.toggleNodeClicked);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -550,10 +552,10 @@ function CanvasImpl() {
             });
           }}
           onPaneClick={() => {
-            toggleClicked();
+            togglePaneClicked();
           }}
           onNodeClick={() => {
-            toggleClicked();
+            toggleNodeClicked();
           }}
           onNodeDragStop={(event, node) => {
             removeDragHighlight();

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -27,6 +27,7 @@ import ReactFlow, {
   useViewport,
   XYPosition,
   useStore as useRfStore,
+  useKeyPress,
 } from "reactflow";
 import "reactflow/dist/style.css";
 
@@ -420,6 +421,18 @@ function CanvasImpl() {
   const [client, setClient] = useState({ x: 0, y: 0 });
   const [parentNode, setParentNode] = useState(undefined);
 
+  const moved = useStore(store, (state) => state.moved);
+  const clicked = useStore(store, (state) => state.clicked);
+  useEffect(() => {
+    setShowContextMenu(false);
+  }, [moved, clicked]);
+  const escapePressed = useKeyPress("Escape");
+  useEffect(() => {
+    if (escapePressed) {
+      setShowContextMenu(false);
+    }
+  }, [escapePressed]);
+
   const onPaneContextMenu = (event) => {
     event.preventDefault();
     setShowContextMenu(true);
@@ -539,6 +552,9 @@ function CanvasImpl() {
           onPaneClick={() => {
             toggleClicked();
           }}
+          onNodeClick={() => {
+            toggleClicked();
+          }}
           onNodeDragStop={(event, node) => {
             removeDragHighlight();
             let mousePos = project({ x: event.clientX, y: event.clientY });
@@ -650,25 +666,38 @@ function CanvasImpl() {
           <CanvasContextMenu
             x={points.x}
             y={points.y}
-            addCode={() =>
-              addNode("CODE", project({ x: client.x, y: client.y }), parentNode)
-            }
-            addScope={() =>
+            addCode={() => {
+              addNode(
+                "CODE",
+                project({ x: client.x, y: client.y }),
+                parentNode
+              );
+              setShowContextMenu(false);
+            }}
+            addScope={() => {
               addNode(
                 "SCOPE",
                 project({ x: client.x, y: client.y }),
                 parentNode
-              )
-            }
-            addRich={() =>
-              addNode("RICH", project({ x: client.x, y: client.y }), parentNode)
-            }
+              );
+              setShowContextMenu(false);
+            }}
+            addRich={() => {
+              addNode(
+                "RICH",
+                project({ x: client.x, y: client.y }),
+                parentNode
+              );
+              setShowContextMenu(false);
+            }}
             handleImportClick={() => {
               // handle CanvasContextMenu "import Jupyter notebook" click
               handleItemClick();
+              setShowContextMenu(false);
             }}
             onShareClick={() => {
               setShareOpen(true);
+              setShowContextMenu(false);
             }}
             parentNode={null}
           />

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -423,38 +423,9 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
   const wsRunChain = useStore(store, (state) => state.wsRunChain);
   // right, bottom
   const isGuest = useStore(store, (state) => state.role === "GUEST");
-  const clonePod = useStore(store, (state) => state.clonePod);
-  const setPaneFocus = useStore(store, (state) => state.setPaneFocus);
-
-  const onCopy = useCallback(
-    (clipboardData: any) => {
-      const pod = clonePod(id);
-      if (!pod) return;
-      clipboardData.setData("text/plain", pod.content);
-      clipboardData.setData(
-        "application/json",
-        JSON.stringify({
-          type: "pod",
-          data: pod,
-        })
-      );
-      setPaneFocus();
-    },
-    [clonePod, id]
-  );
 
   const zoomLevel = useReactFlowStore((s) => s.transform[2]);
   const iconFontSize = zoomLevel < 1 ? `${1.5 * (1 / zoomLevel)}rem` : `1.5rem`;
-
-  const cutBegin = useStore(store, (state) => state.cutBegin);
-
-  const onCut = useCallback(
-    (clipboardData: any) => {
-      onCopy(clipboardData);
-      cutBegin(id);
-    },
-    [onCopy, cutBegin, id]
-  );
 
   return (
     <Box
@@ -492,31 +463,6 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
             <KeyboardDoubleArrowRightIcon style={{ fontSize: iconFontSize }} />
           </IconButton>
         </Tooltip>
-      )}
-      <CopyToClipboard
-        text="dummy"
-        options={{ debug: true, format: "text/plain", onCopy } as any}
-      >
-        <Tooltip title="Copy">
-          <IconButton className="copy-button">
-            <ContentCopyIcon
-              style={{ fontSize: iconFontSize }}
-              className="copy-button"
-            />
-          </IconButton>
-        </Tooltip>
-      </CopyToClipboard>
-      {!isGuest && (
-        <CopyToClipboard
-          text="dummy"
-          options={{ debug: true, format: "text/plain", onCopy: onCut } as any}
-        >
-          <Tooltip title="Cut">
-            <IconButton>
-              <ContentCutIcon style={{ fontSize: iconFontSize }} />
-            </IconButton>
-          </Tooltip>
-        </CopyToClipboard>
       )}
       {!isGuest && (
         <Tooltip style={{ fontSize: iconFontSize }} title="Delete">
@@ -586,7 +532,6 @@ export const CodeNode = memo<NodeProps>(function ({
     store,
     (state) => state.podResults[id]?.exec_count || " "
   );
-  const isCutting = useStore(store, (state) => state.cuttingIds.has(id));
 
   const nodesMap = useStore(store, (state) => state.getNodesMap());
   const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
@@ -774,13 +719,11 @@ export const CodeNode = memo<NodeProps>(function ({
                 ? "4px"
                 : "2px",
               borderRadius: "4px",
-              borderStyle: isCutting ? "dashed" : "solid",
+              borderStyle: "solid",
               width: "100%",
               height: "100%",
               backgroundColor: "rgb(244, 246, 248)",
-              borderColor: isCutting
-                ? "red"
-                : false // FIXME pod.ispublic
+              borderColor: false // FIXME pod.ispublic
                 ? "green"
                 : selected
                 ? "#003c8f"

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -61,34 +61,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
   const reactFlowInstance = useReactFlow();
   const isGuest = useStore(store, (state) => state.role === "GUEST");
   const wsRunScope = useStore(store, (state) => state.wsRunScope);
-  const clonePod = useStore(store, (state) => state.clonePod);
 
-  const onCopy = useCallback(
-    (clipboardData: any) => {
-      const pod = clonePod(id);
-      if (!pod) return;
-      // set the plain text content of a scope as empty
-      clipboardData.setData("text/plain", "");
-      clipboardData.setData(
-        "application/json",
-        JSON.stringify({
-          type: "pod",
-          data: pod,
-        })
-      );
-    },
-    [clonePod, id]
-  );
-
-  const cutBegin = useStore(store, (state) => state.cutBegin);
-
-  const onCut = useCallback(
-    (clipboardData: any) => {
-      onCopy(clipboardData);
-      cutBegin(id);
-    },
-    [onCopy, cutBegin, id]
-  );
   const autoLayout = useStore(store, (state) => state.autoLayout);
 
   const zoomLevel = useReactFlowStore((s) => s.transform[2]);
@@ -134,33 +107,6 @@ function MyFloatingToolbar({ id }: { id: string }) {
             <ViewTimelineOutlinedIcon style={{ fontSize: iconFontSize }} />
           </IconButton>
         </Tooltip>
-      )}
-      {/* copy to clipbooard */}
-      <CopyToClipboard
-        text="dummy"
-        options={{ debug: true, format: "text/plain", onCopy } as any}
-      >
-        <Tooltip title="Copy">
-          <IconButton className="copy-button">
-            <ContentCopyIcon
-              style={{ fontSize: iconFontSize }}
-              className="copy-button"
-            />
-          </IconButton>
-        </Tooltip>
-      </CopyToClipboard>
-
-      {!isGuest && (
-        <CopyToClipboard
-          text="dummy"
-          options={{ debug: true, format: "text/plain", onCopy: onCut } as any}
-        >
-          <Tooltip title="Cut">
-            <IconButton>
-              <ContentCutIcon style={{ fontSize: iconFontSize }} />
-            </IconButton>
-          </Tooltip>
-        </CopyToClipboard>
       )}
       {!isGuest && (
         <Tooltip
@@ -214,7 +160,6 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const devMode = useStore(store, (state) => state.devMode);
-  const isCutting = useStore(store, (state) => state.cuttingIds.has(id));
   const cursorNode = useStore(store, (state) => state.cursorNode);
 
   useEffect(() => {
@@ -301,7 +246,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
       sx={{
         width: "100%",
         height: "100%",
-        border: isCutting ? "dashed 2px red" : "solid 1px #d6dee6",
+        border: "solid 1px #d6dee6",
         borderColor: selected ? "#003c8f" : undefined,
         borderRadius: "4px",
         cursor: "auto",

--- a/ui/src/components/nodes/extensions/link.tsx
+++ b/ui/src/components/nodes/extensions/link.tsx
@@ -186,13 +186,13 @@ function useUpdatePositionerOnMove() {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const moved = useStore(store, (state) => state.moved);
-  const clicked = useStore(store, (state) => state.clicked);
+  const paneClicked = useStore(store, (state) => state.paneClicked);
   useEffect(() => {
     forceUpdatePositioners();
   }, [moved]);
   useEffect(() => {
     emptySelection();
-  }, [clicked]);
+  }, [paneClicked]);
   return;
 }
 

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -839,6 +839,8 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
           //
           // TODO remove from codeMap and richMap?
           nodesMap.delete(change.id);
+          // remove from selected pods
+          get().selectPod(change.id, false);
           // run auto-layout
           if (get().autoRunLayout) {
             get().autoLayoutROOT();

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -299,8 +299,10 @@ export interface CanvasSlice {
   moved: boolean;
   toggleMoved: () => void;
   // clicked-on-canvas indicator
-  clicked: boolean;
-  toggleClicked: () => void;
+  paneClicked: boolean;
+  togglePaneClicked: () => void;
+  nodeClicked: boolean;
+  toggleNodeClicked: () => void;
 
   addNode: (
     type: "CODE" | "SCOPE" | "RICH",
@@ -878,8 +880,10 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
 
   moved: false,
   toggleMoved: () => set({ moved: !get().moved }),
-  clicked: false,
-  toggleClicked: () => set({ clicked: !get().clicked }),
+  paneClicked: false,
+  togglePaneClicked: () => set({ paneClicked: !get().paneClicked }),
+  nodeClicked: false,
+  toggleNodeClicked: () => set({ nodeClicked: !get().nodeClicked }),
 
   autoLayoutROOT: () => {
     // get all scopes,

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -586,7 +586,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
       "application/json",
       JSON.stringify({
         type: "pod",
-        data: nodes[0],
+        data: nodes,
       })
     );
     event.preventDefault();
@@ -603,23 +603,30 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     if (data.type !== "pod") return;
     // TODO support multiple pods
     // console.log("Paste data (should be a node)", data);
-    const oldnode = data.data as Node;
+    const oldnodes = data.data as Node[];
+
+    const minX = Math.min(...oldnodes.map((s) => s.position.x));
+    const minY = Math.min(...oldnodes.map((s) => s.position.y));
 
     // 3. construct new nodes
     const nodesMap = get().getNodesMap();
 
-    // If some pod is selected, paste to it at an offset. otherwise paste to the
-    // center of the screen
-    const newNode = {
-      ...oldnode,
-      id: myNanoId(),
-      position,
-    };
-
-    // 4. add them to the graph
-    nodesMap.set(newNode.id, newNode);
+    const newnodes = oldnodes.map((n) => {
+      const newNode = {
+        ...n,
+        id: myNanoId(),
+        position: {
+          x: n.position.x - minX + position.x,
+          y: n.position.y - minY + position.y,
+        },
+      };
+      return newNode;
+    });
     get().resetSelection();
-    get().selectPod(newNode.id, true);
+    newnodes.forEach((n) => {
+      nodesMap.set(n.id, n);
+      get().selectPod(n.id, true);
+    });
     get().updateView();
   },
 

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -612,11 +612,27 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
 
     // 3. construct new nodes
     const nodesMap = get().getNodesMap();
+    const codeMap = get().getCodeMap();
+    const richMap = get().getRichMap();
 
     const newnodes = oldnodes.map((n) => {
+      const id = myNanoId();
+      switch (n.type) {
+        case "CODE":
+          const ytext = new Y.Text(codeMap.get(n.id)!.toString());
+          codeMap.set(id, ytext);
+          break;
+        case "RICH":
+          const yxml = richMap.get(n.id)!.clone();
+          richMap.set(id, yxml);
+          break;
+        default:
+          break;
+      }
+
       const newNode = {
         ...n,
-        id: myNanoId(),
+        id,
         position: {
           x: n.position.x - minX + position.x,
           y: n.position.y - minY + position.y,

--- a/ui/src/lib/store/canvasSlice.tsx
+++ b/ui/src/lib/store/canvasSlice.tsx
@@ -284,6 +284,9 @@ export interface CanvasSlice {
   selectPod: (id: string, selected: boolean) => void;
   resetSelection: () => boolean;
 
+  handlePaste(event: ClipboardEvent, position: XYPosition): void;
+  handleCopy(event: ClipboardEvent): void;
+
   focusedEditor: string | undefined;
   setFocusedEditor: (id?: string) => void;
 
@@ -291,10 +294,6 @@ export interface CanvasSlice {
   setCursorNode: (id?: string) => void;
 
   updateView: () => void;
-
-  isPaneFocused: boolean;
-  setPaneFocus: () => void;
-  setPaneBlur: () => void;
 
   // onMove indicator
   moved: boolean;
@@ -315,26 +314,9 @@ export interface CanvasSlice {
     cellList: any[]
   ) => void;
 
-  pastingNodes?: Node[];
-  headPastingNodes?: Set<string>;
-  mousePos?: XYPosition | undefined;
-  isPasting: boolean;
-  pasteBegin: (position: XYPosition, pod: Pod, cutting: boolean) => void;
-  pasteEnd: (position: XYPosition, cutting: boolean) => void;
-  cancelPaste: (cutting: boolean) => void;
-  onPasteMove: (mousePos: XYPosition) => void;
-
-  isCutting: boolean;
-  cuttingIds: Set<string>;
-  cutBegin: (id: string) => void;
-  cutEnd: (position: XYPosition, reactFlowInstance: ReactFlowInstance) => void;
-  onCutMove: (mousePos: XYPosition) => void;
-  cancelCut: () => void;
-
   adjustLevel: () => void;
   getScopeAtPos: ({ x, y }: XYPosition, exclude: string) => Node | undefined;
   moveIntoScope: (nodeIds: string[], scopeId?: string) => void;
-  tempUpdateView: ({ x, y }: XYPosition) => void;
 
   helperLineHorizontal: number | undefined;
   helperLineVertical: number | undefined;
@@ -360,17 +342,6 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
 
   setDragHighlight: (dragHighlight) => set({ dragHighlight }),
   removeDragHighlight: () => set({ dragHighlight: undefined }),
-
-  // the nodes being cutting (on the top level)
-  cuttingIds: new Set(),
-  // all temporary nodes created during cutting/pasting
-  pastingNodes: [],
-  // the nodes being pasting (on the top level)
-  headPastingNodes: new Set(),
-  // current mouse position, used to update the pasting nodes on the top level when moving the mouse
-  mousePos: undefined,
-
-  isPaneFocused: false,
 
   selectedPods: new Set(),
   selectionParent: undefined,
@@ -444,14 +415,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
   updateView: () => {
     const nodesMap = get().getNodesMap();
     let selectedPods = get().selectedPods;
-    // We have different sources of nodes:
-    // 1. those from nodesMap, synced with other users
     let nodes = Array.from(nodesMap.values());
-    // We don't use clientId anymore to filter pasting nodes. Instead, we filter
-    // out the nodes that is being cutted. But for now, we are now hiding it,
-    // but giving it a "cutting" className to add a dashed red border.
-    //
-    // .filter((node) => node.id !== get().cuttingId)
     nodes = nodes
       .sort((a: Node, b: Node) => a.data.level - b.data.level)
       .map((node) => ({
@@ -467,17 +431,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
           .with(get().dragHighlight, () => "active")
           .otherwise(() => undefined),
       }));
-    // 2. show the temporary nodes, make the temporary nodes on the front-most
-    nodes = nodes.concat(get().pastingNodes || []);
 
-    const cursor = get().mousePos!;
-    const movingNodes = get().headPastingNodes;
-    if (cursor) {
-      nodes = nodes.map((node) =>
-        // update the position of top-level pasting nodes by the mouse position
-        movingNodes?.has(node.id) ? { ...node, position: cursor } : node
-      );
-    }
     set({ nodes });
     // edges view
     const edgesMap = get().getEdgesMap();
@@ -620,122 +574,53 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
   autoLayoutOnce: false,
   setAutoLayoutOnce: (b) => set({ autoLayoutOnce: b }),
 
-  isPasting: false,
-  isCutting: false,
-
-  pasteBegin: (position, pod, cutting = false) => {
-    // 1. create temporary nodes and pods
-    const nodes = createTemporaryNode(pod, position);
-    set({
-      // Only headPastingNodes moves with the mouse, because the other temporary nodes are children of the headPastingNodes.
-      // For now, we can have only one headPastingNode on the top level.
-      // TODO: support multiple headPastingNodes on the top level when implementing multi-select copy-paste
-      headPastingNodes: new Set([nodes[0][0].id]),
-      // Distinguish the state of cutting or pasting
-      isPasting: !cutting,
-      isCutting: cutting,
-      // But we need to keep all the temporary nodes in the pastingNodes list to render them.
-      pastingNodes: nodes.map(([node, pod]) => node),
-    });
-    get().updateView();
-  },
-  onPasteMove: (mousePos: XYPosition) => {
-    // When the mouse moves, only the top-level nodes move with the mouse. We don't have to update all the view.
-    get().tempUpdateView(mousePos);
-  },
-  pasteEnd: (position, cutting = false) => {
-    // on drop, make this node into nodesMap. The nodesMap.observer will updateView.
-    const leadingNodes = get().headPastingNodes;
-    const pastingNodes = get().pastingNodes;
-    if (!pastingNodes || !leadingNodes) return;
-    let nodesMap = get().getNodesMap();
-
-    // clear the temporary nodes and the pasting/cutting state
-    set(
-      produce((state: MyState) => {
-        state.pastingNodes = undefined;
-        state.headPastingNodes = new Set();
-        state.pastingNodes = [];
-        state.mousePos = undefined;
-        if (cutting) state.isCutting = false;
-        else state.isPasting = false;
+  handleCopy(event) {
+    // TODO get selected nodes recursively
+    const nodesMap = get().getNodesMap();
+    const nodes = Array.from(get().selectedPods).map((id) => nodesMap.get(id));
+    if (nodes.length === 0) return;
+    // TODO get edges
+    // set to clipboard
+    // console.log("set clipboard", nodes[0]);
+    event.clipboardData!.setData(
+      "application/json",
+      JSON.stringify({
+        type: "pod",
+        data: nodes[0],
       })
     );
+    event.preventDefault();
+  },
+  handlePaste(event, position) {
+    // 2. get clipboard data
+    if (!event.clipboardData) return;
+    const payload = event.clipboardData.getData("application/json");
+    if (!payload) {
+      console.warn("No payload");
+      return;
+    }
+    const data = JSON.parse(payload);
+    if (data.type !== "pod") return;
+    // TODO support multiple pods
+    // console.log("Paste data (should be a node)", data);
+    const oldnode = data.data as Node;
 
-    pastingNodes.forEach((node) => {
-      // insert all nodes to the yjs map
-      nodesMap.set(node.id, {
-        ...(leadingNodes?.has(node.id) ? { ...node, position } : node),
-        style: { ...node.style, opacity: 1 },
-        draggable: true,
-      });
-    });
-    // update view
+    // 3. construct new nodes
+    const nodesMap = get().getNodesMap();
+
+    // If some pod is selected, paste to it at an offset. otherwise paste to the
+    // center of the screen
+    const newNode = {
+      ...oldnode,
+      id: myNanoId(),
+      position,
+    };
+
+    // 4. add them to the graph
+    nodesMap.set(newNode.id, newNode);
+    get().resetSelection();
+    get().selectPod(newNode.id, true);
     get().updateView();
-
-    // check if the final position located in another scope
-    leadingNodes.forEach((id) => {
-      let scope = getScopeAt(
-        position.x,
-        position.y,
-        [id],
-        get().nodes,
-        nodesMap
-      );
-      if (scope && scope.id !== id) {
-        get().moveIntoScope([id], scope.id);
-      }
-    });
-  },
-  cancelPaste: (cutting = false) => {
-    const pastingNodes = get().pastingNodes || [];
-    set(
-      produce((state: MyState) => {
-        // Remove pastingNode from store.
-        state.pastingNodes = [];
-        state.headPastingNodes = new Set();
-        // Clear pasting data and update view.
-        state.pastingNodes = undefined;
-        state.mousePos = undefined;
-        if (cutting) state.isCutting = false;
-        else state.isPasting = false;
-      })
-    );
-    get().updateView();
-  },
-
-  //   checkDropIntoScope: (event, nodes: Node[], project: XYPosition=>XYPosition) => {},
-  // cut will:
-  // 1. hide the original node
-  // 2. create a dummy node that move with cursor
-  cutBegin: (id) => {
-    const pod = get().clonePod(id);
-    if (!pod) return;
-
-    // Store only the top-level cut nodes, for now, it contains only one element. But we will support multi-select cut-paste in the future.
-    set({ cuttingIds: new Set([id]) });
-    get().pasteBegin({ x: pod.x, y: pod.y }, pod, true);
-  },
-  onCutMove: (mousePos) => {
-    get().onPasteMove(mousePos);
-  },
-  // 3. on drop, delete the original node and create a new node
-  cutEnd: (position, reactFlowInstance) => {
-    const cuttingIds = get().cuttingIds;
-
-    if (!cuttingIds) return;
-
-    reactFlowInstance.deleteElements({
-      nodes: Array.from(cuttingIds).map((id) => ({ id })),
-    });
-
-    set({ cuttingIds: new Set() });
-
-    get().pasteEnd(position, true);
-  },
-  cancelCut: () => {
-    set({ cuttingIds: new Set() });
-    get().cancelPaste(true);
   },
 
   // NOTE: this does not mutate.
@@ -831,16 +716,6 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     get().adjustLevel();
     // update view
     get().updateView();
-  },
-
-  tempUpdateView: (position) => {
-    const movingNodes = get().headPastingNodes;
-    set({
-      mousePos: position,
-      nodes: get().nodes.map((node) =>
-        movingNodes?.has(node.id) ? { ...node, position } : node
-      ),
-    });
   },
 
   helperLineHorizontal: undefined,
@@ -993,8 +868,6 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     edgesMap.set(edge.id, edge);
     get().updateView();
   },
-  setPaneFocus: () => set({ isPaneFocused: true }),
-  setPaneBlur: () => set({ isPaneFocused: false }),
 
   moved: false,
   toggleMoved: () => set({ moved: !get().moved }),

--- a/ui/src/lib/store/podSlice.tsx
+++ b/ui/src/lib/store/podSlice.tsx
@@ -30,7 +30,6 @@ export interface PodSlice {
   setPodStdout: ({ id, stdout }: { id: string; stdout: string }) => void;
   setPodError: ({ id, ename, evalue, stacktrace }) => void;
   setPodStatus: ({ id, status, lang }) => void;
-  clonePod: (id: string) => any;
 }
 
 export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
@@ -78,16 +77,6 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
         // }
       })
     ),
-  clonePod: (id: string) => {
-    const nodesMap = get().getNodesMap();
-    const node = nodesMap.get(id);
-    const nodes = Array.from(nodesMap.values());
-    const children = nodes.filter((n) => n.parentNode === id);
-    return {
-      ...node,
-      children: children.map((child) => get().clonePod(child.id)),
-    };
-  },
   setPodResult({ id, type, content, count }) {
     const nodesMap = get().getNodesMap();
     const node = nodesMap.get(id);

--- a/ui/src/lib/store/repoStateSlice.tsx
+++ b/ui/src/lib/store/repoStateSlice.tsx
@@ -83,10 +83,8 @@ export interface RepoStateSlice {
   collaborators: any[];
   shareOpen: boolean;
   settingOpen: boolean;
-  cutting: string | null;
   setShareOpen: (open: boolean) => void;
   setSettingOpen: (open: boolean) => void;
-  setCutting: (id: string | null) => void;
   loadError: any;
   role: "OWNER" | "COLLABORATOR" | "GUEST";
   isPublic: boolean;
@@ -126,7 +124,6 @@ export const createRepoStateSlice: StateCreator<
   isPublic: false,
   shareOpen: false,
   settingOpen: false,
-  cutting: null,
   showLineNumbers: false,
   setSessionId: (id) => set({ sessionId: id }),
   addError: (error) => set({ error }),
@@ -194,7 +191,6 @@ export const createRepoStateSlice: StateCreator<
 
   setShareOpen: (open: boolean) => set({ shareOpen: open }),
   setSettingOpen: (open: boolean) => set({ settingOpen: open }),
-  setCutting: (id: string | null) => set({ cutting: id }),
   yjsConnecting: false,
   yjsStatus: undefined,
   yjsSyncStatus: undefined,


### PR DESCRIPTION
New behavior: 
1. select a pod,
2. `ctrl-c` to copy, and
3. `ctrl-v` to paste at the **current mouse position** (the same behavior in [reactflow's example](https://reactflow.dev/docs/examples/interaction/copy-and-paste/)).

TODOs:
- [x] support copying & pasting multiple pods
- [ ] support recursively copying scope pods
- [ ] copy connected edges as well
- [x] copy the content as well, both code and rich pods
- [ ] highlight newly copied pods to indicate that it's not moved into a scope yet
- [ ] support copying results