### PR TITLE
[Prototype] Self-hosted CodeLlama LLM for code autocompletion 

### DIFF
--- a/api/src/run.ts
+++ b/api/src/run.ts
@@ -3,4 +3,21 @@ import { startServer } from "./server";
 const repoDir = `${process.cwd()}/example-repo`;
 console.log("repoDir", repoDir);
 
-startServer({ port: 4000, repoDir });
+const args = process.argv.slice(2);
+
+const options = {
+  copilotIpAddress: "127.0.0.1",
+  copilotPort: 9090,
+};
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--copilotIP" && i + 1 < args.length) {
+    options.copilotIpAddress = args[i + 1];
+    i++;
+  } else if (args[i] === "--copilotPort" && i + 1 < args.length) {
+    options.copilotPort = Number(args[i + 1]);
+    i++;
+  }
+}
+
+startServer({ port: 4000, repoDir, ...options });

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -10,7 +10,15 @@ import { bindState, writeState } from "./yjs/yjs-blob";
 import cors from "cors";
 import { createSpawnerRouter, router } from "./spawner/trpc";
 
-export async function startServer({ port, repoDir }) {
+export const copilotIpAddress = "127.0.0.1";
+export const copilotPort = 9090;
+
+export async function startServer({
+  port,
+  repoDir,
+  copilotIpAddress = "127.0.0.1",
+  copilotPort = 9090,
+}) {
   console.log("starting server ..");
   const app = express();
   app.use(express.json({ limit: "20mb" }));
@@ -33,6 +41,8 @@ export async function startServer({ port, repoDir }) {
   );
 
   const http_server = http.createServer(app);
+  copilotIpAddress = copilotIpAddress;
+  copilotPort = copilotPort;
 
   // Yjs websocket
   const wss = new WebSocketServer({ noServer: true });
@@ -59,6 +69,8 @@ export async function startServer({ port, repoDir }) {
   });
 
   http_server.listen({ port }, () => {
-    console.log(`🚀 Server ready at http://localhost:${port}`);
+    console.log(
+      `🚀 Server ready at http://localhost:${port}, LLM Copilot is hosted at ${copilotIpAddress}:${copilotPort}`
+    );
   });
 }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -10,9 +10,6 @@ import { bindState, writeState } from "./yjs/yjs-blob";
 import cors from "cors";
 import { createSpawnerRouter, router } from "./spawner/trpc";
 
-export const copilotIpAddress = "127.0.0.1";
-export const copilotPort = 9090;
-
 export async function startServer({
   port,
   repoDir,
@@ -35,14 +32,16 @@ export async function startServer({
     "/trpc",
     trpcExpress.createExpressMiddleware({
       router: router({
-        spawner: createSpawnerRouter(yjsServerUrl),
+        spawner: createSpawnerRouter(
+          yjsServerUrl,
+          copilotIpAddress,
+          copilotPort
+        ),
       }),
     })
   );
 
   const http_server = http.createServer(app);
-  copilotIpAddress = copilotIpAddress;
-  copilotPort = copilotPort;
 
   // Yjs websocket
   const wss = new WebSocketServer({ noServer: true });

--- a/api/src/spawner/trpc.ts
+++ b/api/src/spawner/trpc.ts
@@ -8,8 +8,6 @@ import Y from "yjs";
 import WebSocket from "ws";
 import { z } from "zod";
 
-import { copilotIpAddress, copilotPort } from "../server";
-
 // import { WebsocketProvider } from "../../ui/src/lib/y-websocket";
 import { WebsocketProvider } from "../yjs/y-websocket";
 
@@ -61,7 +59,11 @@ async function getMyYDoc({ repoId, yjsServerUrl }): Promise<Y.Doc> {
 
 const routingTable: Map<string, string> = new Map();
 
-export function createSpawnerRouter(yjsServerUrl) {
+export function createSpawnerRouter(
+  yjsServerUrl,
+  copilotIpAddress,
+  copilotPort
+) {
   return router({
     spawnRuntime: publicProcedure
       .input(z.object({ runtimeId: z.string(), repoId: z.string() }))
@@ -282,7 +284,7 @@ export function createSpawnerRouter(yjsServerUrl) {
                 resolve(""); // Resolve with an empty string if no data
               }
               const resData = JSON.parse(responseData.toString());
-              console.log(req.statusCode, resData["content"]);
+              console.log(res.statusCode, resData["content"]);
               resolve(resData["content"]); // Resolve the Promise with the response data
             });
           });
@@ -301,6 +303,6 @@ export function createSpawnerRouter(yjsServerUrl) {
 
 // This is only used for frontend to get the type of router.
 const _appRouter_for_type = router({
-  spawner: createSpawnerRouter(null), // put procedures under "post" namespace
+  spawner: createSpawnerRouter(null, null, null), // put procedures under "post" namespace
 });
 export type AppRouter = typeof _appRouter_for_type;

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -429,23 +429,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
     } else {
       highlightAnnotations(editor, []);
     }
-
-    let llamaCompletionProvider; // Define the provider reference
-    let decompose;
-    if (copilotEnabled) {
-      llamaCompletionProvider = new llamaInlineCompletionProvider(id, editor);
-      decompose = monaco.languages.registerInlineCompletionsProvider(
-        "python",
-        llamaCompletionProvider
-      );
-    }
-    return () => {
-      if (llamaCompletionProvider && !copilotEnabled) {
-        // Unregister the provider if it exists
-        decompose();
-      }
-    };
-  }, [annotations, editor, showAnnotations, scopedVars, copilotEnabled]);
+  }, [annotations, editor, showAnnotations, scopedVars]);
 
   if (lang === "racket") {
     lang = "scheme";
@@ -512,6 +496,16 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
     //   // content is value?
     //   updateGitGutter(editor);
     // });
+    if (copilotEnabled) {
+      const llamaCompletionProvider = new llamaInlineCompletionProvider(
+        id,
+        editor
+      );
+      monaco.languages.registerInlineCompletionsProvider(
+        "python",
+        llamaCompletionProvider
+      );
+    }
     // bind it to the ytext with pod id
     if (!codeMap.has(id)) {
       throw new Error("codeMap doesn't have pod " + id);

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -13,6 +13,8 @@ import { Annotation } from "../lib/parser";
 import { useApolloClient } from "@apollo/client";
 import { trpc } from "../lib/trpc";
 
+import { llamaInlineCompletionProvider } from "../lib/llamaCompletionProvider";
+
 const theme: monaco.editor.IStandaloneThemeData = {
   base: "vs",
   inherit: true,
@@ -492,7 +494,14 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
     //   // content is value?
     //   updateGitGutter(editor);
     // });
-
+    const llamaCompletionProvider = new llamaInlineCompletionProvider(
+      id,
+      editor
+    );
+    monaco.languages.registerInlineCompletionsProvider(
+      "python",
+      llamaCompletionProvider
+    );
     // bind it to the ytext with pod id
     if (!codeMap.has(id)) {
       throw new Error("codeMap doesn't have pod " + id);

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -441,6 +441,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
   const selectPod = useStore(store, (state) => state.selectPod);
   const resetSelection = useStore(store, (state) => state.resetSelection);
   const editMode = useStore(store, (state) => state.editMode);
+  const { client } = trpc.useUtils();
 
   // FIXME useCallback?
   function onEditorDidMount(
@@ -499,7 +500,8 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
     if (copilotEnabled) {
       const llamaCompletionProvider = new llamaInlineCompletionProvider(
         id,
-        editor
+        editor,
+        client
       );
       monaco.languages.registerInlineCompletionsProvider(
         "python",

--- a/ui/src/components/MyMonaco.tsx
+++ b/ui/src/components/MyMonaco.tsx
@@ -406,7 +406,7 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
     (state) => state.parseResult[id]?.annotations
   );
   const showAnnotations = useStore(store, (state) => state.showAnnotations);
-  const copilotEnabled = useStore(store, (state) => state.copilotEnabled);
+  const copilotManualMode = useStore(store, (state) => state.copilotManualMode);
 
   const scopedVars = useStore(store, (state) => state.scopedVars);
   const updateView = useStore(store, (state) => state.updateView);
@@ -493,21 +493,33 @@ export const MyMonaco = memo<MyMonacoProps>(function MyMonaco({
       },
     });
 
+    editor.addAction({
+      id: "trigger-inline-suggest",
+      label: "Trigger Suggest",
+      keybindings: [
+        monaco.KeyMod.WinCtrl | monaco.KeyMod.Shift | monaco.KeyCode.Space,
+      ],
+      run: () => {
+        editor.trigger(null, "editor.action.inlineSuggest.trigger", null);
+      },
+    });
+
     // editor.onDidChangeModelContent(async (e) => {
     //   // content is value?
     //   updateGitGutter(editor);
     // });
-    if (copilotEnabled) {
-      const llamaCompletionProvider = new llamaInlineCompletionProvider(
-        id,
-        editor,
-        client
-      );
-      monaco.languages.registerInlineCompletionsProvider(
-        "python",
-        llamaCompletionProvider
-      );
-    }
+
+    const llamaCompletionProvider = new llamaInlineCompletionProvider(
+      id,
+      editor,
+      client,
+      copilotManualMode || false
+    );
+    monaco.languages.registerInlineCompletionsProvider(
+      "python",
+      llamaCompletionProvider
+    );
+
     // bind it to the ytext with pod id
     if (!codeMap.has(id)) {
       throw new Error("codeMap doesn't have pod " + id);

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -64,6 +64,9 @@ function SidebarSettings() {
   );
   const devMode = useStore(store, (state) => state.devMode);
   const setDevMode = useStore(store, (state) => state.setDevMode);
+  const copilotEnabled = useStore(store, (state) => state.copilotEnabled);
+  const setCopilotEnabled = useStore(store, (state) => state.setCopilotEnabled);
+
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const setShowLineNumbers = useStore(
     store,
@@ -485,6 +488,23 @@ function SidebarSettings() {
                 />
               }
               label="Enable Annotations"
+            />
+          </FormGroup>
+        </Tooltip>
+        <Tooltip title={"Enable Codepod Copilot"} disableInteractive>
+          <FormGroup>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={copilotEnabled}
+                  size="small"
+                  color="warning"
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setCopilotEnabled(event.target.checked);
+                  }}
+                />
+              }
+              label="Enable Codepod Copilot"
             />
           </FormGroup>
         </Tooltip>

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -64,8 +64,11 @@ function SidebarSettings() {
   );
   const devMode = useStore(store, (state) => state.devMode);
   const setDevMode = useStore(store, (state) => state.setDevMode);
-  const copilotEnabled = useStore(store, (state) => state.copilotEnabled);
-  const setCopilotEnabled = useStore(store, (state) => state.setCopilotEnabled);
+  const copilotManualMode = useStore(store, (state) => state.copilotManualMode);
+  const setCopilotManualMode = useStore(
+    store,
+    (state) => state.setCopilotManualMode
+  );
 
   const showLineNumbers = useStore(store, (state) => state.showLineNumbers);
   const setShowLineNumbers = useStore(
@@ -491,20 +494,23 @@ function SidebarSettings() {
             />
           </FormGroup>
         </Tooltip>
-        <Tooltip title={"Enable Codepod Copilot"} disableInteractive>
+        <Tooltip
+          title={"Ctrl+Shift+Space to trigger Copilot manually"}
+          disableInteractive
+        >
           <FormGroup>
             <FormControlLabel
               control={
                 <Switch
-                  checked={copilotEnabled}
+                  checked={copilotManualMode}
                   size="small"
                   color="warning"
                   onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    setCopilotEnabled(event.target.checked);
+                    setCopilotManualMode(event.target.checked);
                   }}
                 />
               }
-              label="Enable Codepod Copilot"
+              label="Trigger Copilot Manually"
             />
           </FormGroup>
         </Tooltip>

--- a/ui/src/lib/llamaCompletionProvider.ts
+++ b/ui/src/lib/llamaCompletionProvider.ts
@@ -1,16 +1,21 @@
 import { monaco } from "react-monaco-editor";
-import { trpcProxyClient } from "./trpc";
 
 export class llamaInlineCompletionProvider
   implements monaco.languages.InlineCompletionsProvider
 {
   private readonly podId: string;
   private readonly editor: monaco.editor.IStandaloneCodeEditor;
+  private readonly trpc: any;
   private isFetchingSuggestions: boolean; // Flag to track if a fetch operation is in progress
 
-  constructor(podId: string, editor: monaco.editor.IStandaloneCodeEditor) {
+  constructor(
+    podId: string,
+    editor: monaco.editor.IStandaloneCodeEditor,
+    trpc: any
+  ) {
     this.podId = podId;
     this.editor = editor;
+    this.trpc = trpc;
     this.isFetchingSuggestions = false; // Initialize the flag
   }
 
@@ -19,7 +24,7 @@ export class llamaInlineCompletionProvider
       return "";
     }
 
-    const suggestion = await trpcProxyClient.spawner.codeAutoComplete.mutate({
+    const suggestion = await this.trpc.spawner.codeAutoComplete.mutate({
       code: input,
       podId: this.podId,
     });

--- a/ui/src/lib/llamaCompletionProvider.ts
+++ b/ui/src/lib/llamaCompletionProvider.ts
@@ -6,16 +6,19 @@ export class llamaInlineCompletionProvider
   private readonly podId: string;
   private readonly editor: monaco.editor.IStandaloneCodeEditor;
   private readonly trpc: any;
+  private readonly manualMode: boolean;
   private isFetchingSuggestions: boolean; // Flag to track if a fetch operation is in progress
 
   constructor(
     podId: string,
     editor: monaco.editor.IStandaloneCodeEditor,
-    trpc: any
+    trpc: any,
+    manualMode: boolean
   ) {
     this.podId = podId;
     this.editor = editor;
     this.trpc = trpc;
+    this.manualMode = manualMode;
     this.isFetchingSuggestions = false; // Initialize the flag
   }
 
@@ -36,10 +39,14 @@ export class llamaInlineCompletionProvider
     context: monaco.languages.InlineCompletionContext,
     token: monaco.CancellationToken
   ): Promise<monaco.languages.InlineCompletions | undefined> {
-    if (!this.editor.hasTextFocus()) {
+    if (!this.editor.hasTextFocus() || token.isCancellationRequested) {
       return;
     }
-    if (token.isCancellationRequested) {
+    if (
+      context.triggerKind ===
+        monaco.languages.InlineCompletionTriggerKind.Automatic &&
+      this.manualMode
+    ) {
       return;
     }
 

--- a/ui/src/lib/llamaCompletionProvider.ts
+++ b/ui/src/lib/llamaCompletionProvider.ts
@@ -1,0 +1,75 @@
+import { monaco } from "react-monaco-editor";
+import { trpcProxyClient } from "./trpc";
+
+export class llamaInlineCompletionProvider
+  implements monaco.languages.InlineCompletionsProvider
+{
+  private readonly podId: string;
+  private readonly editor: monaco.editor.IStandaloneCodeEditor;
+  private isFetchingSuggestions: boolean; // Flag to track if a fetch operation is in progress
+
+  constructor(podId: string, editor: monaco.editor.IStandaloneCodeEditor) {
+    this.podId = podId;
+    this.editor = editor;
+    this.isFetchingSuggestions = false; // Initialize the flag
+  }
+
+  private async provideSuggestions(input: string) {
+    if (/^\s*$/.test(input || " ")) {
+      return "";
+    }
+
+    const suggestion = await trpcProxyClient.spawner.codeAutoComplete.mutate({
+      code: input,
+      podId: this.podId,
+    });
+    return suggestion;
+  }
+  public async provideInlineCompletions(
+    model: monaco.editor.ITextModel,
+    position: monaco.IPosition,
+    context: monaco.languages.InlineCompletionContext,
+    token: monaco.CancellationToken
+  ): Promise<monaco.languages.InlineCompletions | undefined> {
+    if (!this.editor.hasTextFocus()) {
+      return;
+    }
+    if (token.isCancellationRequested) {
+      return;
+    }
+
+    if (!this.isFetchingSuggestions) {
+      this.isFetchingSuggestions = true;
+      try {
+        const suggestion = await this.provideSuggestions(
+          model.getValue() || " "
+        );
+
+        return {
+          items: [
+            {
+              insertText: suggestion,
+              range: new monaco.Range(
+                position.lineNumber,
+                position.column,
+                position.lineNumber,
+                position.column
+              ),
+            },
+          ],
+        };
+      } finally {
+        this.isFetchingSuggestions = false;
+      }
+    }
+  }
+
+  handleItemDidShow?(
+    completions: monaco.languages.InlineCompletions<monaco.languages.InlineCompletion>,
+    item: monaco.languages.InlineCompletion
+  ): void {}
+
+  freeInlineCompletions(
+    completions: monaco.languages.InlineCompletions<monaco.languages.InlineCompletion>
+  ): void {}
+}

--- a/ui/src/lib/store/settingSlice.ts
+++ b/ui/src/lib/store/settingSlice.ts
@@ -8,6 +8,8 @@ export interface SettingSlice {
   setShowAnnotations: (b: boolean) => void;
   devMode?: boolean;
   setDevMode: (b: boolean) => void;
+  copilotEnabled?: boolean;
+  setCopilotEnabled: (b: boolean) => void;
   autoRunLayout?: boolean;
   setAutoRunLayout: (b: boolean) => void;
   contextualZoomParams: Record<any, number>;
@@ -56,6 +58,17 @@ export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
     // also write to local storage
     localStorage.setItem("devMode", JSON.stringify(b));
   },
+
+  copilotEnabled: localStorage.getItem("copilotEnabled")
+    ? JSON.parse(localStorage.getItem("copilotEnabled")!)
+    : false,
+  setCopilotEnabled: (b: boolean) => {
+    // set it
+    set({ copilotEnabled: b });
+    // also write to local storage
+    localStorage.setItem("copilotEnabled", JSON.stringify(b));
+  },
+
   autoRunLayout: localStorage.getItem("autoRunLayout")
     ? JSON.parse(localStorage.getItem("autoRunLayout")!)
     : true,

--- a/ui/src/lib/store/settingSlice.ts
+++ b/ui/src/lib/store/settingSlice.ts
@@ -8,8 +8,8 @@ export interface SettingSlice {
   setShowAnnotations: (b: boolean) => void;
   devMode?: boolean;
   setDevMode: (b: boolean) => void;
-  copilotEnabled?: boolean;
-  setCopilotEnabled: (b: boolean) => void;
+  copilotManualMode?: boolean;
+  setCopilotManualMode: (b: boolean) => void;
   autoRunLayout?: boolean;
   setAutoRunLayout: (b: boolean) => void;
   contextualZoomParams: Record<any, number>;
@@ -59,14 +59,14 @@ export const createSettingSlice: StateCreator<MyState, [], [], SettingSlice> = (
     localStorage.setItem("devMode", JSON.stringify(b));
   },
 
-  copilotEnabled: localStorage.getItem("copilotEnabled")
-    ? JSON.parse(localStorage.getItem("copilotEnabled")!)
+  copilotManualMode: localStorage.getItem("copilotManualMode")
+    ? JSON.parse(localStorage.getItem("copilotManualMode")!)
     : false,
-  setCopilotEnabled: (b: boolean) => {
+  setCopilotManualMode: (b: boolean) => {
     // set it
-    set({ copilotEnabled: b });
+    set({ copilotManualMode: b });
     // also write to local storage
-    localStorage.setItem("copilotEnabled", JSON.stringify(b));
+    localStorage.setItem("copilotManualMode", JSON.stringify(b));
   },
 
   autoRunLayout: localStorage.getItem("autoRunLayout")

--- a/ui/src/lib/trpc.ts
+++ b/ui/src/lib/trpc.ts
@@ -1,3 +1,21 @@
-import { createTRPCReact } from "@trpc/react-query";
+import {
+  createTRPCReact,
+  createTRPCProxyClient,
+  httpBatchLink,
+} from "@trpc/react-query";
 import type { AppRouter } from "../../../api/src/spawner/trpc";
 export const trpc = createTRPCReact<AppRouter>();
+let remoteUrl;
+
+if (import.meta.env.DEV) {
+  remoteUrl = `localhost:4000`;
+} else {
+  remoteUrl = `${window.location.hostname}:${window.location.port}`;
+}
+export const trpcProxyClient = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: `http://${remoteUrl}/trpc`,
+    }),
+  ],
+});

--- a/ui/src/lib/trpc.ts
+++ b/ui/src/lib/trpc.ts
@@ -1,21 +1,3 @@
-import {
-  createTRPCReact,
-  createTRPCProxyClient,
-  httpBatchLink,
-} from "@trpc/react-query";
+import { createTRPCReact } from "@trpc/react-query";
 import type { AppRouter } from "../../../api/src/spawner/trpc";
 export const trpc = createTRPCReact<AppRouter>();
-let remoteUrl;
-
-if (import.meta.env.DEV) {
-  remoteUrl = `localhost:4000`;
-} else {
-  remoteUrl = `${window.location.hostname}:${window.location.port}`;
-}
-export const trpcProxyClient = createTRPCProxyClient<AppRouter>({
-  links: [
-    httpBatchLink({
-      url: `http://${remoteUrl}/trpc`,
-    }),
-  ],
-});


### PR DESCRIPTION
## Summary

This pr provides a solution to use CodeLlama for self-hosted code autocompletion.
- A standalone LLM is required to run separately and expose a RESTful API to access. The most straight-forward way is to use [llama.cpp](https://github.com/ggerganov/llama.cpp), in which you can host the LLM either on a Mac laptop or a GPU-installed machine.
     - Please follow the instructions of [llama.cpp](https://github.com/ggerganov/llama.cpp) to run the LLM locally or in a cloud, also feel free to let me know if a detailed tutorial is needed.
- A Sidebar setting is added to enable/disable the copilot
- tRPC seems not very well support multiple providers in React, [ref](https://github.com/trpc/trpc/discussions/1990), thus I put the Route in `api/src/server`, initially we talked about to create an standalone server service to the copilot-related services.
- There are a couple of follow-up patches to add, e.g., vite bug fix, monitoring the copilot service connection status, similar to the sync statue in the top of Sidebar, adding infilling mode in addition to autocomplete mode. __This PR also aims to collect some early feedback regarding the overall design and architecture.__

## Test
1. First, enable the RESTful API on the llama.cpp, assuming the IP address is `x.x.x.x`, port is `9090`
2. On the local machine, open the terminal, 
     - `cd codepod/api/`
     - `pnpm dev --copilotIP x.x.x.x --copilotPort 9090`
- __Note that, the screenshot below intends to the demonstrate the functionality, the quality of the auto-completion might be low due to the 4-bit quantized llama-7b model__. 


![copilot](https://github.com/codepod-io/codepod/assets/10226241/415ae401-8a17-410f-b587-f95943427d1b)
