### PR TITLE
clean up runtime disconnected status/UI

### DIFF
--- a/apps/ui/src/components/Sidebar.tsx
+++ b/apps/ui/src/components/Sidebar.tsx
@@ -721,40 +721,9 @@ const RuntimeItem = ({ runtimeId }) => {
                 connecting
               </Box>
             ))
-            .with("disconnected", () => (
-              <Box color="yellow" component="span">
-                Disconnected{" "}
-                <Button
-                  onClick={() => {
-                    connect({
-                      variables: {
-                        runtimeId,
-                        repoId,
-                      },
-                    });
-                  }}
-                  sx={{ color: "red" }}
-                >
-                  retry
-                </Button>
-              </Box>
-            ))
             .otherwise(() => (
               <Box color="red" component="span">
-                {runtime.wsStatus || "unknown"}
-                <Button
-                  onClick={() => {
-                    connect({
-                      variables: {
-                        runtimeId,
-                        repoId,
-                      },
-                    });
-                  }}
-                  sx={{ color: "red" }}
-                >
-                  retry
-                </Button>
+                Disconnected{" "}
               </Box>
             ))}
           <RuntimeMoreMenu runtimeId={runtimeId} />


### PR DESCRIPTION
When disconnected, don't show a `retry` button. The runtime connection is retried automatically every 1 second.

TODO: use exponential back-off for the retry time with a up-limit, e.g., 1s, 2s, 4s, 8s, 10s, 10s, 10s, ...