### PR TITLE
fix: handle useMe null; add typing to useMe

### DIFF
--- a/packages/ui/src/lib/me.tsx
+++ b/packages/ui/src/lib/me.tsx
@@ -15,12 +15,10 @@ const PROFILE_QUERY = gql`
 
 export function useMe() {
   /* eslint-disable no-unused-vars */
-  const { loading, data, error } = useQuery(PROFILE_QUERY, {
+  const { loading, data, error } = useQuery<{
+    me: { id: string; firstname: string; lastname: string; email: string };
+  }>(PROFILE_QUERY, {
     // fetchPolicy: "network-only",
   });
-  if (error) {
-    console.error(error);
-    throw new Error("Error fetching user profile.");
-  }
-  return { loading, me: data?.me };
+  return { loading, error, me: data?.me };
 }

--- a/packages/ui/src/pages/dashboard.tsx
+++ b/packages/ui/src/pages/dashboard.tsx
@@ -88,7 +88,7 @@ const StarButton = ({ repo }) => {
       refetchQueries: ["GetDashboardRepos"],
     }
   );
-  const isStarred = repo.stargazers?.map((_) => _.id).includes(me.id);
+  const isStarred = repo.stargazers?.map((_) => _.id).includes(me?.id);
   return (
     <>
       {isStarred ? (
@@ -237,7 +237,7 @@ const RepoCard = ({ repo }) => {
       </CardContent>
       <CardActions disableSpacing>
         <Box>
-          {repo.userId !== me.id && (
+          {repo.userId !== me?.id && (
             <Tooltip title="Shared with me">
               <GroupsIcon fontSize="small" color="primary" />
             </Tooltip>

--- a/packages/ui/src/pages/repo.tsx
+++ b/packages/ui/src/pages/repo.tsx
@@ -373,8 +373,8 @@ function RepoLoader({ id, children }) {
     if (data && data.repo) {
       setRepoData(data.repo);
       if (
-        me.id === data.repo.userId ||
-        data.repo.collaborators.includes(me.id)
+        me?.id === data.repo.userId ||
+        data.repo.collaborators.includes(me?.id)
       ) {
         setEditMode("edit");
       }
@@ -382,8 +382,7 @@ function RepoLoader({ id, children }) {
   }, [data, loading]);
   if (loading) return <Box>Loading</Box>;
   if (error) {
-    console.error("Repo loading error", error);
-    return <Box>Error</Box>;
+    return <Box>Error: Repo not found</Box>;
   }
   if (!data || !data.repo) return <NotFoundAlert />;
   return children;
@@ -422,7 +421,7 @@ function WaitForProvider({ children, yjsWsUrl }) {
   const connectYjs = useStore(store, (state) => state.connectYjs);
   const { me } = useMe();
   useEffect(() => {
-    connectYjs({ yjsWsUrl, name: me.firstname });
+    connectYjs({ yjsWsUrl, name: me?.firstname || "Anonymous" });
     return () => {
       disconnectYjs();
     };
@@ -435,10 +434,9 @@ function WaitForProvider({ children, yjsWsUrl }) {
  * This loads users.
  */
 function UserWrapper({ children }) {
-  const { loading, me } = useMe();
+  const { loading } = useMe();
 
   if (loading) return <Box>Loading ..</Box>;
-  if (!me) return <Box>Loading ..</Box>;
 
   return children;
 }


### PR DESCRIPTION
When `useMe` returns error, it means no user is signed in. This PR handles it instead of just throwing errors, e.g., Anonymous users should be able to see public repos.