### PR TITLE
properly update activeRuntime

### DIFF
--- a/apps/ui/src/lib/store/runtimeSlice.ts
+++ b/apps/ui/src/lib/store/runtimeSlice.ts
@@ -195,7 +195,7 @@ export interface RuntimeSlice {
   getRuntimeMap(): Y.Map<RuntimeInfo>;
   getResultMap(): Y.Map<PodResult>;
   activeRuntime?: string;
-  setActiveRuntime(id: string): void;
+  setActiveRuntime(id?: string): void;
   yjsSendRun(ids: string[]): void;
   isRuntimeReady(): boolean;
 }
@@ -216,7 +216,7 @@ export const createRuntimeSlice: StateCreator<MyState, [], [], RuntimeSlice> = (
     return get().ydoc.getMap("rootMap").get("resultMap") as Y.Map<PodResult>;
   },
   activeRuntime: undefined,
-  setActiveRuntime(id: string) {
+  setActiveRuntime(id?: string) {
     set({ activeRuntime: id });
   },
   /**

--- a/apps/ui/src/lib/store/yjsSlice.ts
+++ b/apps/ui/src/lib/store/yjsSlice.ts
@@ -205,8 +205,21 @@ export const createYjsSlice: StateCreator<MyState, [], [], YjsSlice> = (
       // Set up observers to trigger future runtime status changes.
       runtimeMap.observe(
         (YMapEvent: Y.YEvent<any>, transaction: Y.Transaction) => {
-          // delete runtime is a local change.
-          // if (transaction.local) return;
+          if (transaction.local) return;
+          YMapEvent.changes.keys.forEach((change, key) => {
+            if (change.action === "add") {
+            } else if (change.action === "update") {
+            } else if (change.action === "delete") {
+              // If it was the active runtime, reset it.
+              if (get().activeRuntime === key) {
+                get().setActiveRuntime(undefined);
+              }
+            }
+          });
+          // Set active runtime if it is not set
+          if (runtimeMap.size > 0 && !get().activeRuntime) {
+            get().setActiveRuntime(Array.from(runtimeMap.keys())[0]);
+          }
           get().toggleRuntimeChanged();
         }
       );


### PR DESCRIPTION
Now the active runtime should be set automatically when spawn/kill a runtime.
1. if a runtime is deleted, and if it was the active runtime, set the active runtime to `undefined`
2. if a runtime is added, and there's no active runtime, set the active runtime to the first runtime

#495 also tried to fix it.