### PR TITLE
fix: remove dotenv

### DIFF
--- a/apps/desktop-api/package.json
+++ b/apps/desktop-api/package.json
@@ -18,7 +18,6 @@
     "apollo-server-express": "3.10.2",
     "bcryptjs": "^2.4.3",
     "dockerode": "^3.3.1",
-    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "google-auth-library": "^8.7.0",
     "graphql": "16.6.0",

--- a/apps/spawner/src/run-docker.ts
+++ b/apps/spawner/src/run-docker.ts
@@ -2,8 +2,6 @@ import { startAPIServer } from "./server";
 
 import { killRuntime, spawnRuntime } from "./spawner-docker";
 
-require("dotenv").config();
-
 if (!process.env.JWT_SECRET) {
   throw new Error("JWT_SECRET env variable is not set.");
 }

--- a/apps/spawner/src/run-native.ts
+++ b/apps/spawner/src/run-native.ts
@@ -1,8 +1,6 @@
 import { startAPIServer } from "./server";
 import { killRuntime, spawnRuntime } from "./spawner-native";
 
-require("dotenv").config();
-
 if (!process.env.JWT_SECRET) {
   throw new Error("JWT_SECRET env variable is not set.");
 }

--- a/apps/web-api/package.json
+++ b/apps/web-api/package.json
@@ -18,7 +18,6 @@
     "apollo-server-express": "3.10.2",
     "bcryptjs": "^2.4.3",
     "dockerode": "^3.3.1",
-    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "google-auth-library": "^8.7.0",
     "graphql": "16.6.0",

--- a/apps/web-api/src/server.ts
+++ b/apps/web-api/src/server.ts
@@ -15,9 +15,6 @@ import { typeDefs } from "./typedefs";
 import { createUserResolver } from "./resolver_user";
 import { RepoResolver } from "./resolver_repo";
 
-// dotenv
-require("dotenv").config();
-
 if (!process.env.JWT_SECRET) {
   throw new Error("JWT_SECRET env variable is not set.");
 }

--- a/apps/web-yjs/src/run.ts
+++ b/apps/web-yjs/src/run.ts
@@ -1,7 +1,5 @@
 import { startWsServer } from "./yjs-server";
 
-require("dotenv").config();
-
 if (!process.env.JWT_SECRET) {
   throw new Error("JWT_SECRET env variable is not set.");
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       dockerode:
         specifier: ^3.3.1
         version: 3.3.1
-      dotenv:
-        specifier: ^16.3.1
-        version: 16.3.1
       express:
         specifier: ^4.18.2
         version: 4.18.2
@@ -415,9 +412,6 @@ importers:
       dockerode:
         specifier: ^3.3.1
         version: 3.3.1
-      dotenv:
-        specifier: ^16.3.1
-        version: 16.3.1
       express:
         specifier: ^4.18.2
         version: 4.18.2
@@ -7292,11 +7286,6 @@ packages:
 
   /domino@2.1.6:
     resolution: {integrity: sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==}
-    dev: false
-
-  /dotenv@16.3.1:
-    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
-    engines: {node: '>=12'}
     dev: false
 
   /dynamic-dedupe@0.3.0:


### PR DESCRIPTION
fix #536 

`require(dotenv)` isn't required, because we set ENV variables in compose.yaml, not loaded from `.env` file.