### PR TITLE
functional refactor & fix: remove state.role

### DIFF
--- a/packages/ui/src/components/Canvas.tsx
+++ b/packages/ui/src/components/Canvas.tsx
@@ -431,7 +431,8 @@ function CanvasImpl() {
   );
 
   const repoId = useStore(store, (state) => state.repoId);
-  const isGuest = useStore(store, (state) => state.role === "GUEST");
+
+  const editMode = useStore(store, (state) => state.editMode);
 
   const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
   const shareOpen = useStore(store, (state) => state.shareOpen);
@@ -656,9 +657,9 @@ function CanvasImpl() {
           zoomOnScroll={false}
           panOnScroll={true}
           connectionMode={ConnectionMode.Loose}
-          nodesDraggable={!isGuest}
+          nodesDraggable={editMode === "edit"}
           // disable node delete on backspace when the user is a guest.
-          deleteKeyCode={isGuest ? null : "Backspace"}
+          deleteKeyCode={editMode === "view" ? null : "Backspace"}
           multiSelectionKeyCode={isMac ? "Meta" : "Control"}
           selectionMode={SelectionMode.Partial}
           // TODO restore previous viewport
@@ -682,7 +683,7 @@ function CanvasImpl() {
               }}
               nodeBorderRadius={2}
             />
-            <Controls showInteractive={!isGuest} />
+            <Controls showInteractive={editMode === "edit"} />
 
             <HelperLines
               horizontal={helperLineHorizontal}

--- a/packages/ui/src/components/CanvasContextMenu.tsx
+++ b/packages/ui/src/components/CanvasContextMenu.tsx
@@ -36,11 +36,12 @@ export function CanvasContextMenu(props) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
 
-  const isGuest = useStore(store, (state) => state.role === "GUEST");
+  const editMode = useStore(store, (state) => state.editMode);
+  const editing = editMode === "edit";
   return (
     <Box sx={paneMenuStyle(props.x, props.y)}>
       <MenuList className="paneContextMenu">
-        {!isGuest && (
+        {editing && (
           <MenuItem onClick={props.addCode} sx={ItemStyle}>
             <ListItemIcon sx={{ color: "inherit" }}>
               <CodeIcon />
@@ -48,7 +49,7 @@ export function CanvasContextMenu(props) {
             <ListItemText>New Code</ListItemText>
           </MenuItem>
         )}
-        {!isGuest && (
+        {editing && (
           <MenuItem onClick={props.addRich} sx={ItemStyle}>
             <ListItemIcon sx={{ color: "inherit" }}>
               <NoteIcon />
@@ -56,7 +57,7 @@ export function CanvasContextMenu(props) {
             <ListItemText>New Note</ListItemText>
           </MenuItem>
         )}
-        {!isGuest && (
+        {editing && (
           <MenuItem onClick={props.addScope} sx={ItemStyle}>
             <ListItemIcon sx={{ color: "inherit" }}>
               <PostAddIcon />
@@ -64,7 +65,7 @@ export function CanvasContextMenu(props) {
             <ListItemText>New Scope</ListItemText>
           </MenuItem>
         )}
-        {!isGuest && (
+        {editing && (
           <MenuItem onClick={props.handleImportClick} sx={ItemStyle}>
             <ListItemIcon sx={{ color: "inherit" }}>
               <FileUploadTwoToneIcon />

--- a/packages/ui/src/components/MyMonaco.tsx
+++ b/packages/ui/src/components/MyMonaco.tsx
@@ -391,7 +391,6 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   console.debug("[perf] rendering MyMonaco", id);
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const readOnly = useStore(store, (state) => state.role === "GUEST");
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const yjsRun = useStore(store, (state) => state.yjsRun);
   const apolloClient = useApolloClient();

--- a/packages/ui/src/components/ShareProjDialog.tsx
+++ b/packages/ui/src/components/ShareProjDialog.tsx
@@ -102,7 +102,7 @@ function reducer(state, action) {
   }
 }
 
-function CollaboratorList({ repoId, collaborators, dispatch, isOwner }) {
+function CollaboratorList({ repoId, collaborators, dispatch }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const apolloClient = useApolloClient();
@@ -153,22 +153,20 @@ function CollaboratorList({ repoId, collaborators, dispatch, isOwner }) {
       {collaborators?.map((collab) => (
         <ListItem
           secondaryAction={
-            isOwner && (
-              <IconButton
-                edge="end"
-                aria-label="delete"
-                onClick={() =>
-                  deleteCollaborator({
-                    variables: {
-                      repoId: repoId,
-                      collaboratorId: collab.id,
-                    },
-                  })
-                }
-              >
-                <CloseIcon />
-              </IconButton>
-            )
+            <IconButton
+              edge="end"
+              aria-label="delete"
+              onClick={() =>
+                deleteCollaborator({
+                  variables: {
+                    repoId: repoId,
+                    collaboratorId: collab.id,
+                  },
+                })
+              }
+            >
+              <CloseIcon />
+            </IconButton>
           }
           sx={{ "&:hover": { backgroundColor: "#f5f5f5" } }}
           key={collab.id}
@@ -240,7 +238,6 @@ export function ShareProjDialog({
   const isPublic = useStore(store, (state) => state.isPublic);
   const collaborators = useStore(store, (state) => state.collaborators);
   const setShareOpen = useStore(store, (state) => state.setShareOpen);
-  const isOwner = useStore(store, (state) => state.role === "OWNER");
   const title = useStore(store, (state) => state.repoName || "Untitled");
   const url = `${window.location.protocol}//${window.location.host}/repo/${id}`;
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -309,18 +306,16 @@ export function ShareProjDialog({
                 <HelpOutlineOutlinedIcon fontSize="small" />
               </IconButton>
             </Tooltip>
-            {isOwner && (
-              <Button
-                sx={{ float: "right" }}
-                onClick={() => {
-                  updateVisibility({
-                    variables: { repoId: id, isPublic: !isPublic },
-                  });
-                }}
-              >
-                Make it {isPublic ? "private" : "public"}
-              </Button>
-            )}
+            <Button
+              sx={{ float: "right" }}
+              onClick={() => {
+                updateVisibility({
+                  variables: { repoId: id, isPublic: !isPublic },
+                });
+              }}
+            >
+              Make it {isPublic ? "private" : "public"}
+            </Button>
           </DialogContentText>
 
           {showHelp && (
@@ -337,7 +332,6 @@ export function ShareProjDialog({
           <CollaboratorList
             repoId={id}
             collaborators={collaborators}
-            isOwner={isOwner}
             dispatch={dispatch}
           />
 
@@ -355,7 +349,6 @@ export function ShareProjDialog({
             variant="standard"
             fullWidth
             inputRef={inputRef}
-            disabled={!isOwner}
           />
           <DialogActions>
             <Button
@@ -374,7 +367,6 @@ export function ShareProjDialog({
                 }
                 addCollaborator({ variables: { repoId: id, email } });
               }}
-              disabled={!isOwner}
             >
               Share
             </Button>

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -972,7 +972,6 @@ export const Sidebar = () => {
   // FIXME: improve the implementation logic
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
-  const isGuest = useStore(store, (state) => state.role === "GUEST");
   return (
     <>
       <MyKBar />
@@ -982,14 +981,11 @@ export const Sidebar = () => {
         }}
       >
         <Stack>
-          {!isGuest && (
-            <Box>
-              {/* <SyncStatus /> */}
-              <YjsSyncStatus />
-              <Divider />
-              <YjsRuntimeStatus />
-            </Box>
-          )}
+          <Box>
+            <YjsSyncStatus />
+            <Divider />
+            <YjsRuntimeStatus />
+          </Box>
           <Divider />
           <Typography variant="h6">Export to ..</Typography>
           <ExportButtons />

--- a/packages/ui/src/components/nodes/Scope.tsx
+++ b/packages/ui/src/components/nodes/Scope.tsx
@@ -56,7 +56,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
   const store = useContext(RepoContext);
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const reactFlowInstance = useReactFlow();
-  const isGuest = useStore(store, (state) => state.role === "GUEST");
+  const editMode = useStore(store, (state) => state.editMode);
   const yjsRun = useStore(store, (state) => state.yjsRun);
   const apolloClient = useApolloClient();
 
@@ -83,7 +83,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
       >
         <DragIndicatorIcon fontSize="inherit" />
       </Box>
-      {!isGuest && (
+      {editMode === "edit" && (
         <Tooltip title="Run (shift-enter)">
           <IconButton
             onClick={() => {
@@ -95,7 +95,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
         </Tooltip>
       )}
       {/* auto force layout */}
-      {!isGuest && (
+      {editMode === "edit" && (
         <Tooltip title="force layout">
           <IconButton
             onClick={() => {
@@ -106,7 +106,7 @@ function MyFloatingToolbar({ id }: { id: string }) {
           </IconButton>
         </Tooltip>
       )}
-      {!isGuest && (
+      {editMode === "edit" && (
         <Tooltip
           style={{ fontSize: iconFontSize }}
           title="Delete"
@@ -154,7 +154,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
   if (!store) throw new Error("Missing BearContext.Provider in the tree");
   const setPodName = useStore(store, (state) => state.setPodName);
   const nodesMap = useStore(store, (state) => state.getNodesMap());
-  const isGuest = useStore(store, (state) => state.role === "GUEST");
+  const editMode = useStore(store, (state) => state.editMode);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const devMode = useStore(store, (state) => state.devMode);
@@ -341,7 +341,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
                   // setPodName({ id, name });
                 }}
                 inputRef={inputRef}
-                disabled={isGuest}
+                disabled={editMode === "view"}
                 inputProps={{
                   style: {
                     padding: "0px",

--- a/packages/ui/src/lib/store/canvasSlice.ts
+++ b/packages/ui/src/lib/store/canvasSlice.ts
@@ -71,58 +71,6 @@ export const newNodeShapeConfig = {
 };
 
 /**
- * Creare the temporary nodes as well as the temporary pods based on the given pod.
- * @param pod
- * @param position
- * @param parent
- * @param level
- * @returns
- */
-function createTemporaryNode(pod, position, parent?, level = 0): any {
-  const id = myNanoId();
-  let style = {
-    // create a temporary half-transparent pod
-    opacity: 0.5,
-    width: pod.width,
-  };
-
-  if (pod.type === "SCOPE") {
-    style["height"] = pod.height!;
-    style["backgroundColor"] = level2color[level] || level2color["default"];
-  }
-
-  const newNode = {
-    id,
-    type: pod.type,
-    position,
-    data: {
-      label: id,
-      parent,
-      level,
-    },
-    parentNode: parent,
-    dragHandle: ".custom-drag-handle",
-    width: pod.width,
-    height: pod.height!,
-    // Note: when the temporary node is finally sticked to the canvas, the click
-    // event will trigger drag event/position change of this node once and cause
-    // a bug because the node is not ready in the store and DB. just make it
-    // undraggable during moving to avoid this bug.
-    draggable: false,
-    style,
-  };
-
-  const newPod = { ...pod, parent, id, position, children: [] };
-  const nodes = [[newNode, newPod]];
-  pod.children.forEach((child) => {
-    nodes.push(
-      ...createTemporaryNode(child, { x: child.x, y: child.y }, id, level + 1)
-    );
-  });
-  return nodes;
-}
-
-/**
  * The new reactflow nodes for context-menu's addXXX items.
  */
 function createNewNode(
@@ -918,6 +866,7 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
           break;
         case "dimensions":
           {
+            console.log("dimension change", change.dimensions);
             // Since CodeNode doesn't have a height, this dimension change will
             // be filed for CodeNode at the beginning or anytime the node height
             // is changed due to content height changes.


### PR DESCRIPTION
This is one of the efforts to make the component more **"(purely) functional"** by extracting states out. States are global variables that should be avoided when possible.

Removed states:
* `state.role`. Also removed all isGuest checks (replaced by a more functional state.editMode below).
* `state.user`. The user is only used in Awareness and is now passed as function parameter to `connectYjs` action.
* `state.repoLoaded`

Added states:
* `state.editMode: "edit" | "view"`. This could be set on-demand for web-ui when loading user authentication module.

Bug fix:
* In `Code.tsx` and `Rich.tsx`, the Wrap didn't use correct width/height when the role was in "Guest".

