### PR TITLE
Make all treeview items expanded. Disable toggle.

### DIFF
--- a/apps/ui/src/components/Sidebar.tsx
+++ b/apps/ui/src/components/Sidebar.tsx
@@ -918,25 +918,15 @@ function TableofPods() {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const node2children = useStore(store, (state) => state.node2children);
-  // Set all nodes to expanded by default.
+  // Set all nodes to expanded. Disable the collapse/expand for now.
   const allIds = Array.from(node2children.keys());
-  // Use Controlled TreeView
-  const [expanded, setExpanded] = useState<string[]>(allIds);
 
   return (
     <TreeView
       aria-label="multi-select"
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
-      expanded={expanded}
-      onNodeToggle={(event, nodeIds) => {
-        // Only toggle expansion on the icon, not the label. Ref:
-        // https://github.com/mui/material-ui/issues/19953#issuecomment-635961028
-        const el = event.target as Element;
-        if (el.closest(".MuiTreeItem-iconContainer")) {
-          setExpanded(nodeIds);
-        }
-      }}
+      expanded={allIds}
       multiSelect
     >
       {node2children.size > 0 &&

--- a/apps/ui/src/components/Sidebar.tsx
+++ b/apps/ui/src/components/Sidebar.tsx
@@ -918,15 +918,25 @@ function TableofPods() {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const node2children = useStore(store, (state) => state.node2children);
+  // Set all nodes to expanded by default.
+  const allIds = Array.from(node2children.keys());
+  // Use Controlled TreeView
+  const [expanded, setExpanded] = useState<string[]>(allIds);
 
   return (
     <TreeView
       aria-label="multi-select"
       defaultCollapseIcon={<ExpandMoreIcon />}
       defaultExpandIcon={<ChevronRightIcon />}
-      defaultExpanded={Array.from(node2children.keys()).filter(
-        (key) => node2children!.get(key!)!.length > 0
-      )}
+      expanded={expanded}
+      onNodeToggle={(event, nodeIds) => {
+        // Only toggle expansion on the icon, not the label. Ref:
+        // https://github.com/mui/material-ui/issues/19953#issuecomment-635961028
+        const el = event.target as Element;
+        if (el.closest(".MuiTreeItem-iconContainer")) {
+          setExpanded(nodeIds);
+        }
+      }}
       multiSelect
     >
       {node2children.size > 0 &&


### PR DESCRIPTION
This PR makes the TreeView controlled. All items are expanded, and toggle is disabled.

Some TODOs:

* [ ] the expand/toggle info should be persisted to DB so that it remains after refreshing. This should be kept at UserRepoData, not in the Yjs, because users should have their own views.
* [ ] ba50b0de24 implemented toggle on icon, not label. This is the expected behavior, but needs to be enabled after we save the toggle status to DB/UserRepoData.

This PR also fixes a console error:

<img width="718" alt="Screenshot 2023-09-07 at 6 44 11 PM" src="https://github.com/codepod-io/codepod/assets/4576201/1b818742-62fb-401a-8dec-d8530e94533c">
