### PR TITLE
[docker-compose] Add setup service to install node_modules and init db

### DIFF
--- a/compose/dev/.env.example
+++ b/compose/dev/.env.example
@@ -1,0 +1,10 @@
+COMPOSE_PROJECT_NAME=mydev
+
+POSTGRES_USER=myuser
+POSTGRES_PASSWORD=mypassword
+POSTGRES_DB=codepod
+JWT_SECRET=mysecret
+
+# Optional configs.
+GOOGLE_CLIENT_ID=
+CODEIUM_API_KEY=

--- a/compose/dev/compose.yml
+++ b/compose/dev/compose.yml
@@ -12,25 +12,38 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
 
+  # Run: docker compose up setup
+  # Then run: docker compose up -d
+  setup:
+    image: node:18
+    working_dir: /codepod
+    depends_on:
+      - db
+    volumes:
+      - ../..:/codepod
+    # Need to pnpm config set store-dir ~/pnpm
+    # Ref: https://github.com/pnpm/pnpm/issues/3952#issuecomment-1262136483
+    command: sh -c "corepack enable && pnpm config set store-dir ~/pnpm && pnpm install && cd apps/api && pnpm dlx prisma migrate dev"
+    environment:
+      DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public"
+
   prisma:
     image: node:18
     restart: always
-    command: sh -c "corepack enable && pnpm install && pnpx prisma studio"
-    working_dir: /app
+    command: sh -c "corepack enable && pnpm dlx prisma studio"
+    working_dir: /codepod/apps/api
     volumes:
-      - ../../apps/api:/app
-      - prisma-node-modules:/app/node_modules
+      - ../..:/codepod
     environment:
       DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public"
 
   api:
     image: node:18
-    working_dir: /app
+    working_dir: /codepod/apps/api
     volumes:
-      - ../../apps/api:/app
-      - api-node-modules:/app/node_modules
+      - ../..:/codepod
       - /var/run/docker.sock:/var/run/docker.sock
-    command: sh -c "corepack enable && pnpm install && pnpm dev"
+    command: sh -c "corepack enable && pnpm dev"
     environment:
       DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public"
       JWT_SECRET: ${JWT_SECRET}
@@ -59,12 +72,11 @@ services:
 
   yjs-server:
     image: node:18
-    working_dir: /app
+    working_dir: /codepod/apps/api
     volumes:
-      - ../../apps/api:/app
-      - api-node-modules:/app/node_modules
+      - ../..:/codepod
       - /var/run/docker.sock:/var/run/docker.sock
-    command: sh -c "corepack enable && pnpm install && pnpm dev:yjs"
+    command: sh -c "corepack enable && pnpm dev:yjs"
     environment:
       DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public"
       JWT_SECRET: ${JWT_SECRET}
@@ -89,26 +101,21 @@ services:
 
   ui:
     image: node:18
-    working_dir: /app
-    ports:
-      # For react hot-reloading in development.
-      - 3000:3000
+    working_dir: /codepod/apps/ui
     environment:
+      TEST: "123"
       VITE_APP_GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       VITE_APP_CODEIUM_API_KEY: ${CODEIUM_API_KEY}
-
     volumes:
-      - ../../apps/ui:/app
-      - ui-node-modules:/app/node_modules
-    command: sh -c "corepack enable && pnpm install && pnpm generate && pnpm dev"
+      - ../..:/codepod
+    command: sh -c "corepack enable && pnpm generate && pnpm dev"
 
   proxy:
     image: node:18
-    working_dir: /app
+    working_dir: /codepod/apps/proxy
     volumes:
-      - ../../apps/proxy:/app
-      - proxy-node-modules:/app/node_modules
-    command: sh -c "corepack enable && pnpm install && pnpm dev"
+      - ../..:/codepod
+    command: sh -c "corepack enable && pnpm dev"
 
   nginx:
     image: nginx:alpine
@@ -124,11 +131,10 @@ services:
   # that the docker spawner can use the image without waiting for installing.
   example-runtime-dev:
     image: node:18
-    working_dir: /app
+    working_dir: /codepod/apps/runtime
     volumes:
-      - ../../apps/runtime:/app
-      - runtime-node-modules:/app/node_modules
-    command: sh -c "corepack enable && pnpm install && pnpm dev"
+      - ../..:/codepod
+    command: sh -c "corepack enable && pnpm dev"
 
   example-runtime-prod:
     image: lihebi/codepod-runtime:0.4.13-alpha.49
@@ -140,12 +146,6 @@ services:
 
 volumes:
   db-data:
-  api-node-modules:
-  ui-node-modules:
-  proxy-node-modules:
-  prisma-node-modules:
-  socket-node-modules:
-  runtime-node-modules:
 
 networks:
   default:


### PR DESCRIPTION
New docker-compose stack behavior:

1. remove xxx-node_modules volumes. We'll install directly on the mounted host dir.
2. add a setup service to run `pnpm install` and initialize DB.

As a result, the new development workflow:

```bash
# step 1 (run once): install node_modules and initialize DB
docker compose up setup

# step 2: fire up the stack
docker compose up -d
```
