### PR TITLE
remove CursorNode, fix pod center-on-selection

### DIFF
--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -398,7 +398,6 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const wsRun = useStore(store, (state) => state.wsRun);
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
-  const setCursorNode = useStore(store, (state) => state.setCursorNode);
   const annotations = useStore(
     store,
     (state) => state.parseResult[id]?.annotations
@@ -496,8 +495,8 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
       run: () => {
         if (document.activeElement) {
           (document.activeElement as any).blur();
-          setCursorNode(id);
           setFocusedEditor(undefined);
+          resetSelection();
           selectPod(id, true);
         }
       },

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -1185,7 +1185,12 @@ function ExportButtons() {
 function PodTreeItem({ id, node2children }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const setCursorNode = useStore(store, (state) => state.setCursorNode);
+  const selectPod = useStore(store, (state) => state.selectPod);
+  const resetSelection = useStore(store, (state) => state.resetSelection);
+  const setCenterSelection = useStore(
+    store,
+    (state) => state.setCenterSelection
+  );
 
   if (!node2children.has(id)) return null;
   const children = node2children.get(id);
@@ -1195,7 +1200,9 @@ function PodTreeItem({ id, node2children }) {
       nodeId={id}
       label={id.substring(0, 8)}
       onClick={() => {
-        setCursorNode(id);
+        resetSelection();
+        selectPod(id, true);
+        setCenterSelection(true);
       }}
     >
       {children.length > 0 &&

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -523,7 +523,6 @@ export const CodeNode = memo<NodeProps>(function ({
     };
   }, shallow);
   const isGuest = useStore(store, (state) => state.role === "GUEST");
-  const cursorNode = useStore(store, (state) => state.cursorNode);
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -549,14 +548,6 @@ export const CodeNode = memo<NodeProps>(function ({
       }
     }
   }, [layout]);
-
-  useEffect(() => {
-    if (cursorNode === id) {
-      setShowToolbar(true);
-    } else {
-      setShowToolbar(false);
-    }
-  }, [cursorNode]);
 
   const onResizeStop = useCallback(
     (e, data) => {

--- a/ui/src/components/nodes/Rich.tsx
+++ b/ui/src/components/nodes/Rich.tsx
@@ -256,14 +256,14 @@ const MyStyledWrapper = styled("div")(
 function HotkeyControl({ id }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const setCursorNode = useStore(store, (state) => state.setCursorNode);
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const selectPod = useStore(store, (state) => state.selectPod);
+  const resetSelection = useStore(store, (state) => state.resetSelection);
 
   useKeymap("Escape", () => {
-    setCursorNode(id);
     setFocusedEditor(undefined);
+    resetSelection();
     selectPod(id, true);
     return true;
   });
@@ -540,7 +540,6 @@ export const RichNode = memo<Props>(function ({
   // const pod = useStore(store, (state) => state.pods[id]);
   const setPodName = useStore(store, (state) => state.setPodName);
   const isGuest = useStore(store, (state) => state.role === "GUEST");
-  const cursorNode = useStore(store, (state) => state.cursorNode);
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
 
@@ -612,14 +611,6 @@ export const RichNode = memo<Props>(function ({
     store,
     (state) => state.contextualZoomParams.threshold
   );
-
-  useEffect(() => {
-    if (cursorNode === id) {
-      setShowToolbar(true);
-    } else {
-      setShowToolbar(false);
-    }
-  }, [cursorNode]);
 
   const node = nodesMap.get(id);
   if (!node) return null;

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -160,7 +160,6 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const devMode = useStore(store, (state) => state.devMode);
-  const cursorNode = useStore(store, (state) => state.cursorNode);
 
   useEffect(() => {
     if (!data.name) return;
@@ -171,14 +170,6 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
   }, [data.name, id, setPodName]);
 
   const [showToolbar, setShowToolbar] = useState(false);
-
-  useEffect(() => {
-    if (cursorNode === id) {
-      setShowToolbar(true);
-    } else {
-      setShowToolbar(false);
-    }
-  }, [cursorNode]);
 
   const { width, height, parent } = useReactFlowStore((s) => {
     const node = s.nodeInternals.get(id)!;

--- a/ui/src/lib/store/canvasSlice.ts
+++ b/ui/src/lib/store/canvasSlice.ts
@@ -285,15 +285,14 @@ export interface CanvasSlice {
   selectionParent: string | undefined;
   selectPod: (id: string, selected: boolean) => void;
   resetSelection: () => boolean;
+  centerSelection: boolean;
+  setCenterSelection: (b: boolean) => void;
 
   handlePaste(event: ClipboardEvent, position: XYPosition): void;
   handleCopy(event: ClipboardEvent): void;
 
   focusedEditor: string | undefined;
   setFocusedEditor: (id?: string) => void;
-
-  cursorNode: string | undefined;
-  setCursorNode: (id?: string) => void;
 
   updateView: () => void;
 
@@ -383,6 +382,10 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     );
     return true;
   },
+  centerSelection: false,
+  setCenterSelection(b: boolean) {
+    set({ centerSelection: b });
+  },
 
   focusedEditor: undefined,
   setFocusedEditor: (id?: string) =>
@@ -392,13 +395,6 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
       })
     ),
 
-  cursorNode: undefined,
-  setCursorNode: (id?: string) =>
-    set(
-      produce((state: MyState) => {
-        state.cursorNode = id;
-      })
-    ),
   getNodesMap() {
     return get().ydoc.getMap("rootMap").get("nodesMap") as Y.Map<
       Node<NodeData>
@@ -902,9 +898,6 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
           throw new Error("Add node should not be handled here");
         case "select":
           get().selectPod(change.id, change.selected);
-          if (change.selected) {
-            get().setCursorNode(change.id);
-          }
           break;
         case "dimensions":
           {


### PR DESCRIPTION
Two changes:
- #458 introduced a changing behavior: selecting a pod will trigger a centering event. This PR removes that behavior. Centering event is triggered by `state.setCenterSelection(true)`
- `state.CursorNode` (introduced in #431) has been confusing with `state.SelectedPods`. We mentioned that we want to unify the two in https://github.com/codepod-io/codepod/pull/431#issuecomment-1665767266. Therefore, this PR removes `CursorNode` to use only `SelectedPods`.