### PR TITLE
set partial selection mode

### DIFF
--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -28,6 +28,7 @@ import ReactFlow, {
   XYPosition,
   useStore as useRfStore,
   useKeyPress,
+  SelectionMode,
 } from "reactflow";
 import "reactflow/dist/style.css";
 
@@ -613,6 +614,7 @@ function CanvasImpl() {
           // disable node delete on backspace when the user is a guest.
           deleteKeyCode={isGuest ? null : "Backspace"}
           multiSelectionKeyCode={isMac ? "Meta" : "Control"}
+          selectionMode={SelectionMode.Partial}
           // TODO restore previous viewport
           defaultViewport={{ zoom: 1, x: 0, y: 0 }}
           proOptions={{ hideAttribution: true }}


### PR DESCRIPTION
Easier to drag select pods by dragging partially over them. Recall that drag select is holding shift, then drag a region.

![ezgif-1-e3f01bed83](https://github.com/codepod-io/codepod/assets/4576201/3a54b764-0781-4095-a235-2732b944f871)
