### PR TITLE
[Backend] Reduce resultMap sync frequency

### DIFF
--- a/apps/ui/src/components/nodes/Code.tsx
+++ b/apps/ui/src/components/nodes/Code.tsx
@@ -73,7 +73,7 @@ function Timer({ lastExecutedAt }) {
         padding: "5px",
       }}
     >
-      Last run: {timeDifference(new Date(), lastExecutedAt)}
+      Last run: {timeDifference(new Date(), new Date(lastExecutedAt))}
     </Box>
   );
 }

--- a/apps/ui/src/lib/store/podSlice.ts
+++ b/apps/ui/src/lib/store/podSlice.ts
@@ -1,23 +1,7 @@
 import { createStore, StateCreator, StoreApi } from "zustand";
 import { produce } from "immer";
 
-import * as Y from "yjs";
-
 import { Pod, MyState } from ".";
-
-type PodResult = {
-  exec_count?: number;
-  last_exec_end?: boolean;
-  result: {
-    type?: string;
-    html?: string;
-    text?: string;
-    image?: string;
-  }[];
-  running?: boolean;
-  lastExecutedAt?: Date;
-  error?: { ename: string; evalue: string; stacktrace: string[] } | null;
-};
 
 export interface PodSlice {
   // local reactive variable for pod result

--- a/apps/ui/src/lib/store/runtimeSlice.ts
+++ b/apps/ui/src/lib/store/runtimeSlice.ts
@@ -160,7 +160,6 @@ export type RuntimeInfo = {
 
 type PodResult = {
   exec_count?: number;
-  last_exec_end?: boolean;
   data: {
     type: string;
     html?: string;

--- a/apps/ui/src/lib/store/runtimeSlice.ts
+++ b/apps/ui/src/lib/store/runtimeSlice.ts
@@ -168,7 +168,7 @@ type PodResult = {
     image?: string;
   }[];
   running?: boolean;
-  lastExecutedAt?: Date;
+  lastExecutedAt?: number;
   error?: { ename: string; evalue: string; stacktrace: string[] } | null;
 };
 

--- a/apps/yjs/src/yjs-runtime.ts
+++ b/apps/yjs/src/yjs-runtime.ts
@@ -77,6 +77,7 @@ export async function setupRuntimeSocket({
             type: `${type}_${content.name}`,
             text: content.text,
           });
+          resultMap.set(podId, oldresult);
         }
         break;
       case "execute_result":
@@ -88,6 +89,7 @@ export async function setupRuntimeSocket({
             text: content.data["text/plain"],
             html: content.data["text/html"],
           });
+          resultMap.set(podId, oldresult);
         }
         break;
       case "display_data":
@@ -100,6 +102,7 @@ export async function setupRuntimeSocket({
             image: content.data["image/png"],
             html: content.data["text/html"],
           });
+          resultMap.set(podId, oldresult);
         }
         break;
       case "execute_reply":

--- a/apps/yjs/src/yjs-runtime.ts
+++ b/apps/yjs/src/yjs-runtime.ts
@@ -5,7 +5,6 @@ import { spawnRuntime, killRuntime } from "./runtime";
 
 type PodResult = {
   exec_count?: number;
-  last_exec_end?: boolean;
   data: {
     type: string;
     html?: string;
@@ -67,15 +66,6 @@ export async function setupRuntimeSocket({
     // FIXME is msg.data a string?
     let { type, payload } = JSON.parse(msg.data as string);
     // console.debug("got message", type, payload);
-    let podId = payload["podId"] || undefined;
-    if (podId) {
-      const oldresult: PodResult = resultMap.get(podId) || { data: [] };
-      if (oldresult.last_exec_end) {
-        oldresult.data = [];
-        oldresult.error = null;
-        oldresult.last_exec_end = false;
-      }
-    }
 
     switch (type) {
       case "stream":
@@ -119,7 +109,6 @@ export async function setupRuntimeSocket({
           oldresult.running = false;
           oldresult.lastExecutedAt = Date.now();
           oldresult.exec_count = count;
-          oldresult.last_exec_end = true;
           resultMap.set(podId, oldresult);
         }
         break;


### PR DESCRIPTION
## Summary
- Reduce yjs sync via `resultMap.set()` method
- Fix  #483; very interesting solution from ChatGPT, while I didn't find its sources
   - _Yjs is a CRDT framework that syncs JavaScript objects across multiple peers. However, it does not natively support all JavaScript types. The Date object is one of the types that Yjs does not natively support. When you try to sync a Date object, Yjs will only sync the reference to the object, not the actual date value. This is why you're seeing issues with syncing the "Date" field._

## Test

<img width="803" alt="Screenshot 2023-08-28 at 2 22 12 PM" src="https://github.com/codepod-io/codepod/assets/10226241/30253309-9455-4fac-b3e6-1df2da573150">
