### PR TITLE
[UI] Fix ToC failure due to empty node2children

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -1257,7 +1257,7 @@ function TableofPods() {
       )}
       multiSelect
     >
-      {node2children &&
+      {node2children.size > 0 &&
         node2children!
           .get("ROOT")!
           .map((child) => (


### PR DESCRIPTION
## Summary

When creating a new project, the `ToC` is failed to render due to empty `node2children`

