### PR TITLE
fix: yjs container name

### DIFF
--- a/apps/spawner/src/server.ts
+++ b/apps/spawner/src/server.ts
@@ -38,7 +38,7 @@ async function getMyYDoc({ repoId, token }): Promise<Y.Doc> {
     }
     const ydoc = new Y.Doc();
     // connect to primary database
-    console.log("connecting to y-websocket provider");
+    console.log("connecting to y-websocket provider", yjsServerUrl);
     const provider = new WebsocketProvider(yjsServerUrl, repoId, ydoc, {
       // resyncInterval: 2000,
       //
@@ -48,6 +48,9 @@ async function getMyYDoc({ repoId, token }): Promise<Y.Doc> {
         token,
         role: "runtime",
       },
+    });
+    provider.on("status", ({ status }) => {
+      console.log("provider status", status);
     });
     provider.once("synced", () => {
       console.log("Provider synced");
@@ -113,9 +116,12 @@ export async function startAPIServer({ port, spawnRuntime, killRuntime }) {
           if (!userId) throw new Error("Not authorized.");
           // create the runtime container
           const wsUrl = await spawnRuntime(runtimeId);
+          console.log("Runtime spawned at", wsUrl);
           routingTable.set(runtimeId, wsUrl);
           // set initial runtimeMap info for this runtime
+          console.log("Loading yDoc ..");
           const doc = await getMyYDoc({ repoId, token });
+          console.log("yDoc loaded");
           const rootMap = doc.getMap("rootMap");
           const runtimeMap = rootMap.get("runtimeMap") as Y.Map<RuntimeInfo>;
           runtimeMap.set(runtimeId, {});

--- a/compose/dev/compose.yml
+++ b/compose/dev/compose.yml
@@ -82,7 +82,7 @@ services:
     environment:
       KERNEL_TTL: "43200000"
       LOOP_INTERVAL: "60000"
-      YJS_WS_URL: "ws://yjs-server:4233/socket"
+      YJS_WS_URL: "ws://yjs:4233/socket"
       JWT_SECRET: ${JWT_SECRET}
 
   spawner-docker:
@@ -114,7 +114,7 @@ services:
       WS_RUNTIME_IMAGE: "lihebi/codepod-runtime:0.4.13-alpha.49"
       # spawner need to add routes to proxy server
       # PROXY_API_URL: "http://proxy:4011/graphql"
-      YJS_WS_URL: "ws://yjs-server:4233/socket"
+      YJS_WS_URL: "ws://yjs:4233/socket"
       JWT_SECRET: ${JWT_SECRET}
 
   yjs:

--- a/compose/dev/nginx.conf
+++ b/compose/dev/nginx.conf
@@ -24,7 +24,7 @@ server {
         }
 
         location /socket {
-                proxy_pass http://yjs-server:4233;
+                proxy_pass http://yjs:4233;
                 proxy_http_version 1.1;
                 proxy_set_header Upgrade $http_upgrade;
                 proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Regression caused by #526 changing container name from `yjs-server` to `yjs`, but forgot to update YJS_WS_URL