### PR TITLE
add CI for npm build & publish

### DIFF
--- a/.github/publish.yaml
+++ b/.github/publish.yaml
@@ -1,0 +1,44 @@
+name: Build and Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14 # Change this to your desired Node.js version
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Build UI
+        working-directory: ui
+        run: |
+          pnpm install
+          pnpm build
+        env:
+          NODE_ENV: production
+
+      - name: Build API
+        working-directory: api
+        run: |
+          pnpm install
+          pnpm build
+        env:
+          NODE_ENV: production
+
+      - name: Publish to npm
+        working-directory: api
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # NPM_TOKEN is a GitHub secret containing your npm token

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codepod",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
This CI will
1. build the UI
2. build the API
3. run npm publish

It is triggered on new tags named `v*.*.*`