### PR TITLE
refactor: useStore! instead of checking for null

### DIFF
--- a/packages/ui/src/components/Canvas.tsx
+++ b/packages/ui/src/components/Canvas.tsx
@@ -277,8 +277,7 @@ function useJump() {
 }
 
 export function useCopyPaste() {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const rfDomNode = useRfStore((state) => state.domNode);
   const reactFlowInstance = useReactFlow();
   const handleCopy = useStore(store, (state) => state.handleCopy);
@@ -340,8 +339,7 @@ function CanvasImplWrap() {
 }
 
 function ViewportInfo() {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const { x, y, zoom } = useViewport();
   return (
     <Box
@@ -369,8 +367,7 @@ function ViewportInfo() {
 function CanvasImpl() {
   const reactFlowWrapper = useRef<any>(null);
 
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
 
   const nodes = useStore(store, (state) => state.nodes);
   const edges = useStore(store, (state) => state.edges);

--- a/packages/ui/src/components/CanvasContextMenu.tsx
+++ b/packages/ui/src/components/CanvasContextMenu.tsx
@@ -33,8 +33,7 @@ const ItemStyle = {
 };
 
 export function CanvasContextMenu(props) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
 
   const editMode = useStore(store, (state) => state.editMode);
   const editing = editMode === "edit";

--- a/packages/ui/src/components/MyKBar.tsx
+++ b/packages/ui/src/components/MyKBar.tsx
@@ -37,8 +37,7 @@ function RenderResults() {
 }
 
 export function MyKBar() {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const autoLayoutROOT = useStore(store, (state) => state.autoLayoutROOT);
   const actions = [
     {

--- a/packages/ui/src/components/MyMonaco.tsx
+++ b/packages/ui/src/components/MyMonaco.tsx
@@ -389,8 +389,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
 }) {
   // there's no racket language support
   console.debug("[perf] rendering MyMonaco", id);
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const yjsRun = useStore(store, (state) => state.yjsRun);
   const apolloClient = useApolloClient();

--- a/packages/ui/src/components/ShareProjDialog.tsx
+++ b/packages/ui/src/components/ShareProjDialog.tsx
@@ -103,8 +103,7 @@ function reducer(state, action) {
 }
 
 function CollaboratorList({ repoId, collaborators, dispatch }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const apolloClient = useApolloClient();
   const [deleteCollaborator, { data, loading, error }] = useMutation(
     gql`
@@ -230,8 +229,7 @@ export function ShareProjDialog({
   open = false,
   id = "",
 }: ShareProjDialogProps) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const [showHelp, setShowHelp] = useState(false);
   const [feedback, dispatch] = useReducer(reducer, initialState);
   const apolloClient = useApolloClient();

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -57,8 +57,7 @@ import { toSvg } from "html-to-image";
 import { match } from "ts-pattern";
 
 function SidebarSettings() {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const scopedVars = useStore(store, (state) => state.scopedVars);
   const setScopedVars = useStore(store, (state) => state.setScopedVars);
   const showAnnotations = useStore(store, (state) => state.showAnnotations);
@@ -760,8 +759,7 @@ const YjsRuntimeStatus = () => {
 };
 
 function YjsSyncStatus() {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   // FIXME performance issue
   const yjsStatus = useStore(store, (state) => state.yjsStatus);
   const yjsSyncStatus = useStore(store, (state) => state.yjsSyncStatus);
@@ -796,8 +794,7 @@ function YjsSyncStatus() {
 }
 
 function ToastError() {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const { enqueueSnackbar } = useSnackbar();
   const error = useStore(store, (state) => state.error);
   const clearError = useStore(store, (state) => state.clearError);
@@ -815,8 +812,7 @@ function ToastError() {
 
 function ExportJupyterNB() {
   const { id: repoId } = useParams();
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const repoName = useStore(store, (state) => state.repoName);
   const nodesMap = useStore(store, (state) => state.getNodesMap());
   const resultMap = useStore(store, (state) => state.getResultMap());
@@ -858,8 +854,7 @@ function ExportJupyterNB() {
 function ExportSVG() {
   // The name should contain the name of the repo, the ID of the repo, and the current date
   const { id: repoId } = useParams();
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const repoName = useStore(store, (state) => state.repoName);
   const filename = `${repoName?.replaceAll(
     " ",
@@ -912,8 +907,7 @@ function ExportButtons() {
 }
 
 function PodTreeItem({ id, node2children }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const selectPod = useStore(store, (state) => state.selectPod);
   const resetSelection = useStore(store, (state) => state.resetSelection);
   const setCenterSelection = useStore(
@@ -943,8 +937,7 @@ function PodTreeItem({ id, node2children }) {
 }
 
 function TableofPods() {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const node2children = useStore(store, (state) => state.node2children);
   // Set all nodes to expanded. Disable the collapse/expand for now.
   const allIds = Array.from(node2children.keys());
@@ -970,8 +963,7 @@ function TableofPods() {
 export const Sidebar = () => {
   // never render saving status / runtime module for a guest
   // FIXME: improve the implementation logic
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   return (
     <>
       <MyKBar />

--- a/packages/ui/src/components/nodes/Code.tsx
+++ b/packages/ui/src/components/nodes/Code.tsx
@@ -384,8 +384,7 @@ export const ResultBlock = memo<any>(function ResultBlock({ id, layout }) {
 });
 
 function MyFloatingToolbar({ id, layout, setLayout }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const reactFlowInstance = useReactFlow();
   const devMode = useStore(store, (state) => state.devMode);
   // const pod = useStore(store, (state) => state.pods[id]);
@@ -478,8 +477,7 @@ export const CodeNode = memo<NodeProps>(function ({
   xPos,
   yPos,
 }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const reactFlowInstance = useReactFlow();
   const devMode = useStore(store, (state) => state.devMode);
   // right, bottom

--- a/packages/ui/src/components/nodes/Rich.tsx
+++ b/packages/ui/src/components/nodes/Rich.tsx
@@ -253,8 +253,7 @@ const MyStyledWrapper = styled("div")(
 );
 
 function HotkeyControl({ id }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const focusedEditor = useStore(store, (state) => state.focusedEditor);
   const setFocusedEditor = useStore(store, (state) => state.setFocusedEditor);
   const selectPod = useStore(store, (state) => state.selectPod);
@@ -286,8 +285,7 @@ const MyEditor = ({
   id: string;
 }) => {
   // FIXME this is re-rendered all the time.
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const editMode = useStore(store, (state) => state.editMode);
   // the Yjs extension for Remirror
   const provider = useStore(store, (state) => state.provider)!;
@@ -467,8 +465,7 @@ const MyEditor = ({
 };
 
 function MyFloatingToolbar({ id }: { id: string }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const reactFlowInstance = useReactFlow();
   const editMode = useStore(store, (state) => state.editMode);
   const zoomLevel = useReactFlowStore((s) => s.transform[2]);
@@ -534,8 +531,7 @@ export const RichNode = memo<Props>(function ({
   xPos,
   yPos,
 }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   // const pod = useStore(store, (state) => state.pods[id]);
   const setPodName = useStore(store, (state) => state.setPodName);
   const editMode = useStore(store, (state) => state.editMode);

--- a/packages/ui/src/components/nodes/Scope.tsx
+++ b/packages/ui/src/components/nodes/Scope.tsx
@@ -53,8 +53,7 @@ import { CopyToClipboard } from "react-copy-to-clipboard";
 import { useApolloClient } from "@apollo/client";
 
 function MyFloatingToolbar({ id }: { id: string }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const reactFlowInstance = useReactFlow();
   const editMode = useStore(store, (state) => state.editMode);
   const yjsRun = useStore(store, (state) => state.yjsRun);
@@ -150,8 +149,7 @@ export const ScopeNode = memo<NodeProps>(function ScopeNode({
 }) {
   // add resize to the node
   const ref = useRef(null);
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const setPodName = useStore(store, (state) => state.setPodName);
   const nodesMap = useStore(store, (state) => state.getNodesMap());
   const editMode = useStore(store, (state) => state.editMode);

--- a/packages/ui/src/components/nodes/extensions/link.tsx
+++ b/packages/ui/src/components/nodes/extensions/link.tsx
@@ -183,8 +183,7 @@ function useUpdatePositionerOnMove() {
   // Update (all) the positioners whenever there's a move (pane) on reactflow,
   // so that the toolbar moves with the Rich pod and content.
   const { forceUpdatePositioners, emptySelection } = useCommands();
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const moved = useStore(store, (state) => state.moved);
   const paneClicked = useStore(store, (state) => state.paneClicked);
   useEffect(() => {

--- a/packages/ui/src/components/nodes/utils.tsx
+++ b/packages/ui/src/components/nodes/utils.tsx
@@ -444,8 +444,7 @@ const WrappedHandle = ({ position, children }) => {
  * The two buttons.
  */
 const HandleButton = ({ position, width, height, parent, xPos, yPos }) => {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const addNode = useStore(store, (state) => state.addNode);
   const clickAway = useContext(ClickAwayContext);
   switch (position) {

--- a/packages/ui/src/pages/repo.tsx
+++ b/packages/ui/src/pages/repo.tsx
@@ -147,8 +147,7 @@ const HeaderItem = memo<any>(() => {
 });
 
 function RepoHeader({ id }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
 
   const setShareOpen = useStore(store, (state) => state.setShareOpen);
   const navigate = useNavigate();
@@ -394,8 +393,7 @@ function RepoLoader({ id, children }) {
  * This loads repo metadata.
  */
 function ParserWrapper({ children }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
+  const store = useContext(RepoContext)!;
   const parseAllPods = useStore(store, (state) => state.parseAllPods);
   const resolveAllPods = useStore(store, (state) => state.resolveAllPods);
   const [parserLoaded, setParserLoaded] = useState(false);
@@ -437,9 +435,6 @@ function WaitForProvider({ children, yjsWsUrl }) {
  * This loads users.
  */
 function UserWrapper({ children }) {
-  const store = useContext(RepoContext);
-  if (!store) throw new Error("Missing BearContext.Provider in the tree");
-
   const { loading, me } = useMe();
 
   if (loading) return <Box>Loading ..</Box>;


### PR DESCRIPTION
We don't need to report the error. The error will be reported by zustand. Just keep in mind that the store is only valid inside a <Repo> provided by `RepoContext.Provider`:

https://github.com/codepod-io/codepod/blob/79683dc6279b5086243dae5e155f33c1e32cb694/packages/ui/src/pages/repo.tsx#L451-L461