### PR TITLE
[UI][RFC] SelectiveView

### DIFF
--- a/apps/ui/src/lib/store/canvasSlice.ts
+++ b/apps/ui/src/lib/store/canvasSlice.ts
@@ -283,6 +283,12 @@ export interface CanvasSlice {
   centerSelection: boolean;
   setCenterSelection: (b: boolean) => void;
 
+  isSelectiveView: boolean;
+  setSelectiveView: (b: boolean) => void;
+  selectedToc: Set<string>;
+  clearSelectedToc: () => void;
+  setSelectedToc: (selectedItems: Set<string>) => void;
+
   handlePaste(event: ClipboardEvent, position: XYPosition): void;
   handleCopy(event: ClipboardEvent): void;
 
@@ -382,6 +388,23 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
     set({ centerSelection: b });
   },
 
+  isSelectiveView: false,
+  setSelectiveView: (b: boolean) => set({ isSelectiveView: b }),
+  selectedToc: new Set(),
+  setSelectedToc(selectedItems) {
+    set(
+      produce((state: MyState) => {
+        state.selectedToc = selectedItems;
+      })
+    );
+  },
+  clearSelectedToc: () => {
+    set(
+      produce((state: MyState) => {
+        state.selectedToc.clear();
+      })
+    );
+  },
   focusedEditor: undefined,
   setFocusedEditor: (id?: string) =>
     set(
@@ -408,29 +431,68 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
    * This function handles the real updates to the reactflow nodes to render.
    */
   updateView: () => {
+    let nodes: Node[] = [];
     const nodesMap = get().getNodesMap();
-    let selectedPods = get().selectedPods;
-    let nodes = Array.from<Node>(nodesMap.values());
-    nodes = nodes
-      .sort((a: Node, b: Node) => a.data.level - b.data.level)
-      .map((node) => ({
-        ...node,
-        style: {
-          ...node.style,
-          backgroundColor:
-            node.type === "SCOPE" ? level2color[node.data.level] : undefined,
-        },
-        selected: selectedPods.has(node.id),
-        // className: get().dragHighlight === node.id ? "active" : "",
-        className: match(node.id)
-          .with(get().dragHighlight || "", () => "active")
-          .otherwise(() => undefined),
-      }));
+    if (!get().isSelectiveView) {
+      let selectedPods = get().selectedPods;
+      nodes = Array.from<Node>(nodesMap.values());
+      nodes = nodes
+        .sort((a: Node, b: Node) => a.data.level - b.data.level)
+        .map((node) => ({
+          ...node,
+          style: {
+            ...node.style,
+            backgroundColor:
+              node.type === "SCOPE" ? level2color[node.data.level] : undefined,
+          },
+          selected: selectedPods.has(node.id),
+          // className: get().dragHighlight === node.id ? "active" : "",
+          className: match(node.id)
+            .with(get().dragHighlight || "", () => "active")
+            .otherwise(() => undefined),
+        }));
+    } else {
+      nodes = Array.from(
+        [...get().selectedToc].map((id): Node => {
+          return nodesMap.get(id)!;
+        })
+      );
+      nodes = nodes
+        .sort((a: Node, b: Node) => a.data.level - b.data.level)
+        .map((node) => ({
+          ...node,
+          style: {
+            ...node.style,
+            backgroundColor:
+              node.type === "SCOPE" ? level2color[node.data.level] : undefined,
+          },
+          parentNode:
+            node.parentNode === undefined ||
+            get().selectedToc.has(node.parentNode)
+              ? node.parentNode
+              : undefined,
+          position:
+            node.parentNode === undefined ||
+            get().selectedToc.has(node.parentNode)
+              ? node.position
+              : getAbsPos(node, nodesMap),
+          selected: get().selectedToc.has(node.id),
+          // className: get().dragHighlight === node.id ? "active" : "",
+          className: match(node.id)
+            .with(get().dragHighlight || "", () => "active")
+            .otherwise(() => undefined),
+        }));
+    }
 
     set({ nodes });
     // edges view
     const edgesMap = get().getEdgesMap();
-    set({ edges: Array.from<Edge>(edgesMap.values()).filter((e) => e) });
+    const nodeSet = new Set<Node>(Array.from(nodes));
+    set({
+      edges: Array.from<Edge>(edgesMap.values()).filter(
+        (e) => nodeSet.has(e.sourceNode!) && nodeSet.has(e.targetNode!)
+      ),
+    });
   },
 
   addNode: (type, position, parent) => {


### PR DESCRIPTION
## Summary
A prototype of `SelectiveView` via multi-select items in `ToC`
- The Canvas only displays selected pods.
- The `Edit` mode is not affected.

__However__
- The current implementation creates a deep copy of the __selected__ pods from `nodesMap`, thus ALL operations that engage with `nodesMap` need to be properly synced, e.g., moving a pod, creating a new pod, changing the size of a pod, etc. I am not exactly sure if it's the best approach and ask for some comments here. 

## Test
![selective_view](https://github.com/codepod-io/codepod/assets/10226241/e4532e0d-c441-4b74-97ed-ba02741358c7)

  
 