### PR TITLE
refactor: remove stdout/stderr in results

### DIFF
--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -87,7 +87,6 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
   const store = useContext(RepoContext)!;
   const results = useStore(store, (state) => state.podResults[id]?.result);
   const error = useStore(store, (state) => state.podResults[id]?.error);
-  const stdout = useStore(store, (state) => state.podResults[id]?.stdout);
   const running = useStore(
     store,
     (state) => state.podResults[id]?.running || false
@@ -119,9 +118,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
     (state) =>
       state.podResults[id]?.running ||
       state.podResults[id]?.result ||
-      state.podResults[id]?.error ||
-      state.podResults[id]?.stdout ||
-      state.podResults[id]?.stderr
+      state.podResults[id]?.error
   );
   const [resultScroll, setResultScroll] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
@@ -217,7 +214,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
           maxHeight="1000px"
           border="1px"
         >
-          {(stdout || exec_count || error) && showMenu && (
+          {(exec_count || error) && showMenu && (
             <ButtonGroup
               sx={{
                 // border: '1px solid #757ce8',
@@ -274,14 +271,6 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
             </ButtonGroup>
           )}
 
-          {stdout && (
-            <Box
-              whiteSpace="pre-wrap"
-              sx={{ fontSize: "0.8em", paddingBottom: 1 }}
-            >
-              <Ansi>{stdout}</Ansi>
-            </Box>
-          )}
           {results && results.length > 0 && (
             <Box
               sx={{

--- a/ui/src/lib/store/podSlice.ts
+++ b/ui/src/lib/store/podSlice.ts
@@ -16,8 +16,6 @@ type PodResult = {
   }[];
   running?: boolean;
   lastExecutedAt?: Date;
-  stdout?: string;
-  stderr?: string;
   error?: { ename: string; evalue: string; stacktrace: string[] } | null;
 };
 
@@ -27,7 +25,6 @@ export interface PodSlice {
   podNames: Record<string, string>;
   setPodName: ({ id, name }: { id: string; name: string }) => void;
   setPodResult: ({ id, type, content, count }) => void;
-  setPodStdout: ({ id, stdout }: { id: string; stdout: string }) => void;
   setPodError: ({ id, ename, evalue, stacktrace }) => void;
   setPodStatus: ({ id, status, lang }) => void;
 }
@@ -42,14 +39,6 @@ export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
     set(
       produce((state: MyState) => {
         state.podNames[id] = name;
-      })
-    );
-  },
-  setPodStdout: ({ id, stdout }) => {
-    get().ensureResult(id);
-    set(
-      produce((state: MyState) => {
-        state.podResults[id].stdout = stdout;
       })
     );
   },

--- a/ui/src/lib/store/runtimeSlice.ts
+++ b/ui/src/lib/store/runtimeSlice.ts
@@ -641,15 +641,6 @@ function onMessage(set, get: () => MyState) {
     let { type, payload } = JSON.parse(msg.data || msg.body || undefined);
     console.debug("got message", type, payload);
     switch (type) {
-      case "output":
-        console.log("output:", payload);
-        break;
-      case "stdout":
-        {
-          let { podId, stdout } = payload;
-          get().setPodStdout({ id: podId, stdout });
-        }
-        break;
       case "stream":
         {
           let { podId, content } = payload;
@@ -714,7 +705,7 @@ function onMessage(set, get: () => MyState) {
         get().wsRequestStatus({ lang: payload.lang });
         break;
       default:
-        console.log("WARNING unhandled message", { type, payload });
+        console.warn("WARNING unhandled message", { type, payload });
     }
   };
 }


### PR DESCRIPTION
A minor refactor to remove deprecated `stdout`/`stderr`, as they are handled and saved in `stream` type.