### PR TITLE
fix: support editor view mode; sync on new pods

### DIFF
--- a/packages/ui/src/components/MyMonaco.tsx
+++ b/packages/ui/src/components/MyMonaco.tsx
@@ -411,14 +411,6 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   useEffect(() => {
     if (focusedEditor === id) {
       editor?.focus();
-      editor?.updateOptions({
-        readOnly: false,
-      });
-    } else {
-      editor?.updateOptions({
-        readOnly: true,
-        //cursorWidth: 0,
-      });
     }
   }, [focusedEditor]);
 
@@ -440,6 +432,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
 
   const selectPod = useStore(store, (state) => state.selectPod);
   const resetSelection = useStore(store, (state) => state.resetSelection);
+  const editMode = useStore(store, (state) => state.editMode);
 
   // FIXME useCallback?
   function onEditorDidMount(
@@ -495,7 +488,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
 
     // bind it to the ytext with pod id
     if (!codeMap.has(id)) {
-      codeMap.set(id, new Y.Text());
+      throw new Error("codeMap doesn't have pod " + id);
     }
     const ytext = codeMap.get(id)!;
     new MonacoBinding(
@@ -514,7 +507,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
       theme="codepod"
       options={{
         selectOnLineNumbers: true,
-        readOnly: focusedEditor !== id,
+        readOnly: editMode === "view" || focusedEditor !== id,
         // This scrollBeyondLastLine is super important. Without this, it will
         // try to adjust height infinitely.
         scrollBeyondLastLine: false,

--- a/packages/ui/src/components/nodes/Rich.tsx
+++ b/packages/ui/src/components/nodes/Rich.tsx
@@ -296,9 +296,9 @@ const MyEditor = ({
   const updateView = useStore(store, (state) => state.updateView);
   const richMap = useStore(store, (state) => state.getRichMap());
   if (!richMap.has(id)) {
-    richMap.set(id, new Y.XmlFragment());
+    throw new Error("richMap does not have id" + id);
   }
-  const yXml = richMap.get(id) as Y.XmlFragment;
+  const yXml = richMap.get(id);
 
   const { manager, state, setState } = useRemirror({
     extensions: () => [
@@ -433,6 +433,7 @@ const MyEditor = ({
             {/* Overlay */}
           </Box>
           <Remirror
+            editable={editMode === "edit"}
             manager={manager}
             // Must set initialContent, otherwise the Reactflow will fire two
             // dimension change events at the beginning. This should be caused

--- a/packages/ui/src/lib/store/canvasSlice.ts
+++ b/packages/ui/src/lib/store/canvasSlice.ts
@@ -399,6 +399,15 @@ export const createCanvasSlice: StateCreator<MyState, [], [], CanvasSlice> = (
   addNode: (type, position, parent) => {
     let nodesMap = get().getNodesMap();
     let node = createNewNode(type, position);
+    switch (type) {
+      case "CODE":
+        get().getCodeMap().set(node.id, new Y.Text());
+        break;
+      case "RICH":
+        get().getRichMap().set(node.id, new Y.XmlFragment());
+        break;
+    }
+    // FIXME the above codeMap/richMap should be synced first, which may not be guranteed.
     nodesMap.set(node.id, node);
     if (parent) {
       // we don't assign its parent when created, because we have to adjust its position to make it inside its parent.


### PR DESCRIPTION
Two fixes:
1. If `editMode==="view"`, the code/rich editors will be read-only
2. Newly created nodes will now sync across peers (previously not).