### PR TITLE
[Backend] Adjust active runtime initialization logic

### DIFF
--- a/apps/spawner/src/server.ts
+++ b/apps/spawner/src/server.ts
@@ -129,8 +129,7 @@ export async function startAPIServer({ port }) {
           const doc = getMyYDoc({ repoId, token });
           const rootMap = doc.getMap("rootMap");
           const runtimeMap = rootMap.get("runtimeMap") as Y.Map<RuntimeInfo>;
-          runtimeMap.set(runtimeId, {});
-          // runtimeMap.delete(runtimeId)
+          runtimeMap.delete(runtimeId);
           return true;
         },
 

--- a/apps/ui/src/lib/store/yjsSlice.ts
+++ b/apps/ui/src/lib/store/yjsSlice.ts
@@ -197,10 +197,18 @@ export const createYjsSlice: StateCreator<MyState, [], [], YjsSlice> = (
           });
         }
       );
-      // Set active runtime to the first one.
+      // Set active runtime
       const runtimeMap = get().getRuntimeMap();
       if (runtimeMap.size > 0) {
-        get().setActiveRuntime(Array.from(runtimeMap.keys())[0]);
+        const runtimeList = Array.from(runtimeMap.keys());
+        const activeInstances = runtimeList.filter((id) => {
+          return runtimeMap.get(id)?.status !== undefined;
+        });
+        if (activeInstances) {
+          get().setActiveRuntime(activeInstances[0]);
+        } else {
+          get().setActiveRuntime(runtimeList[0]);
+        }
       }
       // Set up observers to trigger future runtime status changes.
       runtimeMap.observe(

--- a/compose/dev/compose.yml
+++ b/compose/dev/compose.yml
@@ -86,6 +86,7 @@ services:
       # spawner need to add routes to proxy server
       # PROXY_API_URL: "http://proxy:4011/graphql"
       YJS_WS_URL: "ws://yjs-server:4233/socket"
+      JWT_SECRET: ${JWT_SECRET}
 
   yjs-server:
     image: node:18


### PR DESCRIPTION
## Summary
- Find the alive runtime and set as default active runtime
- If `killRuntime()` get called, remove the `runtimeId` from `runtimeMap` 