### PR TITLE
refactor: move apolloClient out of Zustand store

### DIFF
--- a/apps/ui/src/components/Canvas.tsx
+++ b/apps/ui/src/components/Canvas.tsx
@@ -48,6 +48,7 @@ import FloatingEdge from "./nodes/FloatingEdge";
 import CustomConnectionLine from "./nodes/CustomConnectionLine";
 import HelperLines from "./HelperLines";
 import { getAbsPos, newNodeShapeConfig } from "../lib/store/canvasSlice";
+import { useApolloClient } from "@apollo/client";
 
 const nodeTypes = { SCOPE: ScopeNode, CODE: CodeNode, RICH: RichNode };
 const edgeTypes = {
@@ -149,6 +150,7 @@ function useJump() {
   const selectPod = useStore(store, (state) => state.selectPod);
 
   const yjsRun = useStore(store, (state) => state.yjsRun);
+  const apolloClient = useApolloClient();
 
   const setCenterSelection = useStore(
     store,
@@ -238,7 +240,7 @@ function useJump() {
         if (pod.type == "CODE") {
           if (event.shiftKey) {
             // Hitting "SHIFT"+"Enter" will run the code pod
-            yjsRun(id);
+            yjsRun(id, apolloClient);
           } else {
             // Hitting "Enter" on a Code pod will go to "Edit" mode.
             setFocusedEditor(id);
@@ -246,7 +248,7 @@ function useJump() {
         } else if (pod.type === "SCOPE") {
           if (event.shiftKey) {
             // Hitting "SHIFT"+"Enter" on a Scope will run the scope.
-            yjsRun(id);
+            yjsRun(id, apolloClient);
           }
         } else if (pod.type === "RICH") {
           // Hitting "Enter" on a Rich pod will go to "Edit" mode.

--- a/apps/ui/src/components/MyMonaco.tsx
+++ b/apps/ui/src/components/MyMonaco.tsx
@@ -10,6 +10,7 @@ import { RepoContext } from "../lib/store";
 import { MonacoBinding } from "y-monaco";
 import { useReactFlow } from "reactflow";
 import { Annotation } from "../lib/parser";
+import { useApolloClient } from "@apollo/client";
 
 const theme: monaco.editor.IStandaloneThemeData = {
   base: "vs",
@@ -395,6 +396,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const readOnly = useStore(store, (state) => state.role === "GUEST");
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const yjsRun = useStore(store, (state) => state.yjsRun);
+  const apolloClient = useApolloClient();
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const annotations = useStore(
@@ -483,7 +485,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
       label: "Run",
       keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.Enter],
       run: () => {
-        yjsRun(id);
+        yjsRun(id, apolloClient);
       },
     });
     editor.addAction({

--- a/apps/ui/src/components/nodes/Code.tsx
+++ b/apps/ui/src/components/nodes/Code.tsx
@@ -58,6 +58,7 @@ import { timeDifference } from "../../lib/utils/utils";
 import { ButtonGroup } from "@mui/material";
 
 import { ConfirmDeleteButton } from "./utils";
+import { useApolloClient } from "@apollo/client";
 
 function Timer({ lastExecutedAt }) {
   const [counter, setCounter] = useState(0);
@@ -388,6 +389,7 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
   // const pod = useStore(store, (state) => state.pods[id]);
   const yjsRun = useStore(store, (state) => state.yjsRun);
   const yjsRunChain = useStore(store, (state) => state.yjsRunChain);
+  const apolloClient = useApolloClient();
   // right, bottom
   const isGuest = useStore(store, (state) => state.role === "GUEST");
 
@@ -413,7 +415,7 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
         <Tooltip title="Run (shift-enter)">
           <IconButton
             onClick={() => {
-              yjsRun(id);
+              yjsRun(id, apolloClient);
             }}
           >
             <PlayCircleOutlineIcon style={{ fontSize: iconFontSize }} />
@@ -424,7 +426,7 @@ function MyFloatingToolbar({ id, layout, setLayout }) {
         <Tooltip title="Run chain">
           <IconButton
             onClick={() => {
-              yjsRunChain(id);
+              yjsRunChain(id, apolloClient);
             }}
           >
             <KeyboardDoubleArrowRightIcon style={{ fontSize: iconFontSize }} />

--- a/apps/ui/src/components/nodes/Scope.tsx
+++ b/apps/ui/src/components/nodes/Scope.tsx
@@ -50,6 +50,7 @@ import {
   level2fontsize,
 } from "./utils";
 import { CopyToClipboard } from "react-copy-to-clipboard";
+import { useApolloClient } from "@apollo/client";
 
 function MyFloatingToolbar({ id }: { id: string }) {
   const store = useContext(RepoContext);
@@ -57,6 +58,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
   const reactFlowInstance = useReactFlow();
   const isGuest = useStore(store, (state) => state.role === "GUEST");
   const yjsRun = useStore(store, (state) => state.yjsRun);
+  const apolloClient = useApolloClient();
 
   const autoLayout = useStore(store, (state) => state.autoLayout);
 
@@ -85,7 +87,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
         <Tooltip title="Run (shift-enter)">
           <IconButton
             onClick={() => {
-              yjsRun(id);
+              yjsRun(id, apolloClient);
             }}
           >
             <PlayCircleOutlineIcon style={{ fontSize: iconFontSize }} />

--- a/apps/ui/src/pages/repo.tsx
+++ b/apps/ui/src/pages/repo.tsx
@@ -392,14 +392,10 @@ function RepoImpl() {
     }
   }, [addClient, deleteClient, provider]);
 
-  const apolloClient = useApolloClient();
-  const setApolloClient = useStore(store, (state) => state.setApolloClient);
-
   useEffect(() => {
     if (hasToken()) {
       if (!loading && me) {
         setUser(me);
-        setApolloClient(apolloClient);
       }
     }
   }, [loading, me]);


### PR DESCRIPTION
Pass the apolloClient as a paramter instead.

Old:

```
apolloClient = useApolloClient()
setApolloClient(apolloClient)
...
yjsRun(id)
```
New:

```
apolloClient = useApolloClient()
yjsRun(id, apolloClient)
```