### PR TITLE
refactor: remove deprecated resolver code

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,10 +4,8 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "start": "node build/server.js",
-    "dev": "ts-node-dev src/server.ts",
-    "start:yjs": "node build/yjs-server.js",
-    "dev:yjs": "ts-node-dev src/yjs-server.ts",
+    "start": "node build/run.js",
+    "dev": "ts-node-dev src/run.ts",
     "test": "jest --config jest.config.js"
   },
   "dependencies": {

--- a/apps/api/src/run.ts
+++ b/apps/api/src/run.ts
@@ -1,0 +1,3 @@
+import { startServer } from "./server";
+
+startServer({ port: 4000 });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -50,7 +50,7 @@ interface TokenInterface {
   id: string;
 }
 
-async function startServer({ port }) {
+export async function startServer({ port }) {
   const apollo = new ApolloServer({
     typeDefs,
     resolvers,
@@ -86,5 +86,3 @@ async function startServer({ port }) {
     console.log(`🚀 Server ready at http://localhost:${port}`);
   });
 }
-
-startServer({ port: 4000 });

--- a/apps/api/src/typedefs.ts
+++ b/apps/api/src/typedefs.ts
@@ -12,14 +12,12 @@ export const typeDefs = gql`
     password: String!
     firstname: String!
     lastname: String!
-    codeiumAPIKey: String!
+    codeiumAPIKey: String
   }
 
   type Repo {
     id: ID!
     name: String
-    pods: [Pod]
-    edges: [Edge]
     userId: ID!
     stargazers: [User]
     collaborators: [User]
@@ -29,85 +27,13 @@ export const typeDefs = gql`
     accessedAt: String
   }
 
-  type Edge {
-    source: String!
-    target: String!
-  }
-
-  type Pod {
-    id: ID!
-    type: String
-    content: String
-    githead: String
-    staged: String
-    column: Int
-    lang: String
-    parent: Pod
-    index: Int
-    children: [Pod]
-    result: String
-    stdout: String
-    error: String
-    imports: String
-    exports: String
-    reexports: String
-    midports: String
-    fold: Boolean
-    thundar: Boolean
-    utility: Boolean
-    name: String
-    x: Float
-    y: Float
-    width: Float
-    height: Float
-  }
-
-  input PodInput {
-    id: ID!
-    type: String
-    content: String
-    column: Int
-    lang: String
-    result: String
-    stdout: String
-    error: String
-    imports: String
-    exports: String
-    reexports: String
-    midports: String
-    fold: Boolean
-    thundar: Boolean
-    utility: Boolean
-    name: String
-    x: Float
-    y: Float
-    width: Float
-    height: Float
-    parent: ID
-    children: [ID]
-  }
-
-  type RuntimeInfo {
-    startedAt: String
-    lastActive: String
-    sessionId: String
-    ttl: Int
-  }
-
-  input RunSpecInput {
-    code: String
-    podId: String
-  }
-
   type Query {
     hello: String
     users: [User]
     me: User
     repos: [Repo]
     repo(id: String!): Repo
-    pod(id: ID!): Pod
     getDashboardRepos: [Repo]
-    activeSessions: [String]
   }
 
   type Mutation {
@@ -124,12 +50,6 @@ export const typeDefs = gql`
     updateRepo(id: ID!, name: String!): Boolean
     deleteRepo(id: ID!): Boolean
     copyRepo(repoId: String!): ID!
-    updatePod(id: String!, repoId: String!, input: PodInput): Boolean
-    addEdge(source: ID!, target: ID!): Boolean
-    deleteEdge(source: ID!, target: ID!): Boolean
-    clearUser: Boolean
-    clearRepo: Boolean
-    clearPod: Boolean
     updateVisibility(repoId: String!, isPublic: Boolean!): Boolean
     addCollaborator(repoId: String!, email: String!): Boolean
     deleteCollaborator(repoId: String!, collaboratorId: String!): Boolean


### PR DESCRIPTION
Major Changes:
1. Remove code that operates the POD table, as the POD table was entirely deprecated.

Minors:
1. make codeiumAPIKey optional
2. extract server starting code to `run.ts`