### PR TITLE
chore: cleanup console log

### DIFF
--- a/apps/web-ui/src/lib/auth.tsx
+++ b/apps/web-ui/src/lib/auth.tsx
@@ -74,7 +74,6 @@ function useProvideAuth({ apiUrl, spawnerApiUrl }) {
   };
 
   const handleGoogle = async (response) => {
-    console.log("Google Encoded JWT ID token: " + response.credential);
     const client = createApolloClient(false);
     const LoginMutation = gql`
       mutation LoginWithGoogleMutation($idToken: String!) {


### PR DESCRIPTION
The token shouldn't be printed.