### PR TITLE
add registry-url

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "20.x" # Change this to your desired Node.js version
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install pnpm
         run: npm install -g pnpm


### PR DESCRIPTION
This finally fixes the following CI npm auth error:

```
npm notice total files:   180                                     
npm notice 
npm ERR! code ENEEDAUTH
npm ERR! need auth This command requires you to be logged in to https://registry.npmjs.org/
npm ERR! need auth You need to authorize this machine using `npm adduser`

npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/[202](https://github.com/codepod-io/codepod/actions/runs/6712487763/job/18242612030#step:7:203)3-10-31T21_27_17_803Z-debug-0.log
Error: Process completed with exit code 1.
```