### PR TITLE
[chore] add .dockerignore to avoid copying node_modules

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,15 +1,13 @@
 FROM node:18 AS builder
 WORKDIR /app
-COPY package.json .
-COPY yarn.lock .
+COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 COPY . .
 RUN yarn build
 
 FROM node:18 AS server
 WORKDIR /app
-COPY package.json .
-COPY yarn.lock .
+COPY package.json yarn.lock ./
 RUN yarn install --production
 COPY prisma ./prisma
 RUN yarn run prisma generate

--- a/apps/proxy/.dockerignore
+++ b/apps/proxy/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -1,19 +1,15 @@
 FROM node:18 AS builder
-
 WORKDIR /app
-COPY package.json .
-COPY yarn.lock .
+COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
-# FIXME would this copy node_modules?
 COPY . .
 
 RUN yarn build
 
 FROM node:18 AS server
 WORKDIR /app
-COPY package.json .
-COPY yarn.lock .
+COPY package.json yarn.lock ./
 RUN yarn install --production
 COPY --from=builder ./app/build ./build
 EXPOSE 4010 4011

--- a/apps/runtime/.dockerignore
+++ b/apps/runtime/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/apps/runtime/Dockerfile
+++ b/apps/runtime/Dockerfile
@@ -1,19 +1,16 @@
 FROM node:18 AS builder
 
 WORKDIR /app
-COPY package.json .
-COPY yarn.lock .
+COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
-# FIXME would this copy node_modules?
 COPY . .
 
 RUN yarn build
 
 FROM node:18 AS server
 WORKDIR /app
-COPY package.json .
-COPY yarn.lock .
+COPY package.json yarn.lock ./
 COPY kernel ./kernel
 RUN yarn install --production
 COPY --from=builder ./app/build ./build

--- a/apps/ui/.dockerignore
+++ b/apps/ui/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -1,11 +1,9 @@
 FROM node:18 AS builder
 
 WORKDIR /app
-COPY package.json .
-COPY yarn.lock .
+COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
-# FIXME would this copy node_modules?
 COPY . .
 
 ENV NODE_OPTIONS="--max_old_space_size=4096"


### PR DESCRIPTION
## Summary

It appears that we can avoid copying the `node_modules` folder by using `.dockerignore`, [ref](https://stackoverflow.com/questions/43747776/copy-with-docker-but-with-exclusion).