### PR TITLE
init file-backend

### DIFF
--- a/apps/file-backend/.gitignore
+++ b/apps/file-backend/.gitignore
@@ -1,0 +1,3 @@
+dist/
+conns/conn-*.json
+prisma/dev.db

--- a/apps/file-backend/jest.config.js
+++ b/apps/file-backend/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.ts?$": "ts-jest",
+  },
+  transformIgnorePatterns: ["<rootDir>/node_modules/"],
+};

--- a/apps/file-backend/package.json
+++ b/apps/file-backend/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "api",
+  "version": "1.0.0",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "start": "node build/run.js",
+    "dev": "ts-node-dev src/run.ts",
+    "test": "jest --config jest.config.js"
+  },
+  "dependencies": {
+    "@apollo/client": "^3.7.1",
+    "@codepod/prisma": "workspace:*",
+    "@kubernetes/client-node": "^0.17.1",
+    "@prisma/client": "4.3.1",
+    "apollo-server": "^3.5.0",
+    "apollo-server-core": "^3.10.3",
+    "apollo-server-express": "3.10.2",
+    "bcryptjs": "^2.4.3",
+    "dockerode": "^3.3.1",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "google-auth-library": "^8.7.0",
+    "graphql": "16.6.0",
+    "jest": "^29.0.3",
+    "jsdom": "^22.1.0",
+    "jsonwebtoken": "^8.5.1",
+    "lib0": "^0.2.83",
+    "lodash": "^4.17.21",
+    "nanoid": "^3.0.0",
+    "nanoid-dictionary": "^4.3.0",
+    "prisma": "4.3.1",
+    "prosemirror-model": "^1.19.3",
+    "prosemirror-view": "^1.31.7",
+    "ws": "^8.2.3",
+    "y-prosemirror": "^1.2.1",
+    "y-protocols": "^1.0.5",
+    "yjs": "^13.6.7"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.6.4",
+    "@types/bcryptjs": "^2.4.2",
+    "@types/express": "^4.17.14",
+    "@types/jsonwebtoken": "^8.5.9",
+    "@types/node": "^18.11.2",
+    "@types/ws": "^8.5.3",
+    "ts-jest": "^29.0.1",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^4.4.4"
+  }
+}

--- a/apps/file-backend/src/run.ts
+++ b/apps/file-backend/src/run.ts
@@ -1,0 +1,3 @@
+import { startServer } from "./server";
+
+startServer({ port: 4001 });

--- a/apps/file-backend/src/server.ts
+++ b/apps/file-backend/src/server.ts
@@ -1,0 +1,69 @@
+import express from "express";
+import http from "http";
+
+import { ApolloServer, gql } from "apollo-server-express";
+
+import { ApolloServerPluginLandingPageLocalDefault } from "apollo-server-core";
+
+export const typeDefs = gql`
+  type User {
+    id: ID!
+    username: String
+    email: String!
+    password: String!
+    firstname: String!
+    lastname: String!
+    codeiumAPIKey: String
+  }
+
+  type Repo {
+    id: ID!
+    name: String
+    userId: ID!
+    stargazers: [User]
+    collaborators: [User]
+    public: Boolean
+    createdAt: String
+    updatedAt: String
+    accessedAt: String
+  }
+
+  type Query {
+    hello: String
+  }
+
+  type Mutation {
+    world: String
+  }
+`;
+
+export const resolvers = {
+  Query: {
+    hello: () => {
+      return "Hello world!";
+    },
+  },
+  Mutation: {
+    world: () => {
+      return "World!";
+    },
+  },
+};
+
+export async function startServer({ port }) {
+  const apollo = new ApolloServer({
+    typeDefs,
+    resolvers,
+    plugins: [ApolloServerPluginLandingPageLocalDefault({ embed: true })],
+  });
+  const expapp = express();
+  expapp.use(express.json({ limit: "20mb" }));
+  const http_server = http.createServer(expapp);
+
+  await apollo.start();
+  apollo.applyMiddleware({ app: expapp });
+
+  http_server.listen({ port }, () => {
+    console.log(`🚀 Server ready at http://localhost:${port}`);
+  });
+}

--- a/apps/file-backend/tsconfig.json
+++ b/apps/file-backend/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "outDir": "./build",
+        "target": "esnext",
+        "allowJs": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "lib": ["esnext"],
+        "moduleResolution": "node",
+        "noFallthroughCasesInSwitch": true,
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "isolatedModules": true,
+        "noImplicitAny": false,
+    },
+    "ts-node": {
+        // these options are overrides used only by ts-node
+        // same as the --compilerOptions flag and the TS_NODE_COMPILER_OPTIONS environment variable
+        "compilerOptions": {
+          "module": "commonjs"
+        }
+      },
+    "include": ["src"]
+}

--- a/compose/dev/compose.yml
+++ b/compose/dev/compose.yml
@@ -49,10 +49,22 @@ services:
     volumes:
       - ../..:/codepod
       - pnpm-store:/codepod/.pnpm-store
-      - /var/run/docker.sock:/var/run/docker.sock
     command: sh -c "corepack enable && pnpm dev"
     environment:
       DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?schema=public"
+      JWT_SECRET: ${JWT_SECRET}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+
+  file-backend:
+    image: node:18
+    working_dir: /codepod/apps/file-backend
+    ports:
+      - 4001:4001
+    volumes:
+      - ../..:/codepod
+      - pnpm-store:/codepod/.pnpm-store
+    command: sh -c "corepack enable && pnpm dev"
+    environment:
       JWT_SECRET: ${JWT_SECRET}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,118 @@ importers:
         specifier: ~4.5.4
         version: 4.5.4
 
+  apps/file-backend:
+    dependencies:
+      '@apollo/client':
+        specifier: ^3.7.1
+        version: 3.8.1(graphql@16.6.0)(react-dom@18.2.0)(react@18.2.0)
+      '@codepod/prisma':
+        specifier: workspace:*
+        version: link:../../packages/prisma
+      '@kubernetes/client-node':
+        specifier: ^0.17.1
+        version: 0.17.1
+      '@prisma/client':
+        specifier: 4.3.1
+        version: 4.3.1(prisma@4.3.1)
+      apollo-server:
+        specifier: ^3.5.0
+        version: 3.10.3(graphql@16.6.0)
+      apollo-server-core:
+        specifier: ^3.10.3
+        version: 3.12.0(graphql@16.6.0)
+      apollo-server-express:
+        specifier: 3.10.2
+        version: 3.10.2(express@4.18.2)(graphql@16.6.0)
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
+      dockerode:
+        specifier: ^3.3.1
+        version: 3.3.1
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
+      express:
+        specifier: ^4.18.2
+        version: 4.18.2
+      google-auth-library:
+        specifier: ^8.7.0
+        version: 8.7.0
+      graphql:
+        specifier: 16.6.0
+        version: 16.6.0
+      jest:
+        specifier: ^29.0.3
+        version: 29.0.3(@types/node@18.17.10)
+      jsdom:
+        specifier: ^22.1.0
+        version: 22.1.0
+      jsonwebtoken:
+        specifier: ^8.5.1
+        version: 8.5.1
+      lib0:
+        specifier: ^0.2.83
+        version: 0.2.83
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      nanoid:
+        specifier: ^3.0.0
+        version: 3.3.6
+      nanoid-dictionary:
+        specifier: ^4.3.0
+        version: 4.3.0
+      prisma:
+        specifier: 4.3.1
+        version: 4.3.1
+      prosemirror-model:
+        specifier: ^1.19.3
+        version: 1.19.3
+      prosemirror-view:
+        specifier: ^1.31.7
+        version: 1.31.7
+      ws:
+        specifier: ^8.2.3
+        version: 8.13.0
+      y-prosemirror:
+        specifier: ^1.2.1
+        version: 1.2.1(prosemirror-model@1.19.3)(prosemirror-state@1.4.3)(prosemirror-view@1.31.7)(y-protocols@1.0.5)(yjs@13.6.7)
+      y-protocols:
+        specifier: ^1.0.5
+        version: 1.0.5
+      yjs:
+        specifier: ^13.6.7
+        version: 13.6.7
+    devDependencies:
+      '@jest/globals':
+        specifier: ^29.6.4
+        version: 29.6.4
+      '@types/bcryptjs':
+        specifier: ^2.4.2
+        version: 2.4.2
+      '@types/express':
+        specifier: ^4.17.14
+        version: 4.17.17
+      '@types/jsonwebtoken':
+        specifier: ^8.5.9
+        version: 8.5.9
+      '@types/node':
+        specifier: ^18.11.2
+        version: 18.17.10
+      '@types/ws':
+        specifier: ^8.5.3
+        version: 8.5.3
+      ts-jest:
+        specifier: ^29.0.1
+        version: 29.0.1(@babel/core@7.22.11)(jest@29.0.3)(typescript@4.8.4)
+      ts-node-dev:
+        specifier: ^2.0.0
+        version: 2.0.0(@types/node@18.17.10)(typescript@4.8.4)
+      typescript:
+        specifier: ^4.4.4
+        version: 4.8.4
+
   apps/runtime:
     dependencies:
       '@apollo/client':


### PR DESCRIPTION
This is a copy and cleanup of `api/` folder into `file-backend` folder. The file-backend is expected to
1. remove user authentication and
2. write to files instead of DB.

This PR initiates this effort.