### PR TITLE
feat: put runtime behind yjs

### DIFF
--- a/api/src/resolver.ts
+++ b/api/src/resolver.ts
@@ -2,6 +2,7 @@ import UserResolver from "./resolver_user";
 import RepoResolver from "./resolver_repo";
 import RuntimeResolver from "./resolver_runtime";
 import ExportResolver from "./resolver_export";
+import YjsResolver from "./resolver_yjs";
 
 export const resolvers = {
   Query: {
@@ -12,11 +13,13 @@ export const resolvers = {
     ...RepoResolver.Query,
     ...RuntimeResolver.Query,
     ...ExportResolver.Query,
+    ...YjsResolver.Query,
   },
   Mutation: {
     ...UserResolver.Mutation,
     ...RepoResolver.Mutation,
     ...RuntimeResolver.Mutation,
     ...ExportResolver.Mutation,
+    ...YjsResolver.Mutation,
   },
 };

--- a/api/src/resolver_yjs.ts
+++ b/api/src/resolver_yjs.ts
@@ -1,0 +1,69 @@
+import { ApolloClient, InMemoryCache, gql } from "@apollo/client/core";
+
+const apollo_client = new ApolloClient({
+  cache: new InMemoryCache({}),
+  //   uri: process.env.PROXY_API_URL,
+  uri: "http://yjs-server:4011/graphql",
+});
+
+export default {
+  Query: {},
+  Mutation: {
+    connectRuntime: async (_, { runtimeId, repoId }) => {
+      // send this to yjs-server graphql endpoint
+      console.log("connectRuntime", runtimeId, repoId);
+      apollo_client.mutate({
+        mutation: gql`
+          mutation ConnectRuntime($runtimeId: String, $repoId: String) {
+            connectRuntime(runtimeId: $runtimeId, repoId: $repoId)
+          }
+        `,
+        variables: { runtimeId: runtimeId, repoId: repoId },
+      });
+    },
+    runCode: async (_, { spec, runtimeId }) => {
+      // relay this to yjs-server graphql endpoint
+      apollo_client.mutate({
+        mutation: gql`
+          mutation RunCode($runtimeId: String, $spec: RunSpecInput) {
+            runCode(runtimeId: $runtimeId, spec: $spec)
+          }
+        `,
+        variables: { spec, runtimeId },
+      });
+    },
+    runChain: async (_, { specs, runtimeId }) => {
+      // relay this to yjs-server graphql endpoint
+      apollo_client.mutate({
+        mutation: gql`
+          mutation RunChain($specs: [RunSpecInput], $runtimeId: String) {
+            runChain(specs: $specs, runtimeId: $runtimeId)
+          }
+        `,
+        variables: { specs, runtimeId },
+      });
+    },
+    interruptKernel: async (_, { runtimeId }) => {
+      // relay this to yjs-server graphql endpoint
+      apollo_client.mutate({
+        mutation: gql`
+          mutation InterruptKernel($runtimeId: String) {
+            interruptKernel(runtimeId: $runtimeId)
+          }
+        `,
+        variables: { runtimeId: runtimeId },
+      });
+    },
+    requestKernelStatus: async (_, { runtimeId }) => {
+      // relay this to yjs-server graphql endpoint
+      apollo_client.mutate({
+        mutation: gql`
+          mutation RequestKernelStatus($runtimeId: String) {
+            requestKernelStatus(runtimeId: $runtimeId)
+          }
+        `,
+        variables: { runtimeId: runtimeId },
+      });
+    },
+  },
+};

--- a/api/src/typedefs.ts
+++ b/api/src/typedefs.ts
@@ -94,6 +94,11 @@ export const typeDefs = gql`
     ttl: Int
   }
 
+  input RunSpecInput {
+    code: String
+    podId: String
+  }
+
   type Query {
     hello: String
     users: [User]
@@ -138,5 +143,11 @@ export const typeDefs = gql`
     exportJSON(repoId: String!): String!
     exportFile(repoId: String!): String!
     updateCodeiumAPIKey(apiKey: String!): Boolean
+
+    connectRuntime(runtimeId: String, repoId: String): Boolean
+    runCode(runtimeId: String, spec: RunSpecInput): Boolean
+    runChain(runtimeId: String, specs: [RunSpecInput]): Boolean
+    interruptKernel(runtimeId: String): Boolean
+    requestKernelStatus(runtimeId: String): Boolean
   }
 `;

--- a/api/src/yjs-blob.ts
+++ b/api/src/yjs-blob.ts
@@ -24,6 +24,7 @@ import debounce from "lodash/debounce";
 
 import prisma from "./client";
 import { dbtype2nodetype, json2yxml } from "./yjs-utils";
+import { setupObserversToRuntime } from "./yjs-runtime";
 
 const debounceRegistry = new Map<string, any>();
 /**
@@ -40,9 +41,11 @@ function getDebouncedCallback(key) {
           console.log("debounced callback for", key);
           cb();
         },
-        1000,
+        // write if no new activity in 10s
+        10000,
         {
-          maxWait: 2000,
+          // write at least every 20s
+          maxWait: 20000,
         }
       )
     );
@@ -152,6 +155,7 @@ export async function bindState(doc: Y.Doc, repoId: string) {
   await loadFromDB(doc, repoId);
   // Observe changes and write to the database.
   setupObserversToDB(doc, repoId);
+  setupObserversToRuntime(doc, repoId);
 }
 
 export function writeState() {

--- a/api/src/yjs-runtime.ts
+++ b/api/src/yjs-runtime.ts
@@ -1,0 +1,253 @@
+import * as Y from "yjs";
+import WebSocket from "ws";
+
+import runtimeResolver from "./resolver_runtime";
+
+type PodResult = {
+  exec_count?: number;
+  last_exec_end?: boolean;
+  data: {
+    type: string;
+    html?: string;
+    text?: string;
+    image?: string;
+  }[];
+  running?: boolean;
+  lastExecutedAt?: Date;
+  error?: { ename: string; evalue: string; stacktrace: string[] } | null;
+};
+
+type RuntimeInfo = {
+  status?: string;
+  wsStatus?: string;
+};
+
+export const runtime2socket = new Map<string, WebSocket>();
+
+export async function setupRuntimeSocket({
+  socket,
+  sessionId,
+  runtimeMap,
+  resultMap,
+}: {
+  resultMap: Y.Map<PodResult>;
+  runtimeMap: Y.Map<RuntimeInfo>;
+  sessionId: string;
+  socket: WebSocket;
+}) {
+  console.log("--- setupRuntimeSocket", sessionId);
+  socket.onopen = () => {
+    console.log("socket connected for runtime", sessionId);
+    runtimeMap.set(sessionId, {
+      wsStatus: "connected",
+    });
+    runtime2socket.set(sessionId, socket);
+    // request kernel status
+    socket.send(
+      JSON.stringify({
+        type: "requestKernelStatus",
+        payload: {
+          sessionId,
+        },
+      })
+    );
+  };
+  socket.onclose = () => {
+    console.log("Socket closed for runtime", sessionId);
+    runtimeMap.set(sessionId, {
+      wsStatus: "disconnected",
+    });
+    runtime2socket.delete(sessionId);
+  };
+  socket.onerror = (err) => {
+    console.error("[ERROR] Got error", err.message);
+    // if error is 404, try create the kernel
+  };
+  socket.onmessage = (msg) => {
+    // FIXME is msg.data a string?
+    let { type, payload } = JSON.parse(msg.data as string);
+    // console.debug("got message", type, payload);
+
+    switch (type) {
+      case "stream":
+        {
+          let { podId, content } = payload;
+          const oldresult: PodResult = resultMap.get(podId) || { data: [] };
+          // FIXME if I modify the object, would it modify resultMap as well?
+          oldresult.data.push({
+            type: `${type}_${content.name}`,
+            text: content.text,
+          });
+          resultMap.set(podId, oldresult);
+        }
+        break;
+      case "execute_result":
+        {
+          let { podId, content, count } = payload;
+          const oldresult: PodResult = resultMap.get(podId) || { data: [] };
+          oldresult.data.push({
+            type,
+            text: content.data["text/plain"],
+          });
+          resultMap.set(podId, oldresult);
+        }
+        break;
+      case "display_data":
+        {
+          let { podId, content } = payload;
+          const oldresult: PodResult = resultMap.get(podId) || { data: [] };
+          oldresult.data.push({
+            type,
+            text: content.data["text/plain"],
+            image: content.data["image/png"],
+          });
+          resultMap.set(podId, oldresult);
+        }
+        break;
+      case "execute_reply":
+        {
+          let { podId, result, count } = payload;
+          const oldresult: PodResult = resultMap.get(podId) || { data: [] };
+          oldresult.running = false;
+          oldresult.lastExecutedAt = new Date();
+          oldresult.exec_count = count;
+          resultMap.set(podId, oldresult);
+        }
+        break;
+      case "error":
+        {
+          let { podId, ename, evalue, stacktrace } = payload;
+          const oldresult: PodResult = resultMap.get(podId) || { data: [] };
+          oldresult.error = { ename, evalue, stacktrace };
+        }
+        break;
+      case "status":
+        {
+          const { lang, status, id } = payload;
+          // listen to messages
+          runtimeMap.set(sessionId, { ...runtimeMap.get(sessionId), status });
+        }
+        break;
+      case "interrupt_reply":
+        // console.log("got interrupt_reply", payload);
+        break;
+      default:
+        console.warn("WARNING unhandled message", { type, payload });
+    }
+  };
+}
+
+/**
+ * Get the active socket. Create if not connected.
+ */
+export async function connectSocket({
+  runtimeId,
+  runtimeMap,
+  resultMap,
+}: {
+  runtimeId: string;
+  runtimeMap: Y.Map<RuntimeInfo>;
+  resultMap: Y.Map<PodResult>;
+}) {
+  const runtime = runtimeMap.get(runtimeId)!;
+  switch (runtime.wsStatus) {
+    case "connecting":
+      console.log("socket was connecting, skip");
+      return;
+    case "connected":
+      console.log("socket was connected, skip");
+      return;
+    case "disconnected":
+    case undefined:
+      {
+        runtimeMap.set(runtimeId, {
+          ...runtime,
+          wsStatus: "connecting",
+        });
+        let socket = new WebSocket(`ws://proxy:4010/${runtimeId}`);
+        await setupRuntimeSocket({
+          socket,
+          sessionId: runtimeId,
+          runtimeMap,
+          resultMap,
+        });
+      }
+      break;
+    default:
+      throw new Error(`unknown wsStatus ${runtime.wsStatus}`);
+  }
+}
+
+/**
+ * Observe the runtime status info, talk to runtime servver, and update the result.
+ */
+export function setupObserversToRuntime(ydoc: Y.Doc, repoId: string) {
+  const rootMap = ydoc.getMap("rootMap");
+  if (rootMap.get("runtimeMap") === undefined) {
+    rootMap.set("runtimeMap", new Y.Map<RuntimeInfo>());
+  }
+  if (rootMap.get("resultMap") === undefined) {
+    rootMap.set("resultMap", new Y.Map<PodResult>());
+  }
+  const runtimeMap = rootMap.get("runtimeMap") as Y.Map<RuntimeInfo>;
+  // clear runtimeMap status/commands but keep the ID
+  for (let key of runtimeMap.keys()) {
+    runtimeMap.set(key, {});
+  }
+  const resultMap = rootMap.get("resultMap") as Y.Map<PodResult>;
+  runtimeMap.observe(
+    async (ymapEvent: Y.YMapEvent<RuntimeInfo>, transaction: Y.Transaction) => {
+      if (transaction.local) {
+        return;
+      }
+      ymapEvent.changes.keys.forEach(async (change, runtimeId) => {
+        if (change.action === "add") {
+          console.log(
+            `Property "${runtimeId}" was added. Initial value: "${runtimeMap.get(
+              runtimeId
+            )}".`
+          );
+          const runtime = runtimeMap.get(runtimeId)!;
+          console.log(
+            "TODO create runtime",
+            runtimeId,
+            runtimeMap.get(runtimeId)
+          );
+          const sessionId = runtimeId;
+          const created = await runtimeResolver.Mutation.spawnRuntime(null, {
+            sessionId,
+          });
+          if (!created) {
+            // throw new Error("Failed to create runtime");
+            console.error("Failed to create runtime");
+          }
+          // create socket
+          //
+          // FIXME it takes time to create the socket, so we need to wait for a
+          // while, so we need to keep trying to connect. Currently the re-try
+          // logic is done in the frontend.
+          //
+          // TODO in the future, we need to either attach a callback to the
+          // spawner. When the runtime is ready, it should menifest itself.
+          //
+          // await connectSocket({ runtimeId: sessionId, runtimeMap, resultMap
+          // });
+          //
+          // try an interval
+        } else if (change.action === "update") {
+          // NO OP
+        } else if (change.action === "delete") {
+          // FIXME make sure the runtime is deleted.
+          console.log("delete runtime", runtimeId, change.oldValue);
+          // kill the runtime
+          const socket = runtime2socket.get(runtimeId);
+          socket?.close();
+          await runtimeResolver.Mutation.killRuntime(null, {
+            sessionId: runtimeId,
+          });
+          runtime2socket.delete(runtimeId);
+        }
+      });
+    }
+  );
+}

--- a/compose/dev/compose.yml
+++ b/compose/dev/compose.yml
@@ -63,10 +63,29 @@ services:
     volumes:
       - ../../api:/app
       - api-node-modules:/app/node_modules
+      - /var/run/docker.sock:/var/run/docker.sock
     command: sh -c "yarn && yarn dev:yjs"
     environment:
       DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public"
       JWT_SECRET: ${JWT_SECRET}
+      # TODO move kernel spawner to proxy server
+      KERNEL_NETWORK: "codepod"
+      PROXY_API_URL: "http://proxy:4011/graphql"
+      ZMQ_KERNEL_IMAGE: "lihebi/codepod-kernel-python:latest"
+      WS_RUNTIME_IMAGE: "lihebi/codepod-runtime:latest"
+      # Set PROJECT_ROOT to the absolute path of your codepod local repo if you
+      # want to debug the runtime code.
+      #
+      # PROJECT_ROOT: "/path/to/codepod"
+
+      # 1000 * 60 * 3: 3 minutes
+      # KERNEL_TTL: "180000"
+      # 1000 * 60 * 60 * 12: 12 hours
+      KERNEL_TTL: "43200000"
+      # 1000 * 5: 5 seconds
+      # LOOP_INTERVAL: "5000"
+      # 1000 * 60 * 1: 1 minute 
+      LOOP_INTERVAL: "60000"
 
   ui:
     image: node:18

--- a/proxy/src/node-proxy.ts
+++ b/proxy/src/node-proxy.ts
@@ -310,6 +310,16 @@ function startProxyServer() {
     activeTable[req.url] = new Date();
     let match = await getRouteTarget(req);
     if (!match) {
+      console.error("Not match!");
+      // respond to socket
+      socket.write(
+        "HTTP/1.1 404 Not Found\r\n" +
+          "Connection: close\r\n" +
+          "Content-type: text/html\r\n" +
+          "\r\n" +
+          "<html><head></head><body>Not Found</body></html>"
+      );
+      console.log("Finish write no match.");
       return;
     }
     console.log("target", `http://${match.target}`);

--- a/ui/src/components/Canvas.tsx
+++ b/ui/src/components/Canvas.tsx
@@ -153,8 +153,7 @@ function useJump() {
   const resetSelection = useStore(store, (state) => state.resetSelection);
   const selectPod = useStore(store, (state) => state.selectPod);
 
-  const wsRun = useStore(store, (state) => state.wsRun);
-  const wsRunScope = useStore(store, (state) => state.wsRunScope);
+  const yjsRun = useStore(store, (state) => state.yjsRun);
 
   const setCenterSelection = useStore(
     store,
@@ -188,10 +187,10 @@ function useJump() {
     }
 
     // get the sibling nodes
-    const siblings = Array.from(nodesMap.values()).filter(
+    const siblings = Array.from<Node>(nodesMap.values()).filter(
       (node) => node.parentNode === pod.parentNode
     );
-    const children = Array.from(nodesMap.values()).filter(
+    const children = Array.from<Node>(nodesMap.values()).filter(
       (node) => node.parentNode === id
     );
 
@@ -244,7 +243,7 @@ function useJump() {
         if (pod.type == "CODE") {
           if (event.shiftKey) {
             // Hitting "SHIFT"+"Enter" will run the code pod
-            wsRun(id);
+            yjsRun(id);
           } else {
             // Hitting "Enter" on a Code pod will go to "Edit" mode.
             setFocusedEditor(id);
@@ -252,7 +251,7 @@ function useJump() {
         } else if (pod.type === "SCOPE") {
           if (event.shiftKey) {
             // Hitting "SHIFT"+"Enter" on a Scope will run the scope.
-            wsRunScope(id);
+            yjsRun(id);
           }
         } else if (pod.type === "RICH") {
           // Hitting "Enter" on a Rich pod will go to "Edit" mode.

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -394,8 +394,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const readOnly = useStore(store, (state) => state.role === "GUEST");
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
-  const clearResults = useStore(store, (s) => s.clearResults);
-  const wsRun = useStore(store, (state) => state.wsRun);
+  const yjsRun = useStore(store, (state) => state.yjsRun);
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const annotations = useStore(
@@ -484,8 +483,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
       label: "Run",
       keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.Enter],
       run: () => {
-        clearResults(id);
-        wsRun(id);
+        yjsRun(id);
       },
     });
     editor.addAction({

--- a/ui/src/components/nodes/Code.tsx
+++ b/ui/src/components/nodes/Code.tsx
@@ -84,47 +84,33 @@ function Timer({ lastExecutedAt }) {
 }
 
 export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
-  const store = useContext(RepoContext)!;
-  const results = useStore(store, (state) => state.podResults[id]?.result);
-  const error = useStore(store, (state) => state.podResults[id]?.error);
-  const running = useStore(
-    store,
-    (state) => state.podResults[id]?.running || false
-  );
-  const exec_count = useStore(
-    store,
-    (state) => state.podResults[id]?.exec_count
-  );
-  const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
-  const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
-
-  const prevRunning = useRef(false);
-  useEffect(() => {
-    if (autoRunLayout) {
-      if (prevRunning.current != running) {
-        autoLayoutROOT();
-        prevRunning.current = running;
-      }
-    }
-  }, [running]);
-
-  const lastExecutedAt = useStore(
-    store,
-    (state) => state.podResults[id]?.lastExecutedAt
-  );
   const [showOutput, setShowOutput] = useState(true);
-  const hasResult = useStore(
-    store,
-    (state) =>
-      state.podResults[id]?.running ||
-      state.podResults[id]?.result ||
-      state.podResults[id]?.error
-  );
   const [resultScroll, setResultScroll] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
+
+  const store = useContext(RepoContext)!;
+  // TODO run autolayout after result change.
+  // TODO run autolayout when pod size changes caused by content change.
+  const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
+  const autoRunLayout = useStore(store, (state) => state.autoRunLayout);
   const clearResults = useStore(store, (state) => state.clearResults);
-  const result = results ? results[0] : undefined;
-  if (!hasResult) return <></>;
+  // monitor result change
+  // FIXME performance: would this trigger re-render of all pods?
+  const resultChanged = useStore(store, (state) => state.resultChanged[id]);
+  // This is a dummy useEffect to indicate resultChanged is used.
+  useEffect(() => {}, [resultChanged]);
+  const resultMap = useStore(store, (state) => state.getResultMap());
+  const result = resultMap.get(id);
+  if (!result) {
+    return null;
+  }
+  const results = result.data;
+  const error = result.error;
+  const running = result.running;
+  const exec_count = result.exec_count;
+
+  const lastExecutedAt = result.lastExecutedAt;
+
   return (
     <Box
       onMouseEnter={() => setShowMenu(true)}
@@ -156,56 +142,42 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
         cursor: "auto",
       }}
     >
-      {result && (
-        <Box sx={{ display: "flex", flexDirection: "column" }}>
-          {result.html ? (
-            <div dangerouslySetInnerHTML={{ __html: result.html }}></div>
-          ) : (
-            <>
-              {lastExecutedAt && !error && (
-                <Box
-                  color="rgb(0, 183, 87)"
-                  sx={{
-                    padding: "6px",
-                    zIndex: 200,
-                  }}
-                >
-                  <Box
-                    sx={{
-                      fontWeight: 500,
-                      position: "absolute",
-                      padding: "0 5px",
-                      backgroundColor: "rgb(255, 255, 255)",
-                      top: "-13.5px",
-                      left: "15px",
-                      height: "15px",
-                      borderWidth: "1px",
-                      borderStyle: "solid",
-                      borderColor:
-                        "rgb(214, 222, 230) rgb(214, 222, 230) rgb(255, 255, 255)",
-                      borderImage: "initial",
-                      borderTopLeftRadius: "20px",
-                      borderTopRightRadius: "20px",
-                      // FIXME: Why not a complete oval?
-                      // borderBottomLeftRadius: "20px",
-                      // borderBottomRightRadius: "20px",
-                      display: "flex",
-                      fontSize: "0.8em",
-                    }}
-                  >
-                    <CheckCircleIcon
-                      style={{ marginTop: "5px" }}
-                      fontSize="inherit"
-                    />{" "}
-                    <Timer lastExecutedAt={lastExecutedAt} />
-                  </Box>
-                </Box>
-              )}
-            </>
-          )}
+      {lastExecutedAt && !error && (
+        <Box
+          color="rgb(0, 183, 87)"
+          sx={{
+            padding: "6px",
+            zIndex: 200,
+          }}
+        >
+          <Box
+            sx={{
+              fontWeight: 500,
+              position: "absolute",
+              padding: "0 5px",
+              backgroundColor: "rgb(255, 255, 255)",
+              top: "-13.5px",
+              left: "15px",
+              height: "15px",
+              borderWidth: "1px",
+              borderStyle: "solid",
+              borderColor:
+                "rgb(214, 222, 230) rgb(214, 222, 230) rgb(255, 255, 255)",
+              borderImage: "initial",
+              borderTopLeftRadius: "20px",
+              borderTopRightRadius: "20px",
+              // FIXME: Why not a complete oval?
+              // borderBottomLeftRadius: "20px",
+              // borderBottomRightRadius: "20px",
+              display: "flex",
+              fontSize: "0.8em",
+            }}
+          >
+            <CheckCircleIcon style={{ marginTop: "5px" }} fontSize="small" />{" "}
+            <Timer lastExecutedAt={lastExecutedAt} />
+          </Box>
         </Box>
       )}
-
       {running && <CircularProgress />}
       {showOutput ? (
         <Box
@@ -271,6 +243,19 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
             </ButtonGroup>
           )}
 
+          {exec_count && (
+            <Box
+              sx={{
+                color: "#8b8282",
+                textAlign: "left",
+                paddingLeft: "5px",
+                fontSize: "12px",
+              }}
+            >
+              [{exec_count}]
+            </Box>
+          )}
+
           {results && results.length > 0 && (
             <Box
               sx={{
@@ -307,6 +292,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                       </Box>
                     );
                   case "display_data":
+                    // TODO html results
                     return (
                       <Box
                         component="pre"
@@ -336,19 +322,8 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
                         {res.text}
                       </Box>
                     );
-                  case "execute_reply":
-                    if (i == 0) {
-                      return (
-                        <Box
-                          component="pre"
-                          whiteSpace="pre-wrap"
-                          key={combinedKey}
-                          sx={{ fontSize: "0.8em", margin: 0, padding: 0 }}
-                        >
-                          {res.text}
-                        </Box>
-                      );
-                    }
+                  default:
+                    return <Box key="unknown">[WARN] Unknown Result</Box>;
                 }
               })}
             </Box>
@@ -408,8 +383,8 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
   const reactFlowInstance = useReactFlow();
   const devMode = useStore(store, (state) => state.devMode);
   // const pod = useStore(store, (state) => state.pods[id]);
-  const wsRun = useStore(store, (state) => state.wsRun);
-  const wsRunChain = useStore(store, (state) => state.wsRunChain);
+  const yjsRun = useStore(store, (state) => state.yjsRun);
+  const yjsRunChain = useStore(store, (state) => state.yjsRunChain);
   // right, bottom
   const isGuest = useStore(store, (state) => state.role === "GUEST");
 
@@ -435,7 +410,7 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
         <Tooltip title="Run (shift-enter)">
           <IconButton
             onClick={() => {
-              wsRun(id);
+              yjsRun(id);
             }}
           >
             <PlayCircleOutlineIcon style={{ fontSize: iconFontSize }} />
@@ -446,7 +421,7 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
         <Tooltip title="Run chain">
           <IconButton
             onClick={() => {
-              wsRunChain(id);
+              yjsRunChain(id);
             }}
           >
             <KeyboardDoubleArrowRightIcon style={{ fontSize: iconFontSize }} />
@@ -516,10 +491,6 @@ export const CodeNode = memo<NodeProps>(function ({
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const inputRef = useRef<HTMLInputElement>(null);
   const updateView = useStore(store, (state) => state.updateView);
-  const exec_count = useStore(
-    store,
-    (state) => state.podResults[id]?.exec_count || " "
-  );
 
   const nodesMap = useStore(store, (state) => state.getNodesMap());
   const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
@@ -785,16 +756,6 @@ export const CodeNode = memo<NodeProps>(function ({
                     },
                   }}
                 ></InputBase>
-              </Box>
-              <Box
-                sx={{
-                  color: "#8b8282",
-                  textAlign: "left",
-                  paddingLeft: "5px",
-                  fontSize: "12px",
-                }}
-              >
-                [{exec_count}]
               </Box>
               <Box
                 sx={{

--- a/ui/src/components/nodes/Scope.tsx
+++ b/ui/src/components/nodes/Scope.tsx
@@ -60,7 +60,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const reactFlowInstance = useReactFlow();
   const isGuest = useStore(store, (state) => state.role === "GUEST");
-  const wsRunScope = useStore(store, (state) => state.wsRunScope);
+  const yjsRun = useStore(store, (state) => state.yjsRun);
 
   const autoLayout = useStore(store, (state) => state.autoLayout);
 
@@ -89,7 +89,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
         <Tooltip title="Run (shift-enter)">
           <IconButton
             onClick={() => {
-              wsRunScope(id);
+              yjsRun(id);
             }}
           >
             <PlayCircleOutlineIcon style={{ fontSize: iconFontSize }} />

--- a/ui/src/lib/store/canvasSlice.ts
+++ b/ui/src/lib/store/canvasSlice.ts
@@ -415,7 +415,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
   updateView: () => {
     const nodesMap = get().getNodesMap();
     let selectedPods = get().selectedPods;
-    let nodes = Array.from(nodesMap.values());
+    let nodes = Array.from<Node>(nodesMap.values());
     nodes = nodes
       .sort((a: Node, b: Node) => a.data.level - b.data.level)
       .map((node) => ({
@@ -428,14 +428,14 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
         selected: selectedPods.has(node.id),
         // className: get().dragHighlight === node.id ? "active" : "",
         className: match(node.id)
-          .with(get().dragHighlight, () => "active")
+          .with(get().dragHighlight || "", () => "active")
           .otherwise(() => undefined),
       }));
 
     set({ nodes });
     // edges view
     const edgesMap = get().getEdgesMap();
-    set({ edges: Array.from(edgesMap.values()).filter((e) => e) });
+    set({ edges: Array.from<Edge>(edgesMap.values()).filter((e) => e) });
   },
 
   addNode: (type, position, parent) => {
@@ -581,7 +581,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     if (nodes.length === 0) return;
     // If a scope is selected, select all its children
     if (nodes.some((n) => n.type === "SCOPE")) {
-      const allnodes = Array.from(nodesMap.values());
+      const allnodes = Array.from<Node>(nodesMap.values());
       const dp: Record<string, boolean> = {};
       Array.from(get().selectedPods).forEach((id) => (dp[id] = true));
       // dp algorithm for collecting all descendants
@@ -745,7 +745,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
   adjustLevel: () => {
     // adjust the levels of all nodes, using topoSort
     let nodesMap = get().getNodesMap();
-    let nodes = Array.from(nodesMap.values());
+    let nodes = Array.from<Node>(nodesMap.values());
     nodes = topologicalSort(nodes, nodesMap);
     // update nodes' level
     nodes.forEach((node) => {
@@ -992,7 +992,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     // get all scopes,
     console.debug("autoLayoutROOT");
     let nodesMap = get().getNodesMap();
-    let nodes: Node[] = Array.from(nodesMap.values());
+    let nodes = Array.from<Node>(nodesMap.values());
     nodes
       // sort the children so that the inner scope gets processed first.
       .sort((a: Node, b: Node) => b.data.level - a.data.level)

--- a/ui/src/lib/store/podSlice.ts
+++ b/ui/src/lib/store/podSlice.ts
@@ -21,102 +21,19 @@ type PodResult = {
 
 export interface PodSlice {
   // local reactive variable for pod result
-  podResults: Record<string, PodResult>;
   podNames: Record<string, string>;
   setPodName: ({ id, name }: { id: string; name: string }) => void;
-  setPodResult: ({ id, type, content, count }) => void;
-  setPodError: ({ id, ename, evalue, stacktrace }) => void;
-  setPodStatus: ({ id, status, lang }) => void;
 }
 
 export const createPodSlice: StateCreator<MyState, [], [], PodSlice> = (
   set,
   get
 ) => ({
-  podResults: {},
   podNames: {},
   setPodName: ({ id, name }) => {
     set(
       produce((state: MyState) => {
         state.podNames[id] = name;
-      })
-    );
-  },
-  setPodError: ({ id, ename, evalue, stacktrace }) => {
-    get().ensureResult(id);
-    set(
-      produce((state: MyState) => {
-        if (id === "CODEPOD") return;
-        state.podResults[id].error = {
-          ename,
-          evalue,
-          stacktrace,
-        };
-      })
-    );
-  },
-  setPodStatus: ({ id, status, lang }) =>
-    set(
-      produce((state: MyState) => {
-        // console.log("WS_STATUS", { lang, status });
-        state.kernels[lang].status = status;
-        // this is for racket kernel, which does not have a execute_reply
-        // if (lang === "racket" && status === "idle" && state.pods[id]) {
-        //   state.pods[id].running = false;
-        // }
-      })
-    ),
-  setPodResult({ id, type, content, count }) {
-    const nodesMap = get().getNodesMap();
-    const node = nodesMap.get(id);
-    if (!node) {
-      console.log("setPodResult: node not found", id);
-      return;
-    }
-    get().ensureResult(id);
-    set(
-      produce((state: MyState) => {
-        if (state.podResults[id].last_exec_end) {
-          state.podResults[id].result = [];
-          state.podResults[id].last_exec_end = false;
-        }
-        switch (type) {
-          case "display_data":
-            // console.log("WS_DISPLAY_DATA", content);
-            state.podResults[id].result.push({
-              type,
-              text: content.data["text/plain"],
-              image: content.data["image/png"],
-            });
-            break;
-          case "execute_result":
-            // console.log("WS_EXECUTE_RESULT", content);
-            state.podResults[id].result.push({
-              type,
-              text: content.data["text/plain"],
-            });
-            break;
-          case "stream":
-            // console.log("WS_STREAM", content);
-            state.podResults[id].result.push({
-              // content.name : "stdout" or "stderr"
-              type: `${type}_${content.name}`,
-              text: content.text,
-            });
-            break;
-          case "execute_reply":
-            state.podResults[id].running = false;
-            state.podResults[id].lastExecutedAt = new Date();
-            state.podResults[id].result.push({
-              type,
-              text: content,
-            });
-            state.podResults[id].exec_count = count;
-            state.podResults[id].last_exec_end = true;
-            break;
-          default:
-            break;
-        }
       })
     );
   },

--- a/ui/src/lib/store/runtimeSlice.ts
+++ b/ui/src/lib/store/runtimeSlice.ts
@@ -3,6 +3,7 @@ import { ApolloClient, gql } from "@apollo/client";
 import { createStore, StateCreator, StoreApi } from "zustand";
 
 import { Edge, Node } from "reactflow";
+import * as Y from "yjs";
 
 // FIXME cyclic import
 import { MyState } from ".";
@@ -152,85 +153,36 @@ function rewriteCode(id: string, get: () => MyState): string | null {
   return newcode;
 }
 
-async function spawnRuntime(client, sessionId: string) {
-  // load from remote
-  let res = await client.mutate({
-    mutation: gql`
-      mutation spawnRuntime($sessionId: String!) {
-        spawnRuntime(sessionId: $sessionId)
-      }
-    `,
-    variables: {
-      sessionId,
-    },
-    // refetchQueries with array of strings are known not to work in many
-    // situations, ref:
-    // https://lightrun.com/answers/apollographql-apollo-client-refetchqueries-not-working-when-using-string-array-after-mutation
-    //
-    // refetchQueries: ["listAllRuntimes"],
-    refetchQueries: ["ListAllRuntimes", "GetRuntimeInfo"],
-  });
-  if (res.errors) {
-    throw Error(
-      `Error: ${
-        res.errors[0].message
-      }\n ${res.errors[0].extensions.exception.stacktrace.join("\n")}`
-    );
-  }
-  return res.data.spawnRuntime;
-}
+export type RuntimeInfo = {
+  status?: string;
+  wsStatus?: string;
+};
 
-async function killRuntime(client, sessionId) {
-  let res = await client.mutate({
-    mutation: gql`
-      mutation killRuntime($sessionId: String!) {
-        killRuntime(sessionId: $sessionId)
-      }
-    `,
-    variables: {
-      sessionId,
-    },
-    refetchQueries: ["ListAllRuntimes", "GetRuntimeInfo"],
-  });
-  if (res.errors) {
-    throw Error(
-      `Error: ${
-        res.errors[0].message
-      }\n ${res.errors[0].extensions.exception.stacktrace.join("\n")}`
-    );
-  }
-  return res.data.killRuntime;
-}
+type PodResult = {
+  exec_count?: number;
+  last_exec_end?: boolean;
+  data: {
+    type: string;
+    html?: string;
+    text?: string;
+    image?: string;
+  }[];
+  running?: boolean;
+  lastExecutedAt?: Date;
+  error?: { ename: string; evalue: string; stacktrace: string[] } | null;
+};
 
 export interface RuntimeSlice {
-  sessionId: string | null;
-  // From source pod id to target pod id.
-  setSessionId: (sessionId: string) => void;
-  runtimeConnecting: boolean;
-  runtimeConnected: boolean;
-  kernels: Record<string, { status: string | null }>;
-  // queueProcessing: boolean;
-  socket: WebSocket | null;
-  socketIntervalId: number | null;
-  wsConnect: (client, sessionId) => void;
-  wsDisconnect: () => void;
-  restartRuntime: (client: ApolloClient<any>, sessionId: string) => void;
-  wsRequestStatus: ({ lang }) => void;
+  apolloClient?: ApolloClient<any>;
+  setApolloClient: (client: ApolloClient<any>) => void;
+
   parsePod: (id: string) => void;
   parseAllPods: () => void;
   resolvePod: (id) => void;
   resolveAllPods: () => void;
-  runningId: string | null;
-  wsRun: (id: string) => void;
-  wsRunScope: (id: string) => void;
-  wsSendRun: (id: string) => void;
-  wsRunNext: () => void;
-  chain: string[];
-  wsRunChain: (id: string) => void;
-  wsInterruptKernel: ({ lang }) => void;
+  yjsRun: (id: string) => void;
+  yjsRunChain: (id: string) => void;
   clearResults: (id) => void;
-  clearAllResults: () => void;
-  ensureResult(id: string): void;
   setRunning: (id) => void;
   parseResult: Record<
     string,
@@ -241,35 +193,33 @@ export interface RuntimeSlice {
       annotations: Annotation[];
     }
   >;
+  getRuntimeMap(): Y.Map<RuntimeInfo>;
+  getResultMap(): Y.Map<PodResult>;
+  activeRuntime?: string;
+  setActiveRuntime(id: string): void;
+  yjsSendRun(ids: string[]): void;
+  isRuntimeReady(): boolean;
 }
 
 export const createRuntimeSlice: StateCreator<MyState, [], [], RuntimeSlice> = (
   set,
   get
 ) => ({
+  apolloClient: undefined,
+  setApolloClient: (client) => set({ apolloClient: client }),
   parseResult: {},
-  sessionId: null,
-  setSessionId: (id) => set({ sessionId: id }),
-  kernels: {
-    python: {
-      status: null,
-    },
+
+  // new yjs-based runtime
+  getRuntimeMap() {
+    return get().ydoc.getMap("rootMap").get("runtimeMap") as Y.Map<RuntimeInfo>;
   },
-  runtimeConnecting: false,
-  runtimeConnected: false,
-  socket: null,
-  socketIntervalId: null,
-  wsConnect: wsConnect(set, get),
-  wsDisconnect: () => {
-    get().socket?.close();
+  getResultMap() {
+    return get().ydoc.getMap("rootMap").get("resultMap") as Y.Map<PodResult>;
   },
-  restartRuntime: async (client, sessionId) => {
-    console.log("killing runtime ..");
-    await killRuntime(client, sessionId);
-    console.log("runtime killed, spawning new one ..");
-    get().wsConnect(client, sessionId);
+  activeRuntime: undefined,
+  setActiveRuntime(id: string) {
+    set({ activeRuntime: id });
   },
-  wsRequestStatus: wsRequestStatus(set, get),
   /**
    * Parse the code for defined variables and functions.
    * @param id paod
@@ -337,125 +287,89 @@ export const createRuntimeSlice: StateCreator<MyState, [], [], RuntimeSlice> = (
       if (node.type === "CODE") get().resolvePod(node.id);
     });
   },
-  // This runningId is a unique pod id indicating which pod is being run. The
-  // state.pods[id].running is a indicator of the pod in the chain that is
-  // scheduled to run.
-  runningId: null,
-  /**
-   * Actually send the run request.
-   */
-  wsSendRun: async (id) => {
-    if (get().runningId !== null) {
-      // This should never happen: there shouldn't be another pod running.
+  isRuntimeReady() {
+    const runtimeMap = get().getRuntimeMap();
+    const activeRuntime = get().activeRuntime;
+    if (!activeRuntime) {
       get().addError({
         type: "error",
-        msg: "Another pod is running",
+        msg: "No active runtime",
       });
-      return;
+      return false;
     }
-    if (!get().socket) {
+    const runtime = runtimeMap.get(activeRuntime);
+    if (runtime?.wsStatus !== "connected") {
       get().addError({
         type: "error",
         msg: "Runtime not connected",
       });
-      return;
+      return false;
     }
-    // Set this pod as running.
-    set({ runningId: id });
-    // Actually send the run request.
-    // Analyze code and set symbol table
-    get().parsePod(id);
-    // update anontations according to st
-    get().resolvePod(id);
-    // rewrite the code
-    const newcode = rewriteCode(id, get);
-
-    // Run the code in remote kernel.
-    get().setRunning(id);
-    get().socket?.send(
-      JSON.stringify({
-        type: "runCode",
-        payload: {
-          lang: "python",
-          code: newcode,
-          raw: true,
-          podId: id,
-          sessionId: get().sessionId,
-        },
-      })
-    );
+    return true;
   },
-  // All pods are added to the chain before executing.
-  chain: [],
-  /**
-   * Add a pod to the chain and run it.
-   */
-  wsRun: async (id) => {
+  yjsSendRun(ids) {
+    const activeRuntime = get().activeRuntime!;
+    let specs = ids.map((id) => {
+      // Actually send the run request.
+      // Analyze code and set symbol table
+      get().parsePod(id);
+      // update anontations according to st
+      get().resolvePod(id);
+      const newcode = rewriteCode(id, get);
+      return { podId: id, code: newcode };
+    });
+    // FIXME there's no control over duplicate runnings. This causes two
+    // problems:
+    // 1. if you click fast enough, you will see multiple results.
+    // 2. if a pod takes time to run, it will be shown completed after first run
+    //    finishes, but second run results could keep come after that.
+
+    // const resultMap = get().getResultMap();
+    // if (resultMap.get(id)?.running) {
+    //   console.warn(`Pod ${id} is already running.`);
+    //   return;
+    // }
+    specs = specs.filter(({ podId, code }) => {
+      if (code) {
+        get().clearResults(podId);
+        get().setRunning(podId);
+        return true;
+      }
+      return false;
+    });
+    if (specs) {
+      get().apolloClient?.mutate({
+        mutation: gql`
+          mutation RunChain($specs: [RunSpecInput], $runtimeId: String) {
+            runChain(specs: $specs, runtimeId: $runtimeId)
+          }
+        `,
+        variables: {
+          runtimeId: activeRuntime,
+          specs,
+        },
+      });
+    }
+  },
+  yjsRun: (id) => {
+    if (!get().isRuntimeReady()) return;
     const nodesMap = get().getNodesMap();
     const nodes = Array.from<Node>(nodesMap.values());
-    if (!get().socket) {
-      get().addError({
-        type: "error",
-        msg: "Runtime not connected",
-      });
-      return;
-    }
     const node = nodesMap.get(id);
     if (!node) return;
-    // If this pod is a code pod, add it.
-    if (node.type === "CODE") {
-      // Add to the chain
-      get().clearResults(id);
-      get().setRunning(id);
-      set({ chain: [...get().chain, id] });
-    } else if (node.type === "SCOPE") {
-      // If this pod is a scope, run all pods inside a scope by geographical order.
-      // get the pods in the scope
-      const children = nodes
-        .filter((n) => n.parentNode === id)
-        .map((n) => n.id);
-      if (!children) return;
-      // Sort by x and y positions, with the leftmost and topmost first.
-      children.sort((a, b) => {
-        let nodeA = nodesMap.get(a);
-        let nodeB = nodesMap.get(b);
-        if (nodeA && nodeB) {
-          if (nodeA.position.y === nodeB.position.y) {
-            return nodeA.position.x - nodeB.position.x;
-          } else {
-            return nodeA.position.y - nodeB.position.y;
-          }
-        } else {
-          return 0;
-        }
-      });
-      // add to the chain
-      // set({ chain: [...get().chain, ...children.map(({ id }) => id)] });
-      children.forEach((id) => get().wsRun(id));
-    }
-    get().wsRunNext();
-  },
-  wsRunScope: async (id) => {
-    // This is a separate function only because we need to build the node2children map first.
-    // DEPRECATED. node2children is removed.
-    get().wsRun(id);
+    const chain = getDescendants(node, nodes);
+    get().yjsSendRun(chain);
   },
   /**
    * Add the pod and all its downstream pods (defined by edges) to the chain and run the chain.
    * @param id the id of the pod to start the chain
    * @returns
    */
-  wsRunChain: async (id) => {
-    if (!get().socket) {
-      get().addError({
-        type: "error",
-        msg: "Runtime not connected",
-      });
-      return;
-    }
+  yjsRunChain: async (id) => {
+    if (!get().isRuntimeReady()) return;
     // Get the chain: get the edges, and then get the pods
     const edgesMap = get().getEdgesMap();
-    let edges = Array.from(edgesMap.values());
+    let edges = Array.from<Edge>(edgesMap.values());
     // build a node2target map
     let node2target = {};
     edges.forEach(({ source, target }) => {
@@ -464,276 +378,46 @@ export const createRuntimeSlice: StateCreator<MyState, [], [], RuntimeSlice> = (
     });
     // Get the chain
     let chain: string[] = [];
-    let node = id;
-    while (node) {
-      // if the node is already in the chain, then there is a loop
-      if (chain.includes(node)) break;
-      get().clearResults(node);
-      get().setRunning(node);
-      chain.push(node);
-      node = node2target[node];
+    let nodeid = id;
+    while (nodeid) {
+      // if the nodeid is already in the chain, then there is a loop
+      if (chain.includes(nodeid)) break;
+      chain.push(nodeid);
+      nodeid = node2target[nodeid];
     }
-    set({ chain });
-    get().wsRunNext();
-  },
-  wsRunNext: async () => {
-    const codeMap = get().getCodeMap();
-    // run the next pod in the chain
-    if (get().runningId !== null) return;
-    if (get().chain.length > 0) {
-      // Run the first pod in the chain
-      let chain = get().chain;
-      let id = chain[0];
-      console.log("running", id, "remaining number of pods:", chain.length - 1);
-      // remove the first element
-      set({ chain: chain.slice(1) });
-      // If the pod is empty, the kernel won't reply. So, we need to skip it.
-      if (
-        codeMap.get(id)?.toString() === undefined ||
-        codeMap.get(id)?.toString() === ""
-      ) {
-        get().ensureResult(id);
-        set(
-          produce((state: MyState) => {
-            state.podResults[id].running = false;
-          })
-        );
-      } else {
-        get().wsSendRun(id);
-      }
-    }
-  },
-  wsInterruptKernel: ({ lang }) => {
-    get().socket!.send(
-      JSON.stringify({
-        type: "interruptKernel",
-        payload: {
-          sessionId: get().sessionId,
-          lang,
-        },
-      })
-    );
+    get().yjsSendRun(chain);
   },
   clearResults: (id) => {
-    set(
-      produce((state: MyState) => {
-        state.podResults[id] = {
-          result: [],
-        };
-      })
-    );
-  },
-  ensureResult(id) {
-    if (id in get().podResults) return;
-    get().clearResults(id);
-  },
-  clearAllResults: () => {
-    const nodesMap = get().getNodesMap();
-    const nodes = Array.from(nodesMap);
-    nodes.forEach(({ id }) => get().clearResults(id));
+    const resultMap = get().getResultMap();
+    resultMap.delete(id);
   },
   setRunning: (id) => {
-    get().ensureResult(id);
     set(
       produce((state: MyState) => {
-        state.podResults[id].running = true;
+        const resultMap = get().getResultMap();
+        resultMap.set(id, { running: true, data: [] });
       })
     );
   },
 });
 
-let _ws_timeout = 1000;
-let _max_ws_timeout = 10000;
-
-function wsConnect(set, get: () => MyState) {
-  return async (client, sessionId) => {
-    if (get().runtimeConnecting) return;
-    if (get().runtimeConnected) return;
-    console.log(`connecting to runtime ${sessionId} ..`);
-    set({ runtimeConnecting: true });
-
-    // 0. ensure the runtime is created
-    let runtimeCreated = await spawnRuntime(client, sessionId);
-    if (!runtimeCreated) {
-      throw Error("ERROR: runtime not ready");
-    }
-    // 1. get the socket
-    // FIXME socket should be disconnected when leaving the repo page.
-    if (get().socket !== null) {
-      throw new Error("socket already connected");
-    }
-    // reset kernel status
-    set({
-      kernels: {
-        python: {
-          status: null,
-        },
-      },
-    });
-
-    // connect to the remote host
-    // socket = new WebSocket(action.host);
-    //
-    // I canont use "/ws" for a WS socket. Thus I need to detect what's the
-    // protocol used here, so that it supports both dev and prod env.
-    let socket_url;
-    if (window.location.protocol === "http:") {
-      socket_url = `ws://${window.location.host}/runtime/${sessionId}`;
-    } else {
-      socket_url = `wss://${window.location.host}/runtime/${sessionId}`;
-    }
-    console.log("connecting to websocket ..");
-    let socket = new WebSocket(socket_url);
-    // Set timeout.
-    console.log(`Setting ${_ws_timeout} ms timeout.`);
-    setTimeout(() => {
-      if (get().runtimeConnecting) {
-        console.log(`Websocket timed out, but still connecting. Reset socket.`);
-        socket.close();
-        set({ runtimeConnecting: false });
-        _ws_timeout = Math.min(_ws_timeout * 2, _max_ws_timeout);
+/**
+ * Get all code pods inside a scope by geographical order.
+ */
+function getDescendants(node: Node, nodes: Node[]): string[] {
+  if (node.type === "CODE") return [node.id];
+  if (node.type === "SCOPE") {
+    let children = nodes.filter((n) => n.parentNode === node.id);
+    children.sort((a, b) => {
+      if (a.position.y === b.position.y) {
+        return a.position.x - b.position.x;
+      } else {
+        return a.position.y - b.position.y;
       }
-    }, _ws_timeout);
-
-    // socket.emit("spawn", state.sessionId, lang);
-
-    // If the mqAddress is not supplied, use the websocket
-    socket.onmessage = onMessage(set, get);
-
-    // well, since it is already opened, this won't be called
-    //
-    // UPDATE it works, this will be called even after connection
-
-    socket.onopen = () => {
-      console.log("runtime connected");
-      // reset timeout
-      _ws_timeout = 1000;
-      set({ runtimeConnected: true });
-      set({ runtimeConnecting: false });
-      set({ socket });
-      // call connect kernel
-
-      // request kernel status after connection
-      Object.keys(get().kernels).forEach((k) => {
-        get().wsRequestStatus({
-          lang: k,
-        });
-      });
-    };
-    // so I'm setting this
-    // Well, I should probably not dispatch action inside another action
-    // (even though it is in a middleware)
-    //
-    // I probably can dispatch the action inside the middleware, because
-    // this is not a dispatch. It will not modify the store.
-    //
-    // store.dispatch(actions.wsConnected());
-    socket.onclose = () => {
-      console.log("Disconnected ..");
-      set({ runtimeConnected: false });
-      set({ runtimeConnecting: false });
-      set({ socket: null });
-    };
-  };
-}
-
-function onMessage(set, get: () => MyState) {
-  return (msg) => {
-    // console.log("onMessage", msg.data || msg.body || undefined);
-    // msg.data for websocket
-    // msg.body for rabbitmq
-    let { type, payload } = JSON.parse(msg.data || msg.body || undefined);
-    console.debug("got message", type, payload);
-    switch (type) {
-      case "stream":
-        {
-          let { podId, content } = payload;
-          get().setPodResult({
-            id: podId,
-            type,
-            content,
-            count: null,
-          });
-        }
-        break;
-      case "execute_result":
-        {
-          let { podId, content, count } = payload;
-          get().setPodResult({
-            id: podId,
-            type,
-            content,
-            count,
-          });
-        }
-        break;
-      case "display_data":
-        {
-          let { podId, content } = payload;
-          get().setPodResult({
-            id: podId,
-            type,
-            content,
-            count: null,
-          });
-        }
-        break;
-      case "execute_reply":
-        {
-          let { podId, result, count } = payload;
-          get().setPodResult({
-            id: podId,
-            type,
-            content: result,
-            count,
-          });
-          set({ runningId: null });
-          // Continue to run the chain if there is any.
-          get().wsRunNext();
-        }
-        break;
-      case "error":
-        {
-          let { podId, ename, evalue, stacktrace } = payload;
-          get().setPodError({ id: podId, ename, evalue, stacktrace });
-        }
-        break;
-      case "status":
-        {
-          const { lang, status, id } = payload;
-          get().setPodStatus({ id, lang, status });
-        }
-        break;
-      case "interrupt_reply":
-        // console.log("got interrupt_reply", payload);
-        get().wsRequestStatus({ lang: payload.lang });
-        break;
-      default:
-        console.warn("WARNING unhandled message", { type, payload });
-    }
-  };
-}
-
-function wsRequestStatus(set, get) {
-  return ({ lang }) => {
-    if (get().socket) {
-      // set to unknown
-      set(
-        produce((state: MyState) => {
-          state.kernels[lang].status = null;
-        })
-      );
-      get().socket?.send(
-        JSON.stringify({
-          type: "requestKernelStatus",
-          payload: {
-            sessionId: get().sessionId,
-            lang,
-          },
-        })
-      );
-    } else {
-      console.log("ERROR: not connected");
-    }
-  };
+    });
+    return ([] as string[]).concat(
+      ...children.map((n) => getDescendants(n, nodes))
+    );
+  }
+  return [];
 }


### PR DESCRIPTION
Changes:
1. **results are now saved to yDoc** `.getMap("rootMap").get("resultMap")`, so that they sync with peers and are persisted
2. **runtime status is now saved to yDoc** `.getMap("rootMap").get("resultMap")`, so that peers share the exact runtime and share real-time status.
3. the **connection to the runtime kernel is moved behind Yjs**.
    - **Detail**: the front end no longer directly connects to the runtime websocket. Instead, the Yjs server connects to runtime WS, receives and sets results in "resultMap", and sets runtime status in "runtimeMap".
    - **Effect**: if you have some long-running code, **you can now safely close the page. The runtime will continue to run**, and results will continue to be populated (with a TODO caveat[1]). When you reopen the page, you can reload the exact results and runtime status again.
        - [ ] Caveats (TODO): Although the runtime TTL is 12 hours, there's a 30s timeout to keep a YDoc in memory when no one is connected, so for now. These two TTLs shall be unified in the future.
5. Now, you can **create multiple runtimes** and activate either one, see below screenshot:


<img width="233" alt="Screenshot 2023-08-20 at 10 13 53 AM" src="https://github.com/codepod-io/codepod/assets/4576201/a7a301b2-6e5f-4aa7-8d61-a51b8721f762">

