### PR TITLE
[desktop] save repo meta and yjsblob into desktop-var-codepod volume

### DIFF
--- a/apps/desktop-api/src/server.ts
+++ b/apps/desktop-api/src/server.ts
@@ -48,7 +48,8 @@ export const typeDefs = gql`
   }
 `;
 
-const repoDirs = "/var/codepod";
+const CODEPOD_ROOT = "/var/codepod";
+const repoDirs = `${CODEPOD_ROOT}/repos`;
 
 export const resolvers = {
   Query: {

--- a/apps/desktop-yjs/src/yjs-blob.ts
+++ b/apps/desktop-yjs/src/yjs-blob.ts
@@ -56,16 +56,18 @@ type NodeData = {
   name?: string;
 };
 
-const blobDir = "/var/yjs-blob";
+const CODEPOD_ROOT = "/var/codepod";
+const repoDirs = `${CODEPOD_ROOT}/repos`;
 
 async function handleSaveBlob({ repoId, yDocBlob }) {
   console.log("save blob", repoId, yDocBlob.length);
   // create the yjs-blob folder if not exists
+  const blobDir = `${repoDirs}/${repoId}`;
   if (!fs.existsSync(blobDir)) {
     fs.mkdirSync(blobDir);
   }
   // save the blob to file system
-  fs.writeFileSync(`${blobDir}/${repoId}`, yDocBlob);
+  fs.writeFileSync(`${blobDir}/yjs.bin`, yDocBlob);
 }
 
 /**
@@ -110,9 +112,10 @@ async function loadFromFS(ydoc: Y.Doc, repoId: string) {
   // load from the database and write to the ydoc
   console.log("=== loadFromFS");
   // read the blob from file system
-  const path = `${blobDir}/${repoId}`;
-  if (fs.existsSync(path)) {
-    const yDocBlob = fs.readFileSync(path);
+  const blobDir = `${repoDirs}/${repoId}`;
+  const binFile = `${blobDir}/yjs.bin`;
+  if (fs.existsSync(binFile)) {
+    const yDocBlob = fs.readFileSync(binFile);
     Y.applyUpdate(ydoc, yDocBlob);
   } else {
     // init the ydoc

--- a/compose/dev/compose.yml
+++ b/compose/dev/compose.yml
@@ -62,6 +62,7 @@ services:
       - 4001:4001
     volumes:
       - ../..:/codepod
+      - desktop-var-codepod:/var/codepod
       - pnpm-store:/codepod/.pnpm-store
     command: sh -c "corepack enable && pnpm dev"
     environment:
@@ -139,6 +140,7 @@ services:
     volumes:
       - ../..:/codepod
       - pnpm-store:/codepod/.pnpm-store
+      - desktop-var-codepod:/var/codepod
       - /var/run/docker.sock:/var/run/docker.sock
     command: sh -c "corepack enable && pnpm dev"
 
@@ -199,6 +201,7 @@ services:
 volumes:
   db-data:
   pnpm-store:
+  desktop-var-codepod:
 
 networks:
   default:


### PR DESCRIPTION
Now desktop app's data is persisted in `/var/codepod`, which is mounted with docker volume `desktop-var-codepod`.