### PR TITLE
[UI] Update ToC when nodesMap change

### DIFF
--- a/apps/ui/src/components/Canvas.tsx
+++ b/apps/ui/src/components/Canvas.tsx
@@ -413,11 +413,6 @@ function CanvasImpl() {
   const addNode = useStore(store, (state) => state.addNode);
   const importLocalCode = useStore(store, (state) => state.importLocalCode);
 
-  const node2children = useStore(store, (state) => state.node2children);
-  const buildNode2Children = useStore(
-    store,
-    (state) => state.buildNode2Children
-  );
   const selectedPods = useStore(store, (state) => state.selectedPods);
 
   const reactFlowInstance = useReactFlow();
@@ -458,12 +453,6 @@ function CanvasImpl() {
       setShowContextMenu(false);
     }
   }, [escapePressed]);
-
-  useEffect(() => {
-    if (node2children.size == 0) {
-      buildNode2Children();
-    }
-  }, [node2children]);
 
   const centerSelection = useStore(store, (state) => state.centerSelection);
   const setCenterSelection = useStore(

--- a/apps/ui/src/components/Canvas.tsx
+++ b/apps/ui/src/components/Canvas.tsx
@@ -413,6 +413,11 @@ function CanvasImpl() {
   const addNode = useStore(store, (state) => state.addNode);
   const importLocalCode = useStore(store, (state) => state.importLocalCode);
 
+  const node2children = useStore(store, (state) => state.node2children);
+  const buildNode2Children = useStore(
+    store,
+    (state) => state.buildNode2Children
+  );
   const selectedPods = useStore(store, (state) => state.selectedPods);
 
   const reactFlowInstance = useReactFlow();
@@ -453,6 +458,12 @@ function CanvasImpl() {
       setShowContextMenu(false);
     }
   }, [escapePressed]);
+
+  useEffect(() => {
+    if (node2children.size == 0) {
+      buildNode2Children();
+    }
+  }, [node2children]);
 
   const centerSelection = useStore(store, (state) => state.centerSelection);
   const setCenterSelection = useStore(

--- a/apps/ui/src/components/Sidebar.tsx
+++ b/apps/ui/src/components/Sidebar.tsx
@@ -1213,31 +1213,7 @@ function PodTreeItem({ id, node2children }) {
 function TableofPods() {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const nodesMap = useStore(store, (state) => state.getNodesMap());
-  let node2children = new Map<string, string[]>();
-  let keys = new Set(nodesMap.keys());
-
-  for (const key of Array.from(keys)) {
-    if (!node2children.has(key)) {
-      node2children.set(key, []);
-    }
-    const parent =
-      nodesMap.get(key)?.parentNode === undefined
-        ? "ROOT"
-        : nodesMap.get(key)?.parentNode;
-
-    if (!node2children.has(parent!)) {
-      node2children.set(parent!, []);
-    }
-
-    node2children.get(parent!)!.push(key);
-  }
-
-  for (const value of Array.from(node2children.values())) {
-    if (value.length > 1) {
-      sortNodes(value, nodesMap);
-    }
-  }
+  const node2children = useStore(store, (state) => state.node2children);
 
   return (
     <TreeView

--- a/apps/ui/src/lib/store/yjsSlice.ts
+++ b/apps/ui/src/lib/store/yjsSlice.ts
@@ -182,6 +182,8 @@ export const createYjsSlice: StateCreator<MyState, [], [], YjsSlice> = (
       get().updateView();
       // Trigger initial results rendering.
       const resultMap = get().getResultMap();
+      // Initialize node2children
+      get().buildNode2Children();
       Array.from(resultMap.keys()).forEach((key) => {
         get().toggleResultChanged(key);
       });


### PR DESCRIPTION
## Summary
- Restore `node2children` and `buildNode2Children()` in `canvasSlice`
- Update `ToC` using `node2children`
- Fix issue #503 

## Test

![ToC_patch](https://github.com/codepod-io/codepod/assets/10226241/5aa251e3-435e-458b-a617-9213aeeafe43)
