### PR TITLE
add docker volume for pnpm-store

### DIFF
--- a/compose/dev/compose.yml
+++ b/compose/dev/compose.yml
@@ -21,9 +21,13 @@ services:
       - db
     volumes:
       - ../..:/codepod
-    # Need to pnpm config set store-dir ~/pnpm
-    # Ref: https://github.com/pnpm/pnpm/issues/3952#issuecomment-1262136483
-    command: sh -c "corepack enable && pnpm config set store-dir ~/pnpm && pnpm install && cd apps/api && pnpm dlx prisma migrate dev"
+      # pnpm-store serves two purposes:
+      # 1. without it, pnpm install will throw error. Ref:
+      #    https://github.com/pnpm/pnpm/issues/3952#issuecomment-1262136483
+      # 2. it is mounted to all service containers, and will cache and speed up
+      #    pnpm install and pnpm add/remove
+      - pnpm-store:/codepod/.pnpm-store
+    command: sh -c "corepack enable && pnpm install && cd apps/api && pnpm dlx prisma migrate dev"
     environment:
       DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public"
 
@@ -42,6 +46,7 @@ services:
     working_dir: /codepod/apps/api
     volumes:
       - ../..:/codepod
+      - pnpm-store:/codepod/.pnpm-store
       - /var/run/docker.sock:/var/run/docker.sock
     command: sh -c "corepack enable && pnpm dev"
     environment:
@@ -75,6 +80,7 @@ services:
     working_dir: /codepod/apps/api
     volumes:
       - ../..:/codepod
+      - pnpm-store:/codepod/.pnpm-store
       - /var/run/docker.sock:/var/run/docker.sock
     command: sh -c "corepack enable && pnpm dev:yjs"
     environment:
@@ -108,6 +114,7 @@ services:
       VITE_APP_CODEIUM_API_KEY: ${CODEIUM_API_KEY}
     volumes:
       - ../..:/codepod
+      - pnpm-store:/codepod/.pnpm-store
     command: sh -c "corepack enable && pnpm generate && pnpm dev"
 
   proxy:
@@ -115,6 +122,7 @@ services:
     working_dir: /codepod/apps/proxy
     volumes:
       - ../..:/codepod
+      - pnpm-store:/codepod/.pnpm-store
     command: sh -c "corepack enable && pnpm dev"
 
   nginx:
@@ -134,6 +142,7 @@ services:
     working_dir: /codepod/apps/runtime
     volumes:
       - ../..:/codepod
+      - pnpm-store:/codepod/.pnpm-store
     command: sh -c "corepack enable && pnpm dev"
 
   example-runtime-prod:
@@ -146,6 +155,7 @@ services:
 
 volumes:
   db-data:
+  pnpm-store:
 
 networks:
   default:


### PR DESCRIPTION
Following up #475, add a docker volume `pnpm-store`, which serves two purposes:
1. Without it, pnpm install will throw an error. We had to use `pnpm config set store-dir ~/pnpm` to bypass the error, but this led to unusable `pnpm add/remove` afterward. Ref: https://github.com/pnpm/pnpm/issues/3952#issuecomment-1262136483
2. This volume is mounted to all service containers and will cache and speed up `pnpm install` and `pnpm add/remove`